### PR TITLE
Disable `save_fig()` in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.263
+    rev: v0.0.264
     hooks:
       - id: ruff
         args: [--fix]

--- a/pymatviz/histograms.py
+++ b/pymatviz/histograms.py
@@ -281,7 +281,7 @@ def spacegroup_hist(
 
 def hist_elemental_prevalence(
     formulas: ElemValues,
-    count_mode: CountMode = "element_composition",
+    count_mode: CountMode = "composition",
     log: bool = False,
     keep_top: int = None,
     ax: plt.Axes = None,

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -84,8 +84,9 @@ def count_elements(
                 )
             ).value_counts()
         else:
+            attr = "element_composition" if count_mode == "composition" else count_mode
             srs = pd.DataFrame(
-                getattr(Composition(formula), count_mode).as_dict() for formula in srs
+                getattr(Composition(formula), attr).as_dict() for formula in srs
             ).sum()  # sum up element occurrences
     else:
         raise ValueError(

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -24,16 +24,13 @@ if TYPE_CHECKING:
     ElemValues: TypeAlias = dict[str | int, int | float] | pd.Series | Sequence[str]
 
 CountMode = Literal[
-    "element_composition",
-    "fractional_composition",
-    "reduced_composition",
-    "occurrence",
+    "composition", "fractional_composition", "reduced_composition", "occurrence"
 ]
 
 
 def count_elements(
     elem_values: ElemValues,
-    count_mode: CountMode = "element_composition",
+    count_mode: CountMode = "composition",
     exclude_elements: Sequence[str] = (),
     fill_value: float | None = 0,
 ) -> pd.Series:
@@ -53,7 +50,7 @@ def count_elements(
             composition strings/objects or map from element symbols to heatmap values.
         count_mode ('(element|fractional|reduced)_composition'):
             Only used when elem_values is a list of composition strings/objects.
-            - element_composition (default): Count elements in each composition as is,
+            - composition (default): Count elements in each composition as is,
                 i.e. without reduction or normalization.
             - fractional_composition: Convert to normalized compositions in which the
                 amounts of each species sum to before counting.
@@ -137,7 +134,7 @@ def ptable_heatmap(
     elem_values: ElemValues,
     log: bool = False,
     ax: plt.Axes = None,
-    count_mode: CountMode = "element_composition",
+    count_mode: CountMode = "composition",
     cbar_title: str = "Element Count",
     cbar_max: float | int | None = None,
     cmap: str = "summer_r",
@@ -324,7 +321,7 @@ def ptable_heatmap(
 def ptable_heatmap_ratio(
     elem_values_num: ElemValues,
     elem_values_denom: ElemValues,
-    count_mode: CountMode = "element_composition",
+    count_mode: CountMode = "composition",
     normalize: bool = False,
     cbar_title: str = "Element Ratio",
     not_in_numerator: tuple[str, str] = ("#DDD", "gray: not in 1st list"),
@@ -389,7 +386,7 @@ def ptable_heatmap_ratio(
 
 def ptable_heatmap_plotly(
     elem_values: ElemValues,
-    count_mode: CountMode = "element_composition",
+    count_mode: CountMode = "composition",
     colorscale: str | Sequence[str] | Sequence[tuple[float, str]] = "viridis",
     showscale: bool = True,
     heat_mode: Literal["value", "fraction", "percent"] | None = "value",

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import os
 import subprocess
 from os.path import dirname
 from shutil import which
@@ -289,6 +290,7 @@ def save_fig(
     fig: go.Figure | plt.Figure | plt.Axes,
     path: str,
     plotly_config: dict[str, Any] = None,
+    env_disable: Sequence[str] = ("CI",),
     **kwargs: Any,
 ) -> None:
     """Write a plotly figure to an HTML file. If the file is has .svelte
@@ -303,9 +305,13 @@ def save_fig(
         Defaults to dict(showTips=False, responsive=True, modeBarButtonsToRemove=
         ["lasso2d", "select2d", "autoScale2d", "toImage"]).
         See https://plotly.com/python/configuration-options.
+        env_disable (list[str], optional): Do nothing if any of these environment
+            variables are set. Defaults to ("CI",).
 
         **kwargs: Keyword arguments passed to fig.write_html().
     """
+    if any(os.getenv(var) for var in env_disable):
+        return
     # handle matplotlib figures
     if isinstance(fig, (plt.Figure, plt.Axes)):
         if hasattr(fig, "figure"):

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -310,7 +310,7 @@ def save_fig(
 
         **kwargs: Keyword arguments passed to fig.write_html().
     """
-    if any(os.getenv(var) for var in env_disable):
+    if any(var in os.environ for var in env_disable):
         return
     # handle matplotlib figures
     if isinstance(fig, (plt.Figure, plt.Axes)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ ignore = [
 ]
 pydocstyle.convention = "google"
 isort.lines-after-imports = 2
-# TODO maybe remove after https://github.com/charliermarsh/ruff/issues/4153
 isort.split-on-trailing-comma = false
 
 [tool.ruff.per-file-ignores]

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -68,7 +68,7 @@ def steel_elem_counts(steel_formulas: pd.Series[Composition]) -> pd.Series[int]:
 @pytest.mark.parametrize(
     "count_mode, counts",
     [
-        ("element_composition", {"Fe": 22, "O": 63, "P": 12}),
+        ("composition", {"Fe": 22, "O": 63, "P": 12}),
         ("fractional_composition", {"Fe": 2.5, "O": 5, "P": 0.5}),
         ("reduced_composition", {"Fe": 13, "O": 27, "P": 3}),
         ("occurrence", {"Fe": 8, "O": 8, "P": 3}),


### PR DESCRIPTION
 47f62d4 `save_fig()` add kwarg `env_disable: Sequence[str] = ("CI",)` to disable saving figs in CI
 b45adee rename `count_elements()` default `count_mode` `'element_composition'` to `'composition'`