### PR TITLE
`ptable_heatmap` add keywords `cbar_range` and `cbar_kwargs`

### DIFF
--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -180,7 +180,7 @@ def ptable_heatmap(
             and size: [x, y, width, height] anchored at lower left corner. Defaults to
             (0.18, 0.8, 0.42, 0.05).
         cbar_kwargs (dict[str, Any], optional): Additional keyword arguments passed to
-            fig.colorbar(). Defaults to {}.
+            fig.colorbar(). Defaults to None.
         colorscale (str, optional): Matplotlib colormap name to use. Defaults to
             "viridis". See https://matplotlib.org/stable/users/explain/colors/colormaps
             for available options.

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -144,8 +144,9 @@ def ptable_heatmap(
     ax: plt.Axes | None = None,
     count_mode: CountMode = "composition",
     cbar_title: str = "Element Count",
-    cbar_max: float | None = None,
+    cbar_range: tuple[float | None, float | None] | None = None,
     cbar_coords: tuple[float, float, float, float] = (0.18, 0.8, 0.42, 0.05),
+    cbar_kwargs: dict[str, Any] | None = None,
     colorscale: str = "viridis",
     infty_color: str = "lightskyblue",
     na_color: str = "white",
@@ -172,12 +173,14 @@ def ptable_heatmap(
             Reduce or normalize compositions before counting. See count_elements() for
             details. Only used when values is list of composition strings/objects.
         cbar_title (str, optional): Color bar title. Defaults to "Element Count".
-        cbar_max (float, optional): Max value of the color bar range. Will be ignored
-            if smaller than the largest plotted value. For creating multiple plots with
-            identical color bars for visual comparison. Defaults to 0.
+        cbar_range (tuple[float | None, float | None], optional): Color bar range.
+            Can be used e.g. to create multiple plots with identical color bars for
+            visual comparison. Defaults to automatic based on data range.
         cbar_coords (tuple[float, float, float, float], optional): Color bar position
             and size: [x, y, width, height] anchored at lower left corner. Defaults to
             (0.18, 0.8, 0.42, 0.05).
+        cbar_kwargs (dict[str, Any], optional): Additional keyword arguments passed to
+            fig.colorbar(). Defaults to {}.
         colorscale (str, optional): Matplotlib colormap name to use. Defaults to
             "viridis". See https://matplotlib.org/stable/users/explain/colors/colormaps
             for available options.
@@ -252,8 +255,11 @@ def ptable_heatmap(
     norm = LogNorm() if log else Normalize()
 
     norm.autoscale(clean_vals.to_numpy())
-    if cbar_max is not None:
-        norm.vmax = cbar_max
+    if cbar_range is not None and len(cbar_range) == 2:
+        if cbar_range[0] is not None:
+            norm.vmin = cbar_range[0]
+        if cbar_range[1] is not None:
+            norm.vmax = cbar_range[1]
 
     text_style = dict(
         horizontalalignment="center", fontsize=label_font_size, fontweight="semibold"
@@ -350,11 +356,15 @@ def ptable_heatmap(
             )
             return f"{val:{cbar_fmt or fmt or default_fmt}}"
 
+        cbar_kwargs = cbar_kwargs or {}
         cbar = fig.colorbar(
             mappable,
-            cax=cb_ax,
-            orientation="horizontal",
-            format=cbar_fmt if callable(cbar_fmt) else tick_fmt,
+            cax=cbar_kwargs.pop("cax", cb_ax),
+            orientation=cbar_kwargs.pop("orientation", "horizontal"),
+            format=cbar_kwargs.pop(
+                "format", cbar_fmt if callable(cbar_fmt) else tick_fmt
+            ),
+            **cbar_kwargs,
         )
 
         cbar.outline.set_linewidth(1)

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -142,9 +142,19 @@ def test_ptable_heatmap(
     # element properties as heatmap values
     ptable_heatmap(df_ptable.atomic_mass, text_color=("red", "blue"))
 
-    # custom max color bar value
-    ptable_heatmap(glass_formulas, cbar_max=1e2)
-    ptable_heatmap(glass_formulas, log=True, cbar_max=1e2)
+    # custom cbar_range
+    ptable_heatmap(glass_formulas, cbar_range=(0, 100))
+    ptable_heatmap(glass_formulas, log=True, cbar_range=(None, 100))
+    ptable_heatmap(glass_formulas, log=True, cbar_range=(1, None))
+
+    with pytest.raises(ValueError, match="Invalid vmin or vmax"):
+        # can't use cbar_min=0 with log=True
+        ptable_heatmap(glass_formulas, log=True, cbar_range=(0, None))
+
+    # cbar_kwargs
+    ax = ptable_heatmap(glass_formulas, cbar_kwargs=dict(orientation="horizontal"))
+    cax = ax.inset_axes([0.1, 0.9, 0.8, 0.05])
+    ptable_heatmap(glass_formulas, cbar_kwargs={"cax": cax, "format": "%.3f"})
 
     # element counts
     ptable_heatmap(glass_elem_counts)
@@ -157,12 +167,12 @@ def test_ptable_heatmap(
     with pytest.raises(ValueError, match=r"Unexpected symbol\(s\) foobar"):
         ptable_heatmap(glass_elem_counts, exclude_elements=["foobar"])
 
-    # test cbar_fmt as string
+    # cbar_fmt as string
     ax = ptable_heatmap(glass_elem_counts, cbar_fmt=".3f")
     cbar_1st_label = ax.child_axes[0].get_xticklabels()[0].get_text()
     assert cbar_1st_label == "0.000"
 
-    # test cbar_fmt as function
+    # cbar_fmt as function
     ax = ptable_heatmap(glass_elem_counts, fmt=si_fmt)
     ax = ptable_heatmap(glass_elem_counts, fmt=lambda x, _: f"{x:.0f}", cbar_fmt=si_fmt)
     ax = ptable_heatmap(glass_elem_counts, cbar_fmt=lambda x, _: f"{x:.3f} kg")
@@ -171,7 +181,7 @@ def test_ptable_heatmap(
     cbar_1st_label = ax.child_axes[0].get_xticklabels()[0].get_text()
     assert cbar_1st_label == "0.000%"
 
-    # test tile_size
+    # tile_size
     ptable_heatmap(df_ptable.atomic_mass, tile_size=1)
     ptable_heatmap(df_ptable.atomic_mass, tile_size=(0.9, 1))
 


### PR DESCRIPTION
c48d4ca ptable_heatmap add keywords cbar_range: tuple[float | None, float | None] and cbar_kwargs: dict[str, Any]
2d30cdb add tests ptable_heatmap with custom cbar_range and cbar_kwargs