### PR TITLE
Support semi-log + log-log plots in `add_identity_line`

### DIFF
--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -429,7 +429,7 @@ def ptable_heatmap_plotly(
     colorscale: str | Sequence[str] | Sequence[tuple[float, str]] = "viridis",
     showscale: bool = True,
     heat_mode: Literal["value", "fraction", "percent"] | None = "value",
-    precision: str | None = None,
+    fmt: str | None = None,
     hover_props: Sequence[str] | dict[str, str] | None = None,
     hover_data: dict[str, str | int | float] | pd.Series | None = None,
     font_colors: Sequence[str] = ("#eff", "black"),
@@ -466,7 +466,7 @@ def ptable_heatmap_plotly(
             or not at all (None). Defaults to "value".
             "fraction" and "percent" can be used to make the colors in different
             periodic table heatmap plots comparable.
-        precision (str): f-string format option for heat labels. Defaults to ".1%"
+        fmt (str): f-string format option for heat labels. Defaults to ".1%"
             (1 decimal place) if heat_mode="percent" else ".3g".
         hover_props (list[str] | dict[str, str]): Elemental properties to display in the
             hover tooltip. Can be a list of property names to display only the values
@@ -583,12 +583,12 @@ def ptable_heatmap_plotly(
             label = "excl."
         elif heat_value := heat_value_element_map.get(symbol):
             if heat_mode == "percent":
-                label = f"{heat_value:{precision or '.1%'}}"
+                label = f"{heat_value:{fmt or '.1%'}}"
             else:
                 default_prec = ".1f" if heat_value < 100 else ",.0f"
                 if heat_value > 1e5:
                     default_prec = ".2g"
-                label = f"{heat_value:{precision or default_prec}}".replace("e+0", "e")
+                label = f"{heat_value:{fmt or default_prec}}".replace("e+0", "e")
 
         style = f"font-weight: bold; font-size: {1.5 * (font_size or 12)};"
         tile_text = (

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -296,29 +296,34 @@ def add_identity_line(
         xaxis_type = full_fig.layout.xaxis.type
         yaxis_type = full_fig.layout.yaxis.type
 
-        if xaxis_type == "log" or yaxis_type == "log":
-            xy_min = min(full_fig.layout.xaxis.range[0], full_fig.layout.yaxis.range[0])
-            xy_max = max(full_fig.layout.xaxis.range[1], full_fig.layout.yaxis.range[1])
-            # Convert to linear space for plotting
-            xy_min, xy_max = 10**xy_min, 10**xy_max
-        else:
-            xy_range = full_fig.layout.xaxis.range + full_fig.layout.yaxis.range
-            xy_min, xy_max = min(xy_range), max(xy_range)
+        x_range = full_fig.layout.xaxis.range
+        y_range = full_fig.layout.yaxis.range
+
+        # Convert log range to linear if necessary
+        if xaxis_type == "log":
+            x_range = [10**val for val in x_range]
+        if yaxis_type == "log":
+            y_range = [10**val for val in y_range]
+
+        xy_min = min(x_range[0], y_range[0])
+        xy_max = max(x_range[1], y_range[1])
     except ValueError:
         trace = fig.data[trace_idx]
         df = pd.DataFrame({"x": trace.x, "y": trace.y}).dropna()
 
-        x_min, x_max = min(df.x), max(df.x)
-        y_min, y_max = min(df.y), max(df.y)
-
-        # If the axes are logarithmic, adjust the min and max accordingly
+        # Determine ranges based on the type of axes
         if fig.layout.xaxis.type == "log":
-            x_min, x_max = 10**x_min, 10**x_max
-        if fig.layout.yaxis.type == "log":
-            y_min, y_max = 10**y_min, 10**y_max
+            x_range = [10**val for val in (min(df.x), max(df.x))]
+        else:
+            x_range = [min(df.x), max(df.x)]
 
-        xy_min = min(x_min, y_min)
-        xy_max = max(x_max, y_max)
+        if fig.layout.yaxis.type == "log":
+            y_range = [10**val for val in (min(df.y), max(df.y))]
+        else:
+            y_range = [min(df.y), max(df.y)]
+
+        xy_min = min(x_range[0], y_range[0])
+        xy_max = max(x_range[1], y_range[1])
 
     line_defaults = dict(color="gray", width=1, dash="dash")
     fig.add_shape(

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -157,7 +157,7 @@ def test_ptable_heatmap(
     with pytest.raises(ValueError, match=r"Unexpected symbol\(s\) foobar"):
         ptable_heatmap(glass_elem_counts, exclude_elements=["foobar"])
 
-    # test cbar_precision
+    # test cbar_fmt
     ax = ptable_heatmap(glass_elem_counts, cbar_fmt=".3f")
     cbar_1st_label = ax.child_axes[0].get_xticklabels()[0].get_text()
     assert cbar_1st_label == "0.000"


### PR DESCRIPTION
e84dc19 support log-log plots in add_identity_line
3a8ca7d also support semi-log plots
0bcdc3e breaking: ptable_heatmap_plotly rename precision keyword to fmt
0e2d2ca parametrize test_add_identity_line to test linear, semi-log, log-log plots