### PR TITLE
Breaking: Fix and rename `df_to_(svelte->html)_table`

### DIFF
--- a/dataset_exploration/boltztrap_mp/explore_boltztrap_mp.py
+++ b/dataset_exploration/boltztrap_mp/explore_boltztrap_mp.py
@@ -20,7 +20,7 @@ The properties are reported at 300 Kelvin and carrier concentration of 1e18/cm3.
 
 Reference:
 Ricci, F. et al. An ab initio electronic transport database for inorganic materials.
-https://nature.com/articles/sdata201785
+https://www.nature.com/articles/sdata201785
 Dryad Digital Repository. https://doi.org/10.5061/dryad.gn001
 
 https://hackingmaterials.lbl.gov/matminer/dataset_summary.html

--- a/dataset_exploration/readme.md
+++ b/dataset_exploration/readme.md
@@ -2,11 +2,11 @@
 
 The majority of datasets explored in this directory are from the [`matbench`](https://matbench.materialsproject.org) collection. Others include:
 
-- [`ricci_carrier_transport`](https://hackingmaterials.lbl.gov/matminer/dataset_summary): [Electronic Transport Properties by F. Ricci et al.][carrier_transport] from MPContribs which contains 48,000 DFT Seebeck coefficients ([Paper](https://nature.com/articles/sdata201785)). [[Download link][carrier_transport.json.gz] (from [here](https://git.io/JOMwY))].
+- [`ricci_carrier_transport`](https://hackingmaterials.lbl.gov/matminer/dataset_summary): [Electronic Transport Properties by F. Ricci et al.][carrier_transport] from MPContribs which contains 48,000 DFT Seebeck coefficients ([Paper](https://www.nature.com/articles/sdata201785)). [[Download link][carrier_transport.json.gz] (from [here](https://git.io/JOMwY))].
 - [`boltztrap_mp`](https://hackingmaterials.lbl.gov/matminer/dataset_summary) which contains ~9000 effective mass and thermoelectric properties calculated by the BoltzTraP software package.
 - [`tri_camd_2022`](https://data.matr.io/7): Toyota Research Institute's 2nd active learning crystal discovery dataset from Computational Autonomy for
 Materials Discovery (CAMD)
-- `WBM`: From the paper [Predicting stable crystalline compounds using chemical similarity](https://nature.com/articles/s41524-020-00481-6) published Jan 26, 2021 in Nature. A dataset generated with DFT building on earlier work by some of the same authors published in [The optimal one dimensional periodic table: a modified Pettifor chemical scale from data mining](https://doi.org/10.1088/1367-2630/18/9/093011). Kindly shared by the author Hai-Chen Wang on email request.
+- `WBM`: From the paper [Predicting stable crystalline compounds using chemical similarity](https://www.nature.com/articles/s41524-020-00481-6) published Jan 26, 2021 in Nature. A dataset generated with DFT building on earlier work by some of the same authors published in [The optimal one dimensional periodic table: a modified Pettifor chemical scale from data mining](https://doi.org/10.1088/1367-2630/18/9/093011). Kindly shared by the author Hai-Chen Wang on email request.
 
 ## [MatBench v0.1](https://matbench.materialsproject.org)
 
@@ -15,7 +15,7 @@ Materials Discovery (CAMD)
 > MatBench is an [ImageNet](http://www.image-net.org) for materials science; a set of 13 supervised, pre-cleaned, ready-to-use ML tasks for benchmarking and fair comparison. The tasks span across the domain of inorganic materials science applications.
 
 To browse these datasets online, go to [ml.materialsproject.org] and log in.
-Datasets were originally published in <https://nature.com/articles/s41524-020-00406-3>.
+Datasets were originally published in <https://www.nature.com/articles/s41524-020-00406-3>.
 
 Detailed information about how each dataset was created and prepared for use is available at <https://hackingmaterials.lbl.gov/matminer/dataset_summary.html>
 

--- a/dataset_exploration/ricci_carrier_transport/explore_carrier_transport.py
+++ b/dataset_exploration/ricci_carrier_transport/explore_carrier_transport.py
@@ -10,7 +10,7 @@ https://contribs.materialsproject.org/projects/carrier_transport.json.gz
 
 Reference:
 Ricci, F. et al. An ab initio electronic transport database for inorganic materials.
-https://nature.com/articles/sdata201785
+https://www.nature.com/articles/sdata201785
 Dryad Digital Repository. https://doi.org/10.5061/dryad.gn001
 
 Extensive column descriptions and metadata at

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -270,7 +270,7 @@ def normalize_and_crop_pdf(
         raise RuntimeError("Error cropping PDF margins") from exc
 
 
-def df_to_svelte_table(
+def df_to_html_table(
     styler: Styler,
     file_path: str | Path,
     inline_props: str = "",

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -176,9 +176,9 @@ def df_to_pdf(
             and other options.
         style (str): CSS style string to be inserted into the HTML file.
             Defaults to "".
-        styler_css (bool | dict[str, str]): Whether to apply some sensible default CSS.
-            Defaults to True. If dict, the keys are selectors and the values are CSS
-            strings. Example: {"td, th": "border: none; padding: 4px 6px;"}
+        styler_css (bool | dict[str, str]): Whether to apply some sensible default CSS
+            to the pandas Styler. Defaults to True. If dict, keys are selectors and
+            values CSS strings. Example: {"td, th": "border: none; padding: 4px 6px;"}
         **kwargs: Keyword arguments passed to Styler.to_html().
     """
     try:
@@ -275,7 +275,7 @@ def normalize_and_crop_pdf(
 def df_to_html_table(
     styler: Styler,
     file_path: str | Path,
-    inline_props: str = "",
+    inline_props: str | None = "",
     script: str | None = "",
     styles: str | None = "table { overflow: scroll; max-width: 100%; display: block; }",
     styler_css: bool | dict[str, str] = True,
@@ -295,9 +295,9 @@ def df_to_html_table(
             the somewhere in the script. Defaults to "".
         styles (str): CSS rules to add to the table styles. Defaults to
             `table { overflow: scroll; max-width: 100%; display: block; }`.
-        styler_css (bool | dict[str, str]): Whether to apply some sensible default CSS.
-            Defaults to True. If dict, the keys are selectors and the values are CSS
-            strings. Example: {"td, th": "border: none; padding: 4px 6px;"}
+        styler_css (bool | dict[str, str]): Whether to apply some sensible default CSS
+            to the pandas Styler. Defaults to True. If dict, keys are selectors and
+            values CSS strings. Example: {"td, th": "border: none; padding: 4px 6px;"}
         **kwargs: Keyword arguments passed to Styler.to_html().
     """
     default_script = """<script lang="ts">
@@ -314,9 +314,14 @@ def df_to_html_table(
             [dict(selector=sel, props=val) for sel, val in styler_css.items()]
         )
     html = styler.to_html(**kwargs)
-    if script is not None:
+    if script:
         html = html.replace("<table", f"{script or default_script}")
     if inline_props:
+        if "<table " not in html:
+            raise ValueError(
+                f"Got {inline_props=} but no '<table ...' tag found in HTML string to "
+                "attach to"
+            )
         html = html.replace("<table", f"<table {inline_props}")
     if styles is not None:
         # insert styles at end of closing </style> tag so they override default styles

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -171,8 +171,9 @@ def df_to_pdf(
         crop (bool): Whether to crop the PDF margins. Requires pdfCropMargins.
             Defaults to True. Be careful to set size correctly (not much too large as
             is the default) if you set crop=False.
-        size (str): Page size. Defaults to "100cm". See
-            https://developer.mozilla.org/@page for 'landscape' and other options.
+        size (str): Page size. Defaults to "4cm * n_cols x 2cm * n_rows"
+            (width x height). See https://developer.mozilla.org/@page for 'landscape'
+            and other options.
         style (str): CSS style string to be inserted into the HTML file.
             Defaults to "".
         default_styles (bool): Whether to apply some sensible default CSS.
@@ -195,7 +196,7 @@ def df_to_pdf(
 
     if size is None:
         n_rows, n_cols = styler.data.shape
-        size = f"{n_cols * 3}cm {n_rows * 1}cm"
+        size = f"{n_cols * 4}cm {n_rows * 2}cm"
 
     # CSS to adjust layout and margins
     html_str = f"""

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -276,6 +276,7 @@ def df_to_svelte_table(
     inline_props: str = "",
     script: str | None = "",
     styles: str | None = "table { overflow: scroll; max-width: 100%; display: block; }",
+    default_styles: bool = True,
     **kwargs: Any,
 ) -> None:
     """Convert a pandas Styler to a svelte table.
@@ -292,6 +293,8 @@ def df_to_svelte_table(
             since that exact string is replaced. Defaults to "".
         styles (str): CSS rules to add to the table styles. Defaults to
             `table { overflow: scroll; max-width: 100%; display: block; }`.
+        default_styles (bool): Whether to apply some sensible default CSS.
+            Defaults to True.
         **kwargs: Keyword arguments passed to Styler.to_html().
     """
     default_script = """<script lang="ts">
@@ -300,6 +303,12 @@ def df_to_svelte_table(
 
     <table use:sortable {...$$props}
     """
+
+    styler.set_uuid("")
+    if default_styles:
+        styler.set_table_styles(
+            [dict(selector=sel, props=val) for sel, val in DEFAULT_DF_STYLES.items()]
+        )
     html = styler.to_html(**kwargs)
     if script is not None:
         html = html.replace("<table", f"{script or default_script}")

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -5,7 +5,7 @@ import subprocess
 from os.path import dirname
 from shutil import which
 from time import sleep
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal
 
 import matplotlib.pyplot as plt
 import plotly.graph_objects as go
@@ -146,6 +146,14 @@ def save_and_compress_svg(
         subprocess.run([svgo, "--multipass", filepath], check=True)
 
 
+DEFAULT_DF_STYLES: Final = {
+    "": "font-family: sans-serif; border-collapse: collapse;",
+    "td, th": "border: none; padding: 4px 6px; white-space: nowrap;",
+    "th.col_heading": "border: 1px solid; border-width: 1px 0; text-align: left;",
+    "th.row_heading": "font-weight: normal; padding: 3pt;",
+}
+
+
 def df_to_pdf(
     styler: Styler,
     file_path: str | Path,
@@ -178,19 +186,11 @@ def df_to_pdf(
         raise ImportError(msg) from exc
 
     if default_styles:
-        # Apply default styles
-        styles = {
-            "": "font-family: sans-serif; border-collapse: collapse;",
-            "td, th": "border: none; padding: 4px 6px; white-space: nowrap;",
-            "th.col_heading": "border: 1px solid; border-width: 1px 0; "
-            "text-align: left;",
-            "th.row_heading": "font-weight: normal; padding: 3pt;",
-        }
         styler.set_table_styles(
-            [dict(selector=sel, props=styles[sel]) for sel in styles]
+            [dict(selector=sel, props=val) for sel, val in DEFAULT_DF_STYLES.items()]
         )
-        styler.set_uuid("")
 
+    styler.set_uuid("")
     html_str = styler.to_html(**kwargs)
 
     if size is None:

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -286,8 +286,9 @@ def df_to_svelte_table(
             "class='table' style='width: 100%'". Defaults to "".
         script (str): JavaScript to insert above the table. Will replace the opening
             `<table` tag to allow passing props to it. Uses ...props to allow for
-            Svelte props forwarding to the table element. See source code for lengthy
-            default script.
+            Svelte props forwarding to the table element. See source code for
+            default script as example. Don't forget to include '<table' in the script,
+            since that exact string is replaced. Defaults to "".
         styles (str): CSS rules to add to the table styles. Defaults to
             `table { overflow: scroll; max-width: 100%; display: block; }`.
         **kwargs: Keyword arguments passed to Styler.to_html().
@@ -299,12 +300,12 @@ def df_to_svelte_table(
     <table use:sortable {...$$props}
     """
     html = styler.to_html(**kwargs)
+    if script is not None:
+        html = html.replace("<table", f"{script or default_script}")
     if inline_props:
         html = html.replace("<table", f"<table {inline_props}")
-    if script is not None:
-        html = html.replace("<table", f"<table {script or default_script}")
     if styles is not None:
         # insert styles at end of closing </style> tag so they override default styles
-        html = html.replace("</style>", f"{styles}</style>")
+        html = html.replace("</style>", f"{styles}\n</style>")
     with open(file_path, "w") as file:
         file.write(html)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -10,7 +10,7 @@ import plotly.graph_objects as go
 import pytest
 from matplotlib import pyplot as plt
 
-from pymatviz.io import df_to_pdf, df_to_svelte_table, normalize_and_crop_pdf, save_fig
+from pymatviz.io import df_to_html_table, df_to_pdf, normalize_and_crop_pdf, save_fig
 
 
 if TYPE_CHECKING:
@@ -67,7 +67,7 @@ def test_plotly_pdf_no_mathjax_loading(tmp_path: Path) -> None:
     PyPDF2 = pytest.importorskip("PyPDF2")
 
     fig = go.Figure()
-    fig.add_trace(go.Scatter(x=[1, 2], y=[3, 4]))
+    fig.add_scatter(x=[1, 2], y=[3, 4])
     path = f"{tmp_path}/test.pdf"
     save_fig(fig, path)
 
@@ -188,14 +188,14 @@ def test_normalize_and_crop_pdf(
         ),
     ],
 )
-def test_df_to_svelte_table(
+def test_df_to_html_table(
     tmp_path: Path, script: str, styles: str, inline_props: str
 ) -> None:
     df = pd._testing.makeMixedDataFrame()
 
     file_path = tmp_path / "test_df.svelte"
 
-    df_to_svelte_table(
+    df_to_html_table(
         df.style, file_path, script=script, styles=styles, inline_props=inline_props
     )
 


### PR DESCRIPTION
77b77cd fix broken nature links
a31a77b fix bad script or default_script string replacement
2e1319c move DEFAULT_DF_STYLES to module scope
e5f5be0 df_to_pdf change default size = f"{n_cols * 4}cm {n_rows * 2}cm"
24b8dc7 df_to_svelte_table use same default_styles as df_to_pdf
42a52cb rename df_to_(svelte->html)_table