### PR TITLE
More flexible `annotate_metrics` util

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
       - id: codespell
         stages: [commit, commit-msg]
         exclude_types: [csv, svg, html, yaml, jupyter]
+        args: [--ignore-words-list, "hist,mape"]
 
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.6.4

--- a/examples/mprester_ptable.ipynb
+++ b/examples/mprester_ptable.ipynb
@@ -235,7 +235,7 @@
     "    return fig\n",
     "\n",
     "\n",
-    "app.run_server(debug=True, mode=\"inline\")"
+    "app.run(debug=True, mode=\"inline\")"
    ]
   }
  ],

--- a/pymatviz/__init__.py
+++ b/pymatviz/__init__.py
@@ -30,4 +30,4 @@ from pymatviz.uncertainty import error_decay_with_uncert as error_decay_with_unc
 from pymatviz.uncertainty import qq_gaussian as qq_gaussian
 from pymatviz.utils import ROOT as ROOT
 from pymatviz.utils import annotate_bars as annotate_bars
-from pymatviz.utils import annotate_mae_r2 as annotate_mae_r2
+from pymatviz.utils import annotate_metrics as annotate_metrics

--- a/pymatviz/parity.py
+++ b/pymatviz/parity.py
@@ -82,7 +82,7 @@ def density_scatter(
         identity (bool, optional): Whether to add an identity/parity line (y = x).
             Defaults to True.
         stats (bool | dict[str, Any], optional): Whether to display a text box with MAE
-            and R^2. Defaults to True. Can be dict to pass kwargs to `annotate_metrics`.
+            and R^2. Defaults to True. Can be dict to pass kwargs to annotate_metrics().
             E.g. stats=dict(loc="upper left", prefix="Title", prop=dict(fontsize=16)).
         **kwargs: Additional keyword arguments to pass to ax.scatter(). E.g. cmap to
             change the color map.
@@ -116,7 +116,7 @@ def density_scatter(
         )
 
     if stats:
-        annotate_metrics(x, y, ax, **(stats if isinstance(stats, dict) else {}))
+        annotate_metrics(x, y, ax=ax, **(stats if isinstance(stats, dict) else {}))
 
     ax.set(xlabel=xlabel, ylabel=ylabel)
 
@@ -163,7 +163,7 @@ def scatter_with_err_bar(
     # identity line
     ax.axline((0, 0), (1, 1), alpha=0.5, zorder=0, linestyle="dashed", color="black")
 
-    annotate_metrics(x, y, ax)
+    annotate_metrics(x, y, ax=ax)
 
     ax.set(xlabel=xlabel, ylabel=ylabel, title=title)
 
@@ -211,7 +211,7 @@ def density_hexbin(
     # identity line
     ax.axline((0, 0), (1, 1), alpha=0.5, zorder=0, linestyle="dashed", color="black")
 
-    annotate_metrics(x, y, ax, loc="upper left")
+    annotate_metrics(x, y, ax=ax, loc="upper left")
 
     ax.set(xlabel=xlabel, ylabel=ylabel)
 

--- a/pymatviz/parity.py
+++ b/pymatviz/parity.py
@@ -9,7 +9,7 @@ import pandas as pd
 import scipy.interpolate
 from matplotlib.gridspec import GridSpec
 
-from pymatviz.utils import Array, annotate_mae_r2, df_to_arrays, with_hist
+from pymatviz.utils import Array, annotate_metrics, df_to_arrays, with_hist
 
 
 def hist_density(
@@ -82,7 +82,7 @@ def density_scatter(
         identity (bool, optional): Whether to add an identity/parity line (y = x).
             Defaults to True.
         stats (bool | dict[str, Any], optional): Whether to display a text box with MAE
-            and R^2. Defaults to True. Can be dict to pass kwargs to `annotate_mae_r2`.
+            and R^2. Defaults to True. Can be dict to pass kwargs to `annotate_metrics`.
             E.g. stats=dict(loc="upper left", prefix="Title", prop=dict(fontsize=16)).
         **kwargs: Additional keyword arguments to pass to ax.scatter(). E.g. cmap to
             change the color map.
@@ -116,7 +116,7 @@ def density_scatter(
         )
 
     if stats:
-        annotate_mae_r2(x, y, ax, **(stats if isinstance(stats, dict) else {}))
+        annotate_metrics(x, y, ax, **(stats if isinstance(stats, dict) else {}))
 
     ax.set(xlabel=xlabel, ylabel=ylabel)
 
@@ -163,7 +163,7 @@ def scatter_with_err_bar(
     # identity line
     ax.axline((0, 0), (1, 1), alpha=0.5, zorder=0, linestyle="dashed", color="black")
 
-    annotate_mae_r2(x, y, ax)
+    annotate_metrics(x, y, ax)
 
     ax.set(xlabel=xlabel, ylabel=ylabel, title=title)
 
@@ -211,7 +211,7 @@ def density_hexbin(
     # identity line
     ax.axline((0, 0), (1, 1), alpha=0.5, zorder=0, linestyle="dashed", color="black")
 
-    annotate_mae_r2(x, y, ax, loc="upper left")
+    annotate_metrics(x, y, ax, loc="upper left")
 
     ax.set(xlabel=xlabel, ylabel=ylabel)
 

--- a/pymatviz/sankey.py
+++ b/pymatviz/sankey.py
@@ -16,7 +16,7 @@ def sankey_from_2_df_cols(
 
     Args:
         df (pd.DataFrame): Pandas dataframe.
-        cols (Sequence[str]): 2-tuple of source and target column names. Source
+        cols (list[str]): 2-tuple of source and target column names. Source
             corresponds to left, target to right side of the diagram.
         labels_with_counts (bool, optional): Whether to append value counts to node
             labels. Defaults to True.

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -10,9 +10,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
+import sklearn
 from matplotlib.gridspec import GridSpec
 from matplotlib.offsetbox import AnchoredText
 from numpy.typing import NDArray
+from sklearn.metrics import mean_absolute_percentage_error as mape
 from sklearn.metrics import r2_score
 
 
@@ -132,9 +134,10 @@ def annotate_bars(
     ax.set(ylim=(None, y_max * y_max_headroom))
 
 
-def annotate_mae_r2(
+def annotate_metrics(
     xs: NDArray[np.float64 | np.int_],
     ys: NDArray[np.float64 | np.int_],
+    metrics: dict[str, float] | Sequence[str] = ("MAE", "R2"),
     ax: plt.Axes = None,
     prefix: str = "",
     suffix: str = "",
@@ -148,10 +151,15 @@ def annotate_mae_r2(
     Args:
         xs (array, optional): x values.
         ys (array, optional): y values.
+        metrics (dict[str, float] | list[str], optional): Metrics to show. Can be a
+            subset of recognized keys MAE, R2, R2_adj, RMSE, MSE, MAPE or the names of
+            sklearn.metrics.regression functions or any dict of metric names and values.
+            Defaults to ("MAE", "R2").
         ax (Axes, optional): matplotlib Axes on which to add the box. Defaults to None.
         loc (str, optional): Where on the plot to place the AnchoredText object.
             Defaults to "lower right".
-        prec (int, optional): decimal places in printed metrics. Defaults to 3.
+        prec (int, optional): Precision, i.e. decimal places to show in printed metrics.
+            Defaults to 3.
         prefix (str, optional): Title or other string to prepend to metrics.
             Defaults to "".
         suffix (str, optional): Text to append after metrics. Defaults to "".
@@ -162,16 +170,36 @@ def annotate_mae_r2(
     Returns:
         AnchoredText: Instance containing the metrics.
     """
-    ax = ax or plt.gca()
+    funcs = {
+        "MAE": lambda x, y: np.abs(x - y).mean(),
+        "RMSE": lambda x, y: (((x - y) ** 2).mean()) ** 0.5,
+        "MSE": lambda x, y: ((x - y) ** 2).mean(),
+        "MAPE": mape,
+        "R2": r2_score,
+        "R2_adj": lambda x, y: 1 - (1 - r2_score(x, y)) * (len(x) - 1) / (len(x) - 2),
+    }
+    for key in set(metrics) - set(funcs):
+        func = getattr(sklearn.metrics, key, None)
+        if func:
+            funcs[key] = func
+    if bad_keys := set(metrics) - set(funcs):
+        raise ValueError(f"Unrecognized metrics: {bad_keys}")
 
+    ax = ax or plt.gca()
     nans = np.isnan(xs) | np.isnan(ys)
     xs, ys = xs[~nans], ys[~nans]
 
-    text = f"{prefix}$\\mathrm{{MAE}} = {np.abs(xs - ys).mean():.{prec}f}$"
-    text += f"\n$R^2 = {r2_score(xs, ys):.{prec}f}${suffix}"
+    text = prefix
+    if isinstance(metrics, dict):
+        for key, val in metrics.items():
+            text += f"{key} = {val:.{prec}f}\n"
+    else:
+        for metric in metrics:
+            text += f"{metric} = {funcs[metric](xs, ys):.{prec}f}\n"
+    text += suffix
 
-    kwargs["frameon"] = kwargs.get("frameon", False)
-    kwargs["loc"] = kwargs.get("loc", "lower right")
+    kwargs["frameon"] = kwargs.get("frameon", False)  # default to no frame
+    kwargs["loc"] = kwargs.get("loc", "lower right")  # default to lower right
     text_box = AnchoredText(text, **kwargs)
     ax.add_artist(text_box)
 

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -137,8 +137,8 @@ def annotate_bars(
 def annotate_metrics(
     xs: NDArray[np.float64 | np.int_],
     ys: NDArray[np.float64 | np.int_],
-    metrics: dict[str, float] | Sequence[str] = ("MAE", "R2"),
     ax: plt.Axes = None,
+    metrics: dict[str, float] | Sequence[str] = ("MAE", "R2"),
     prefix: str = "",
     suffix: str = "",
     prec: int = 3,
@@ -176,6 +176,7 @@ def annotate_metrics(
         "MSE": lambda x, y: ((x - y) ** 2).mean(),
         "MAPE": mape,
         "R2": r2_score,
+        # TODO: check this for correctness
         "R2_adj": lambda x, y: 1 - (1 - r2_score(x, y)) * (len(x) - 1) / (len(x) - 2),
     }
     for key in set(metrics) - set(funcs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,6 @@ warn_unused_ignores = true
 show_error_codes = true
 no_implicit_optional = false
 
-[tool.codespell]
-ignore-words-list = "hist"
-
 [tool.ruff]
 target-version = "py38"
 select = [


### PR DESCRIPTION
 a695412 rename `annotate_mae_r2()` to `annotate_metrics()`
 5c06534 extend `test_annotate_metrics()` with parametrized `metrics` and `prec` kwargs