### PR TITLE
Support matplotlib `Axes` and `Figure` in `add_identity_line`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,14 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.1.7
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.0
+    rev: v1.7.1
     hooks:
       - id: mypy
         additional_dependencies: [types-requests]

--- a/pymatviz/parity.py
+++ b/pymatviz/parity.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import scipy.interpolate
 
-from pymatviz.utils import annotate_metrics, df_to_arrays, with_hist
+from pymatviz.utils import add_identity_line, annotate_metrics, df_to_arrays, with_hist
 
 
 if TYPE_CHECKING:
@@ -114,15 +114,7 @@ def density_scatter(
     ax.scatter(x, y, c=cs, norm=norm, **kwargs)
 
     if identity:
-        x_mid = sum(ax.get_xlim()) / 2
-        ax.axline(
-            (x_mid, x_mid),
-            slope=1,
-            alpha=0.5,
-            zorder=0,
-            linestyle="dashed",
-            color="black",
-        )
+        add_identity_line(ax)
 
     if stats:
         annotate_metrics(x, y, ax=ax, **(stats if isinstance(stats, dict) else {}))
@@ -169,8 +161,7 @@ def scatter_with_err_bar(
     styles = dict(markersize=6, fmt="o", ecolor="g", capthick=2, elinewidth=2)
     ax.errorbar(x, y, xerr=xerr, yerr=yerr, **kwargs, **styles)
 
-    # identity line
-    ax.axline((0, 0), (1, 1), alpha=0.5, zorder=0, linestyle="dashed", color="black")
+    add_identity_line(ax)
 
     annotate_metrics(x, y, ax=ax)
 
@@ -227,8 +218,7 @@ def density_hexbin(
         # make title vertical
         cb_ax.set_title(cbar_label, rotation=90, pad=10)
 
-    # identity line
-    ax.axline((0, 0), (1, 1), alpha=0.5, zorder=0, linestyle="dashed", color="black")
+    add_identity_line(ax)
 
     annotate_metrics(x, y, ax=ax, loc="upper left")
 

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -718,6 +718,7 @@ def ptable_hists(
     symbol_text: str | Callable[[Element], str] = lambda elem: elem.symbol,
     cbar_title: str = "Values",
     cbar_title_kwds: dict[str, Any] | None = None,
+    cbar_kwds: dict[str, Any] | None = None,
     symbol_pos: tuple[float, float] = (0.5, 0.8),
     log: bool = False,
     anno_kwds: dict[str, Any] | None = None,
@@ -746,6 +747,7 @@ def ptable_hists(
         cbar_title (str): Color bar title. Defaults to "Histogram Value".
         cbar_title_kwds (dict): Keyword arguments passed to cbar.ax.set_title().
             Defaults to dict(fontsize=12, pad=10).
+        cbar_kwds (dict): Keyword arguments passed to fig.colorbar().
         symbol_pos (tuple[float, float]): Position of element symbols relative to the
             lower left corner of each tile. Defaults to (0.5, 0.8). (1, 1) is the upper
             right corner.
@@ -857,7 +859,7 @@ def ptable_hists(
     _cbar = fig.colorbar(
         plt.cm.ScalarMappable(norm=norm, cmap=cmap),
         cax=cbar_ax,
-        orientation="horizontal",
+        **{"orientation": "horizontal"} | (cbar_kwds or {}),
     )
     # set color bar title
     cbar_title_kwds = cbar_title_kwds or {}

--- a/pymatviz/uncertainty.py
+++ b/pymatviz/uncertainty.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import norm
 
-from pymatviz.utils import df_to_arrays
+from pymatviz.utils import add_identity_line, df_to_arrays
 
 
 if TYPE_CHECKING:
@@ -79,8 +79,7 @@ def qq_gaussian(
         )
         lines.append([line, miscal_area])
 
-    # identity line
-    ax.axline((0, 0), (1, 1), alpha=0.5, zorder=0, linestyle="dashed", color="black")
+    add_identity_line(ax)  # guiding line for perfect calibration
 
     ax.set(xlim=(0, 1), ylim=(0, 1))
     ax.set(xlabel="Theoretical Quantile", ylabel="Observed Quantile")

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -170,8 +170,8 @@ def test_ptable_heatmap(
 
     # cbar_fmt as string
     ax = ptable_heatmap(glass_elem_counts, cbar_fmt=".3f")
-    cbar_1st_label = ax.child_axes[0].get_xticklabels()[0].get_text()
-    assert cbar_1st_label == "0.000"
+    cbar_labels = [label.get_text() for label in ax.child_axes[0].get_xticklabels()]
+    assert cbar_labels[:2] == ["0.000", "50.000"]
 
     # cbar_fmt as function
     ax = ptable_heatmap(glass_elem_counts, fmt=si_fmt)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,9 +98,17 @@ def test_crystal_sys_from_spg_num_invalid(spg: int) -> None:
 
 
 @pytest.fixture()
-def scatter_fig() -> go.Figure:
+def plotly_scatter() -> go.Figure:
     fig = go.Figure(go.Scatter(x=[1, 10, 100], y=[10, 100, 1000]))
     fig.add_scatter(x=[1, 10, 100], y=[1, 10, 100])
+    return fig
+
+
+@pytest.fixture()
+def matplotlib_scatter() -> plt.Figure:
+    fig, ax = plt.subplots()
+    ax.plot([1, 10, 100], [10, 100, 1000])
+    ax.plot([1, 10, 100], [1, 10, 100])
     return fig
 
 
@@ -109,17 +117,17 @@ def scatter_fig() -> go.Figure:
 @pytest.mark.parametrize("trace_idx", [0, 1])
 @pytest.mark.parametrize("line_kwds", [None, {"color": "blue"}])
 def test_add_identity_line(
-    scatter_fig: go.Figure,
+    plotly_scatter: go.Figure,
     xaxis_type: str,
     yaxis_type: str,
     trace_idx: int,
     line_kwds: dict[str, str] | None,
 ) -> None:
     # Set axis types
-    scatter_fig.layout.xaxis.type = xaxis_type
-    scatter_fig.layout.yaxis.type = yaxis_type
+    plotly_scatter.layout.xaxis.type = xaxis_type
+    plotly_scatter.layout.yaxis.type = yaxis_type
 
-    fig = add_identity_line(scatter_fig, line_kwds=line_kwds, trace_idx=trace_idx)
+    fig = add_identity_line(plotly_scatter, line_kwds=line_kwds, trace_idx=trace_idx)
     assert isinstance(fig, go.Figure)
 
     # retrieve identity line
@@ -134,6 +142,22 @@ def test_add_identity_line(
     # check fig axis types
     assert fig.layout.xaxis.type == xaxis_type
     assert fig.layout.yaxis.type == yaxis_type
+
+
+@pytest.mark.parametrize("line_kwds", [None, {"color": "blue"}])
+def test_add_identity_matplotlib(
+    matplotlib_scatter: plt.Figure, line_kwds: dict[str, str] | None
+) -> None:
+    # test Figure
+    fig = add_identity_line(matplotlib_scatter, line_kwds=line_kwds)
+    assert isinstance(fig, plt.Figure)
+
+    # test Axes
+    ax = add_identity_line(matplotlib_scatter.axes[0], line_kwds=line_kwds)
+    assert isinstance(ax, plt.Axes)
+
+    line = fig.axes[0].lines[-1]  # retrieve identity line
+    assert line.get_color() == line_kwds["color"] if line_kwds else "black"
 
 
 def test_df_to_arrays() -> None:


### PR DESCRIPTION
fc40cd7 add and test `si_fmt_int` in `pymatviz/utils.py`
7598b60 add `cbar_kwds` keyword to `ptable_hists`
2315d18 fix `ptable_hists` handling of `x_range` and `x_ticks`
6912840 enhance `ptable_heatmap()` log keyword to take `matplotlib.colors.Normalize` instances
2c162f5 support matplotlib `Axes` and `Figures` in `add_identity_line` util
5e9e04b use `add_identity_line` in `pymatviz` matplotlib functions
fa351f4 add `test_add_identity_matplotlib`