### PR TITLE
Support Python 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v2.29.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py37-plus]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.910

--- a/ml_matrics/elements.py
+++ b/ml_matrics/elements.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Literal, Sequence, Union
+import sys
+from typing import Any, Dict, Sequence, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -11,6 +12,11 @@ from pymatgen.core import Composition
 
 from ml_matrics.utils import ROOT, annotate_bar_heights
 
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 PTABLE = pd.read_csv(f"{ROOT}/ml_matrics/elements.csv")
 

--- a/ml_matrics/metrics.py
+++ b/ml_matrics/metrics.py
@@ -1,4 +1,5 @@
-from typing import Dict, Literal, Union
+import sys
+from typing import Dict, Union
 
 import numpy as np
 from sklearn.metrics import (
@@ -9,6 +10,12 @@ from sklearn.metrics import (
 )
 
 from ml_matrics.utils import NumArray
+
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 def regression_metrics(

--- a/ml_matrics/utils.py
+++ b/ml_matrics/utils.py
@@ -1,19 +1,23 @@
 from os.path import abspath, dirname
-from typing import Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.gridspec import GridSpec
 from matplotlib.offsetbox import AnchoredText
-from numpy.typing import NDArray
 from sklearn.metrics import r2_score
 
 
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    NumArray = NDArray[Union[np.float64, np.int_]]
+else:
+    NumArray = Sequence[Union[int, float]]
+    NDArray = Sequence
+
 ROOT: str = dirname(dirname(abspath(__file__)))
-
-
-NumArray = NDArray[Union[np.float64, np.int_]]
 
 
 def with_hist(

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,8 @@ install_requires =
     matplotlib >= 3.1
     pymatgen >= 2021.2.16
     scipy >= 1.5
-    scikit_learn >= 0.24
+    scikit-learn >= 0.24
+    typing-extensions;python_version<'3.8'
 
 # used during pip install .[test]
 [options.extras_require]


### PR DESCRIPTION
By adding `typing_extensions` as a dependency on `python<=3.7` and dynamically importing `Literal` based on current version, we can make `ml_matrics` backwards compatible so it runs on Google Colab (which is Python 3.7 only https://github.com/googlecolab/colabtools/issues/2165).

In particular, fixes this Jupyter notebook: https://git.io/JKON8