### PR TITLE
`ruff` enable more rule sets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.264
+    rev: v0.0.265
     hooks:
       - id: ruff
         args: [--fix]

--- a/dataset_exploration/ricci_carrier_transport/convert_dtype+add_strucs.py
+++ b/dataset_exploration/ricci_carrier_transport/convert_dtype+add_strucs.py
@@ -18,7 +18,7 @@ df_carrier = pd.concat([df_carrier, pd.json_normalize(df_carrier.data)], axis=1)
     columns=["data", "is_public", "project"]
 )
 
-df_carrier.set_index("identifier", inplace=True)
+df_carrier = df_carrier.set_index("identifier")
 df_carrier.index.name = "mp_id"
 
 
@@ -85,7 +85,7 @@ col_map = {
     "mₑᶜ.n.ε₂": "mₑᶜ.n.ε₂ [mₑ]",
     "mₑᶜ.n.ε₃": "mₑᶜ.n.ε₃ [mₑ]",
 }
-df_carrier.rename(columns=col_map, inplace=True)
+df_carrier = df_carrier.rename(columns=col_map)
 
 
 # %% convert all target columns to dtype float

--- a/examples/matbench_perovskites_eda.ipynb
+++ b/examples/matbench_perovskites_eda.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Matbench Perovskite Dataset\n",
     "\n",
-    "Exploratory Data Analysis (EDA). [MPContribs link](https://ml.materialsproject.org/projects/matbench_perovskites)"
+    "Exploratory Data Analysis (EDA). [MPContribs link](https://ml.materialsproject.org/projects/matbench_perovskites)\n"
    ]
   },
   {
@@ -244,7 +244,7 @@
     "# takes ~6h (when running uninterrupted)\n",
     "for idx, struct in tqdm(df_perov.structure.items(), total=len(df_perov)):\n",
     "    if pd.isna(df_perov.aflow_wyckoff[idx]):\n",
-    "        df_perov.at[idx, \"aflow_wyckoff\"] = get_aflow_label_aflow(\n",
+    "        df_perov.loc[idx, \"aflow_wyckoff\"] = get_aflow_label_aflow(\n",
     "            struct, \"/path/to/aflow\"  # defaults to aflow\n",
     "        )"
    ]
@@ -276,6 +276,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -293,12 +294,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Surprisingly large disparity between Spglib and Aflow spacegroups\n",
     "\n",
-    "Spglib is fast while Aflow uses a slower adaptive but presumably more correct algorithm."
+    "Spglib is fast while Aflow uses a slower adaptive but presumably more correct algorithm.\n"
    ]
   },
   {

--- a/examples/mprester_ptable.ipynb
+++ b/examples/mprester_ptable.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Materials Project Element Distribution by Arity"
+    "# Materials Project Element Distribution by Arity\n"
    ]
   },
   {
@@ -231,8 +231,7 @@
     "@app.callback(Output(graph.id, \"figure\"), Input(dropdown.id, \"value\"))\n",
     "def update_figure(dropdown_value: str) -> go.Figure:\n",
     "    \"\"\"Update figure based on dropdown value.\"\"\"\n",
-    "    fig = arity_figs[dropdown_value]\n",
-    "    return fig\n",
+    "    return arity_figs[dropdown_value]\n",
     "\n",
     "\n",
     "app.run(debug=True, mode=\"inline\")"

--- a/pymatviz/histograms.py
+++ b/pymatviz/histograms.py
@@ -332,7 +332,7 @@ def hist_elemental_prevalence(
     if bar_values is not None:
         if bar_values == "percent":
             sum_elements = non_zero.sum()
-            labels = [f"{el / sum_elements:.1%}" for el in non_zero.values]
+            labels = [f"{el / sum_elements:.1%}" for el in non_zero.to_numpy()]
         else:
             labels = non_zero.astype(int).to_list()
         annotate_bars(

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -570,12 +570,12 @@ def ptable_heatmap_plotly(
 
     rgba0 = "rgba(0, 0, 0, 0)"
     if colorscale is None:
-        colorscale = [rgba0] + px.colors.sequential.Pinkyl
+        colorscale = [rgba0, *px.colors.sequential.Pinkyl]
     elif isinstance(colorscale, str):
-        colorscale = [(0, rgba0)] + px.colors.get_colorscale(colorscale)
-        colorscale[1][0] = 1e-6  # type: ignore
+        colorscale = [(0, rgba0), *px.colors.get_colorscale(colorscale)]
+        colorscale[1][0] = 1e-6
     elif isinstance(colorscale, Sequence) and isinstance(colorscale[0], str):
-        colorscale = [rgba0] + list(colorscale)  # type: ignore
+        colorscale = [rgba0, *colorscale]
     elif isinstance(colorscale, Sequence) and isinstance(colorscale[0], (list, tuple)):
         # list of tuples(float in [0, 1], color)
         # make sure we're dealing with mutable lists

--- a/pymatviz/sankey.py
+++ b/pymatviz/sankey.py
@@ -34,7 +34,7 @@ def sankey_from_2_df_cols(
         )
 
     source, target, value = (
-        df[list(cols)].value_counts().reset_index().values.T.tolist()
+        df[list(cols)].value_counts().reset_index().to_numpy().T.tolist()
     )
 
     if labels_with_counts:
@@ -64,5 +64,4 @@ def sankey_from_2_df_cols(
         **kwargs,
     )
 
-    fig = go.Figure(data=[sankey])
-    return fig
+    return go.Figure(data=[sankey])

--- a/pymatviz/uncertainty.py
+++ b/pymatviz/uncertainty.py
@@ -178,7 +178,7 @@ def get_std_decay(y_true: Array, y_pred: Array, y_std: Array) -> Array:
 
     decay_by_std = abs_err[y_std_sort].cumsum() / n_inc
 
-    return decay_by_std
+    return decay_by_std  # noqa: RET504
 
 
 def error_decay_with_uncert(

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -438,9 +438,9 @@ def df_to_arrays(
     df_no_nan = df.dropna(subset=flat_args)
     for idx, col_name in enumerate(args):
         if isinstance(col_name, (str, int)):
-            args[idx] = df_no_nan[col_name].values  # type: ignore[index]
+            args[idx] = df_no_nan[col_name].to_numpy()  # type: ignore[index]
         else:
-            col_data = df_no_nan[[*col_name]].values.T
+            col_data = df_no_nan[[*col_name]].to_numpy().T
             args[idx] = dict(zip(col_name, col_data))  # type: ignore[index]
 
     return args  # type: ignore[return-value]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,15 @@ select = [
     "E",   # pycodestyle
     "F",   # pyflakes
     "I",   # isort
+    "N",   # pep8-naming
+    "PD",  # pandas-vet
     "PIE", # flake8-pie
-    "PLE", # pylint error
-    "PLW", # pylint warning
+    "PL",  # pylint
     "PT",  # flake8-pytest-style
     "PYI", # flakes8-pyi
     "Q",   # flake8-quotes
+    "RET", # flake8-return
+    "RUF", # ruff
     "SIM", # flake8-simplify
     "TID", # tidy imports
     "UP",  # pyupgrade
@@ -91,12 +94,18 @@ ignore = [
     "D100",    # Missing docstring in public module
     "D104",    # Missing docstring in public package
     "D205",    # 1 blank line required between summary line and description
-    "SIM105",  # Use contextlib.suppress(FileNotFoundError) instead of try-except-pass
-    "SIM115",  # Use context handler for opening files
+    "N806",    # non-lowercase-variable-in-function
+    "PD901",   # pandas-df-variable-name
+    "PLC0414", # useless-import-alias
+    "PLC1901", # compare-to-empty-string
+    "PLR",     # pylint refactor
     "PLW2901", # Outer for loop variable overwritten by inner assignment target
     "PT006",   # pytest-parametrize-names-wrong-type
     "PT011",   # pytest-raises-too-broad
     "PT013",   # pytest-incorrect-pytest-import
+    "RUF001",  # ambiguous-unicode-character-string
+    "SIM105",  # Use contextlib.suppress(FileNotFoundError) instead of try-except-pass
+    "SIM115",  # Use context handler for opening files
 ]
 pydocstyle.convention = "google"
 isort.lines-after-imports = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,10 @@ select = [
     "E",   # pycodestyle
     "F",   # pyflakes
     "I",   # isort
+    "PIE", # flake8-pie
     "PLE", # pylint error
     "PLW", # pylint warning
+    "PT",  # flake8-pytest-style
     "PYI", # flakes8-pyi
     "Q",   # flake8-quotes
     "SIM", # flake8-simplify
@@ -92,6 +94,9 @@ ignore = [
     "SIM105",  # Use contextlib.suppress(FileNotFoundError) instead of try-except-pass
     "SIM115",  # Use context handler for opening files
     "PLW2901", # Outer for loop variable overwritten by inner assignment target
+    "PT006",   # pytest-parametrize-names-wrong-type
+    "PT011",   # pytest-raises-too-broad
+    "PT013",   # pytest-incorrect-pytest-import
 ]
 pydocstyle.convention = "google"
 isort.lines-after-imports = 2

--- a/site/src/lib/Example.svelte
+++ b/site/src/lib/Example.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { CopyButton } from 'svelte-zoo'
+
   export let title: string
   export let file: string
   export let code: string
@@ -8,7 +10,10 @@
 <h2>{title}</h2>
 
 <section>
-  {@html highlighted}
+  <div>
+    <CopyButton content={code} style="position: absolute; top: 1ex; right: 1ex;" />
+    {@html highlighted}
+  </div>
   <img src="/assets/{file}" alt={title} />
 </section>
 
@@ -20,21 +25,25 @@
   section {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-gap: 2em;
+    grid-gap: 1em;
     width: 100%;
     max-width: 90vw;
     margin: 1em auto;
   }
-  section > :global(pre) {
+  section > div {
+    position: relative;
+  }
+  section :global(pre) {
     width: 100%;
     font-size: 9pt;
     height: fit-content;
     margin: 0;
+    box-sizing: border-box;
   }
   section > img {
     width: 100%;
     max-height: 50vh;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: rgba(255, 255, 255, 0.05);
     border-radius: 4pt;
   }
 </style>

--- a/site/src/routes/[slug]/+page.server.ts
+++ b/site/src/routes/[slug]/+page.server.ts
@@ -1,11 +1,11 @@
 import { compile } from 'mdsvex'
 
 export const load = async ({ params }) => {
-  const raw = import.meta.glob(`./**/*.py`, { eager: true, as: `raw` })
+  const files = import.meta.glob(`./**/*.py`, { eager: true, as: `raw` })
   const { slug } = params
 
   // exclude files starting with _
-  const matches = Object.keys(raw).filter(
+  const matches = Object.keys(files).filter(
     (key) => key.startsWith(`./${slug}/`) && !key.startsWith(`./${slug}/_`)
   )
 
@@ -13,12 +13,12 @@ export const load = async ({ params }) => {
   if (matches.length == 0) return { status: 404 }
 
   const examples = matches.map(async (path) => {
-    let code = raw[path]
+    let code = files[path]
     const name = path.split(`/`).at(-1)?.split(`.`)[1] ?? ``
     let title = name.replace(/-/g, ` `)
 
     if (code.startsWith(`# `)) {
-      // split 1st line into title and code
+      // extract title from leading code comment
       const lines = code.split(`\n\n`)
       title = lines[0].replace(`# `, ``)
       code = lines.slice(1).join(`\n\n`)

--- a/site/src/routes/notebooks/+page.svelte
+++ b/site/src/routes/notebooks/+page.svelte
@@ -2,7 +2,7 @@
   <h1 class="toc-exclude">Examples</h1>
 
   <ol>
-    {#each Object.keys(import.meta.glob(`$root/examples/*.html`, { eager: true })) as key}
+    {#each Object.keys(import.meta.glob( `$root/examples/*.html`, { eager: true, as: `url` } )) as key}
       {@const filename = key.split(`/`).at(-1)?.split(`.`)[0]}
       <li><a href="/notebooks/{filename}">{filename}.ipynb</a></li>
     {/each}

--- a/site/src/routes/notebooks/+page.svelte
+++ b/site/src/routes/notebooks/+page.svelte
@@ -2,7 +2,7 @@
   <h1 class="toc-exclude">Examples</h1>
 
   <ol>
-    {#each Object.keys(import.meta.glob( `$root/examples/*.html`, { eager: true, as: `url` } )) as key}
+    {#each Object.keys(import.meta.glob(`$root/examples/*.html`, { eager: true })) as key}
       {@const filename = key.split(`/`).at(-1)?.split(`.`)[0]}
       <li><a href="/notebooks/{filename}">{filename}.ipynb</a></li>
     {/each}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ df_x_y_clf = [(None, y_binary, y_proba), (df_clf, *df_clf.columns[:2])]
 
 
 @pytest.fixture(autouse=True)
-def run_around_tests() -> Generator[None, None, None]:
+def _run_around_tests() -> Generator[None, None, None]:
     # runs before each test
 
     yield
@@ -49,14 +49,14 @@ def run_around_tests() -> Generator[None, None, None]:
     plt.close()
 
 
-@pytest.fixture
+@pytest.fixture()
 def spg_symbols() -> list[str]:
     symbols = "C2/m C2/m Fm-3m C2/m Cmc2_1 P4/nmm P-43m P-43m P6_3mc".split()
     symbols += "P-43m P6_3mc Cmcm P2_1/m I2_13 P-6m2".split()
     return symbols
 
 
-@pytest.fixture
+@pytest.fixture()
 def structures() -> list[Structure]:
     coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
     lattice = [[3.8, 0, 0], [1.9, 3.3, 0], [0, -2.2, 3.1]]
@@ -75,7 +75,7 @@ def structures() -> list[Structure]:
     return [Si2, Si2Ru2Pr2]
 
 
-@pytest.fixture
+@pytest.fixture()
 def plotly_scatter() -> go.Figure:
     xs = np.arange(7)
     y1 = xs**2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,8 +71,8 @@ def structures() -> list[Structure]:
         [0.75, 0.75, 0.324],
     ]
     lattice = Lattice.tetragonal(4.192, 6.88)
-    Si2Ru2Pr2 = Structure(lattice, ["Si", "Si", "Ru", "Ru", "Pr", "Pr"], coords)
-    return [Si2, Si2Ru2Pr2]
+    Si2_Ru2_Pr2 = Structure(lattice, "Si Si Ru Ru Pr Pr".split(), coords)
+    return [Si2, Si2_Ru2_Pr2]
 
 
 @pytest.fixture()
@@ -80,5 +80,4 @@ def plotly_scatter() -> go.Figure:
     xs = np.arange(7)
     y1 = xs**2
     y2 = xs**0.5
-    fig = px.scatter(x=xs, y=[y1, y2])
-    return fig
+    return px.scatter(x=xs, y=[y1, y2])

--- a/tests/test_histograms.py
+++ b/tests/test_histograms.py
@@ -34,7 +34,7 @@ def test_residual_hist(bins: int | None, xlabel: str | None) -> None:
 @pytest.mark.parametrize("cmap", ["hot", "Blues"])
 @pytest.mark.parametrize(
     "df, y_true, y_pred, y_std",
-    [[None, y_true, y_pred, y_std_mock], [df, *df.columns[:2], df.columns[0]]],
+    [(None, y_true, y_pred, y_std_mock), (df, *df.columns[:2], df.columns[0])],
 )
 def test_true_pred_hist(
     df: pd.DataFrame | None,

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from pymatviz.ptable import CountMode
 
 
-@pytest.fixture
+@pytest.fixture()
 def glass_formulas() -> list[str]:
     """First 20 materials in the Matbench glass dataset.
 
@@ -38,12 +38,12 @@ def glass_formulas() -> list[str]:
     ).split()
 
 
-@pytest.fixture
+@pytest.fixture()
 def glass_elem_counts(glass_formulas: pd.Series[Composition]) -> pd.Series[int]:
     return count_elements(glass_formulas)
 
 
-@pytest.fixture
+@pytest.fixture()
 def steel_formulas() -> list[str]:
     """Unusually fractional compositions, good for testing edge cases.
 
@@ -60,7 +60,7 @@ def steel_formulas() -> list[str]:
     ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def steel_elem_counts(steel_formulas: pd.Series[Composition]) -> pd.Series[int]:
     return count_elements(steel_formulas)
 

--- a/tests/test_structure_viz.py
+++ b/tests/test_structure_viz.py
@@ -43,7 +43,8 @@ def test_plot_structure_2d(
     assert ax.get_aspect() == 1, "aspect ratio should be set to 'equal', i.e. 1:1"
     x_min, x_max, y_min, y_max = ax.axis()
     assert x_min == y_min == 0, "x/y_min should be 0"
-    assert x_max > 5 and y_max > 5, "x/y_max should be > 5"
+    assert x_max > 5
+    assert y_max > 5
 
     patch_counts = pd.Series(
         [type(patch).__name__ for patch in ax.patches]

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -21,10 +21,10 @@ assert len(df_x_y[0]) == 3
 @pytest.mark.parametrize(
     "df, x, y, y_std",
     [
-        [None, y_true, y_pred, y_std_mock],
-        [None, y_true, y_pred, {"y_std_mock": y_std_mock}],
-        [df, *df.columns[:2], df.columns[0]],  # single std col
-        [df, *df.columns[:2], df.columns[:2]],  # multiple std cols
+        (None, y_true, y_pred, y_std_mock),
+        (None, y_true, y_pred, {"y_std_mock": y_std_mock}),
+        (df, *df.columns[:2], df.columns[0]),  # single std col
+        (df, *df.columns[:2], df.columns[:2]),  # multiple std cols
     ],
 )
 @pytest.mark.parametrize("n_rand", [10, 100, 1000])
@@ -53,10 +53,10 @@ def test_error_decay_with_uncert(
 @pytest.mark.parametrize(
     "df, x, y, y_std",
     [
-        [*df_x_y[0], xs],
-        [*df_x_y[0], {"foo": xs, "bar": 0.1 * xs}],
-        [*df_x_y[1], df.columns[0]],
-        [*df_x_y[1], df.columns[:2]],
+        (*df_x_y[0], xs),
+        (*df_x_y[0], {"foo": xs, "bar": 0.1 * xs}),
+        (*df_x_y[1], df.columns[0]),
+        (*df_x_y[1], df.columns[:2]),
     ],
 )
 @pytest.mark.parametrize("ax", [None, plt.gca()])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,10 +26,10 @@ from tests.conftest import y_pred, y_true
 @pytest.mark.parametrize(
     "metrics, prec",
     [
-        [["RMSE"], 1],
-        [("MAPE", "MSE"), 2],
-        [{"MAE", "R2", "RMSE"}, 3],
-        [{"MAE": 1, "R2": 2, "RMSE": 3}, 0],
+        (["RMSE"], 1),
+        (("MAPE", "MSE"), 2),
+        ({"MAE", "R2", "RMSE"}, 3),
+        ({"MAE": 1, "R2": 2, "RMSE": 3}, 0),
     ],
 )
 def test_annotate_metrics(metrics: dict[str, float] | Sequence[str], prec: int) -> None:


### PR DESCRIPTION
 8513cb8 add CopyButton to example code snippets
 49ff117 ruff enable flake8-pie + flake8-pytest-style
 56a8c4f more sets: `pep8-naming`, `pandas-vet`, `pylint`, `flake8-return`, `ruff`