### PR TITLE
Tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest] # windows-latest
     uses: janosh/workflows/.github/workflows/pytest-release.yml@main
     with:
       os: ${{ matrix.os }}

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -284,6 +284,7 @@ def df_to_html_table(
     script: str | None = "",
     styles: str | None = TABLE_SCROLL_CSS,
     styler_css: bool | dict[str, str] = True,
+    sortable: bool = True,
     **kwargs: Any,
 ) -> None:
     """Convert a pandas Styler to a svelte table.
@@ -303,9 +304,11 @@ def df_to_html_table(
             to the pandas Styler. Defaults to True. If dict, keys are CSS selectors and
             values CSS strings. Example:
             dict("td, th": "border: none; padding: 4px 6px;")
+        sortable (bool): Whether to enable sorting the table by clicking on column
+            headers. Defaults to True.
         **kwargs: Keyword arguments passed to Styler.to_html().
     """
-    default_script = """<script lang="ts">
+    sortable_script = """<script lang="ts">
       import { sortable } from 'svelte-zoo/actions'
     </script>
 
@@ -320,7 +323,9 @@ def df_to_html_table(
         )
     html = styler.to_html(**kwargs)
     if script:
-        html = html.replace("<table", f"{script or default_script}")
+        html = html.replace("<table", script)
+    if sortable:
+        html = html.replace("<table", sortable_script)
     if inline_props:
         if "<table " not in html:
             raise ValueError(

--- a/pymatviz/parity.py
+++ b/pymatviz/parity.py
@@ -22,6 +22,7 @@ def hist_density(
     df: pd.DataFrame | None = None,
     sort: bool = True,
     bins: int = 100,
+    method: str = "nearest",
 ) -> tuple[ArrayLike, ArrayLike, ArrayLike]:
     """Return an approximate density of 2d points.
 
@@ -32,6 +33,8 @@ def hist_density(
         sort (bool, optional): Whether to sort points by density so that densest points
             are plotted last. Defaults to True.
         bins (int, optional): Number of bins (histogram resolution). Defaults to 100.
+        method (str, optional): Interpolation method. Defaults to "nearest".
+            See scipy.interpolate.interpn() for options.
 
     Returns:
         tuple[array, array]: x and y values (sorted by density) and density itself
@@ -44,7 +47,7 @@ def hist_density(
         (0.5 * (x_e[1:] + x_e[:-1]), 0.5 * (y_e[1:] + y_e[:-1])),
         data,
         np.vstack([x, y]).T,
-        method="splinef2d",
+        method=method,
         bounds_error=False,
     )
 

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -227,6 +227,8 @@ def ptable_heatmap(
     Returns:
         ax: matplotlib Axes with the heatmap.
     """
+    if not isinstance(log, bool):
+        raise ValueError(f"{log=} must be bool")
     if log and heat_mode in ("fraction", "percent"):
         raise ValueError(
             "Combining log color scale and heat_mode='fraction'/'percent' unsupported"
@@ -370,7 +372,8 @@ def ptable_heatmap(
             cax=cbar_kwargs.pop("cax", cbar_ax),
             orientation=cbar_kwargs.pop("orientation", "horizontal"),
             format=cbar_kwargs.pop(
-                "format", cbar_fmt if callable(cbar_fmt) else tick_fmt
+                "format",
+                cbar_fmt or fmt if any(map(callable, (fmt, cbar_fmt))) else tick_fmt,
             ),
             **cbar_kwargs,
         )

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -335,6 +335,7 @@ def add_identity_line(
         **dict(x0=xy_min, y0=xy_min, x1=xy_max, y1=xy_max),
         layer="below",
         line=line_defaults | (line_kwds or {}),
+        **dict(row="all", col="all"),
         **kwargs,
     )
 

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -329,13 +329,16 @@ def add_identity_line(
         xy_min = min(x_range[0], y_range[0])
         xy_max = max(x_range[1], y_range[1])
 
+    if fig._grid_ref is not None:
+        kwargs.setdefault("row", "all")
+        kwargs.setdefault("col", "all")
+
     line_defaults = dict(color="gray", width=1, dash="dash")
     fig.add_shape(
         type="line",
         **dict(x0=xy_min, y0=xy_min, x1=xy_max, y1=xy_max),
         layer="below",
         line=line_defaults | (line_kwds or {}),
-        **dict(row="all", col="all"),
         **kwargs,
     )
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,8 @@ A toolkit for visualizations in materials informatics.
 
 </h4>
 
-**Note**: This project is not endorsed by [`pymatgen`](https://github.com/materialsproject/pymatgen), but aims to complement it with additional plotting functionality.
+> [!NOTE]
+> If you use `pymatviz` in your research, please cite the [Zenodo DOI](https://zenodo.org/badge/latestdoi/340898532) above.
 
 ## Installation
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -190,7 +190,7 @@ def test_normalize_and_crop_pdf(
         (None, "", None, False),
         ("", "body { margin: 0; padding: 1em; }", "<table class='table'", True),
         (
-            "<script>import { sortable } from 'svelte-zoo/actions'<s/script><table",
+            "<script>import { sortable } from 'svelte-zoo/actions'</script><table",
             "body { margin: 0; padding: 1em; }",
             "style='width: 100%'",
             {"tb, th, td": "border: 1px solid black;"},
@@ -221,7 +221,7 @@ def test_df_to_html_table(
     content = file_path.read_text()
 
     if script is not None:
-        assert script in content
+        assert script.split("<table")[0] in content, content
     if styles is not None:
         assert f"{styles}\n</style>" in content
     if inline_props:


### PR DESCRIPTION
362a383 add zenodo readme note
b8953ab fix making html tables exported from dataframes sortable
2cd2cd3 hist_density change default scipy.interpolate.interpn method to "nearest"
8cd71da ptable_heatmap fix ValueError from colorbar if fmt is callable
691ffb2 fix add_identity_line, now applies to all subplots in a plotly facet plot