### PR TITLE
Add `si_fmt()` for formatting large numbers in human-readable format

### DIFF
--- a/examples/matbench_perovskites_eda.ipynb
+++ b/examples/matbench_perovskites_eda.ipynb
@@ -245,7 +245,8 @@
     "for idx, struct in tqdm(df_perov.structure.items(), total=len(df_perov)):\n",
     "    if pd.isna(df_perov.aflow_wyckoff[idx]):\n",
     "        df_perov.loc[idx, \"aflow_wyckoff\"] = get_aflow_label_aflow(\n",
-    "            struct, \"/path/to/aflow\"  # defaults to aflow\n",
+    "            struct,\n",
+    "            \"/path/to/aflow\",  # defaults to aflow\n",
     "        )"
    ]
   },

--- a/examples/mp_bimodal_e_form.ipynb
+++ b/examples/mp_bimodal_e_form.ipynb
@@ -204,7 +204,7 @@
     "# %store df_e_form\n",
     "\n",
     "# load cached MP data\n",
-    "# %store -r df_e_form"
+    "# %store -r df_e_form\n"
    ]
   },
   {
@@ -475,7 +475,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -499,3 +499,45 @@ def pick_bw_for_contrast(
     """
     light_bg = luminance(color) > text_color_threshold
     return "black" if light_bg else "white"
+
+
+def si_fmt(
+    val: float, fmt_spec: str = ".1f", sep: str = "", binary: bool = False
+) -> str:
+    """Convert large numbers into human readable format using SI prefixes in binary
+    (1024) or metric (1000) mode.
+
+    https://nist.gov/pml/weights-and-measures/metric-si-prefixes
+
+    Args:
+        val (int | float): Some numerical value to format.
+        binary (bool, optional): If True, scaling factor is 2^10 = 1024 else 1000.
+            Defaults to False.
+        fmt_spec (str): f-string format specifier. Configure precision and left/right
+            padding in returned string. Defaults to ".1f". Can be used to ensure leading
+            or trailing whitespace for shorter numbers. Ex.1: ">10.2f" has 2 decimal
+            places and is at least 10 characters long with leading spaces if necessary.
+            Ex.2: "<20.3g" uses 3 significant digits (g: scientific notation on large
+            numbers) with at least 20 chars through trailing space.
+        sep (str): Separator between number and postfix. Defaults to "".
+
+    Returns:
+        str: Formatted number.
+    """
+    factor = 1024 if binary else 1000
+
+    if abs(val) >= 1:
+        # 1, Kilo, Mega, Giga, Tera, Peta, Exa, Zetta, Yotta
+        for _scale in ("", "K", "M", "G", "T", "P", "E", "Z", "Y"):
+            if abs(val) < factor:
+                break
+            val /= factor
+    else:
+        mu_unicode = "\u03BC"
+        # milli, micro, nano, pico, femto, atto, zepto, yocto
+        for _scale in ("", "m", mu_unicode, "n", "p", "f", "a", "z", "y"):
+            if abs(val) > 1:
+                break
+            val *= factor
+
+    return f"{val:{fmt_spec}}{sep}{_scale}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,7 @@ from pymatviz.utils import (
     luminance,
     patch_dict,
     pick_bw_for_contrast,
+    si_fmt,
 )
 from tests.conftest import y_pred, y_true
 
@@ -368,3 +369,15 @@ def test_pick_bw_for_contrast(
     expected: Literal["black", "white"],
 ) -> None:
     assert pick_bw_for_contrast(color, text_color_threshold) == expected
+
+
+def test_si_fmt() -> None:
+    assert si_fmt(123456) == "123.5K"
+
+    assert si_fmt(12345678, fmt_spec=">6.2f", sep=" ") == " 12.35 M"
+
+    assert si_fmt(-0.00123, fmt_spec=".3g", binary=False) == "-1.23m"
+
+    assert si_fmt(0.00000123, fmt_spec="5.1f", sep="\t", binary=True) == "  1.3\tμ"
+
+    assert si_fmt(0.00000123, fmt_spec="5.1f", sep="\t", binary=False) == "  1.2\tμ"


### PR DESCRIPTION
7aeed9b add si_fmt() for formatting large numbers in human-readable format
0fbdf1f Add test_si_fmt() in test_utils.py
14af440 ruff format examples/