### PR TITLE
Add `show_values: bool = True` to `ptable_heatmap[_plotly]()` and `last_peak_anno: str` to `plot_phonon_dos()`

### DIFF
--- a/assets/_generate_assets.py
+++ b/assets/_generate_assets.py
@@ -120,6 +120,7 @@ fig = ptable_heatmap_plotly(
     df_ptable.atomic_mass,
     hover_props=["atomic_mass", "atomic_number"],
     hover_data="density = " + df_ptable.density.astype(str) + " g/cm^3",
+    show_values=False,
 )
 fig.update_layout(
     title=dict(text="<b>Atomic mass heatmap</b>", x=0.4, y=0.94, font_size=20)

--- a/pymatviz/__init__.py
+++ b/pymatviz/__init__.py
@@ -138,15 +138,14 @@ axis_template = dict(
     zeroline=True,
     linewidth=1,
     showgrid=True,
-    gridcolor="lightgray",
 )
 white_axis_template = axis_template | dict(linecolor="black", gridcolor="lightgray")
 pio.templates["pymatviz_white"] = pio.templates["plotly_white"].update(
-    layout=dict(xaxis=axis_template, yaxis=axis_template)
+    layout=dict(xaxis=white_axis_template, yaxis=white_axis_template)
 )
 black_axis_template = axis_template | dict(linecolor="white", gridcolor="darkgray")
 pio.templates["pymatviz_black"] = pio.templates["plotly_dark"].update(
-    layout=dict(xaxis=axis_template, yaxis=axis_template)
+    layout=dict(xaxis=black_axis_template, yaxis=black_axis_template)
 )
 
 px.defaults.template = "pymatviz_white"

--- a/pymatviz/parity.py
+++ b/pymatviz/parity.py
@@ -117,7 +117,7 @@ def density_scatter(
         add_identity_line(ax)
 
     if stats:
-        annotate_metrics(x, y, ax=ax, **(stats if isinstance(stats, dict) else {}))
+        annotate_metrics(x, y, fig=ax, **(stats if isinstance(stats, dict) else {}))
 
     ax.set(xlabel=xlabel, ylabel=ylabel)
 
@@ -163,7 +163,7 @@ def scatter_with_err_bar(
 
     add_identity_line(ax)
 
-    annotate_metrics(x, y, ax=ax)
+    annotate_metrics(x, y, fig=ax)
 
     ax.set(xlabel=xlabel, ylabel=ylabel, title=title)
 
@@ -220,7 +220,7 @@ def density_hexbin(
 
     add_identity_line(ax)
 
-    annotate_metrics(x, y, ax=ax, loc="upper left")
+    annotate_metrics(x, y, fig=ax, loc="upper left")
 
     ax.set(xlabel=xlabel, ylabel=ylabel)
 

--- a/pymatviz/phonons.py
+++ b/pymatviz/phonons.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Literal, Union
 import plotly.express as px
 import plotly.graph_objects as go
 import scipy.constants as const
-from ffonons import find_last_dos_peak
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.dos import PhononDos
@@ -254,7 +253,7 @@ def plot_phonon_dos(
     qual_colors = px.colors.qualitative.Plotly
     if last_peak_anno:
         for idx, (key, dos) in enumerate(doses.items()):
-            last_peak = find_last_dos_peak(dos)
+            last_peak = dos.get_last_peak()
             color = (
                 fig.data[idx].line.color
                 or fig.data[idx].marker.color

--- a/pymatviz/phonons.py
+++ b/pymatviz/phonons.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal, Union
 import plotly.express as px
 import plotly.graph_objects as go
 import scipy.constants as const
+from ffonons import find_last_dos_peak
 from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.dos import PhononDos
@@ -189,6 +190,7 @@ def plot_phonon_dos(
     sigma: float = 0,
     units: Literal["THz", "eV", "meV", "Ha", "cm-1"] = "THz",
     normalize: Literal["max", "sum", "integral"] | None = None,
+    last_peak_anno: str | None = None,
     **kwargs: Any,
 ) -> go.Figure:
     """Plot phonon DOS using Plotly.
@@ -201,6 +203,10 @@ def plot_phonon_dos(
         units (str): Units for the frequencies. Defaults to "THz".
         legend (dict): Legend configuration.
         normalize (bool): Whether to normalize the DOS. Defaults to False.
+        last_peak_anno (str): Annotation for last DOS peak with f-string placeholders
+            for key (of dict containing multiple DOSes), last_peak frequency and units.
+            Defaults to None, meaning last peak annotation is disabled. Set to "" to
+            enable with a sensible default string.
         **kwargs: Passed to Plotly's Figure.add_scatter method.
 
     Returns:
@@ -209,10 +215,13 @@ def plot_phonon_dos(
     valid_normalize = (None, "max", "sum", "integral")
     if normalize not in valid_normalize:
         raise ValueError(f"Invalid {normalize=}, must be one of {valid_normalize}.")
+    if last_peak_anno == "":
+        last_peak_anno = "ω<sub>{key}</sub></span>={last_peak:.1f} {units}"
 
     fig = go.Figure()
+    doses = {"": doses} if isinstance(doses, PhononDos) else doses
 
-    for key, dos in ({"": doses} if isinstance(doses, PhononDos) else doses).items():
+    for key, dos in doses.items():
         frequencies = dos.frequencies
         densities = dos.get_smeared_densities(sigma)
 
@@ -241,7 +250,29 @@ def plot_phonon_dos(
     fig.layout.margin = dict(t=5, b=5, l=5, r=5)
     fig.layout.font.size = 16 * (fig.layout.width or 800) / 800
     fig.layout.legend.update(x=0.005, y=0.99, orientation="h", yanchor="top")
-    fig.layout.template = "pymatviz_white"
+
+    qual_colors = px.colors.qualitative.Plotly
+    if last_peak_anno:
+        for idx, (key, dos) in enumerate(doses.items()):
+            last_peak = find_last_dos_peak(dos)
+            color = (
+                fig.data[idx].line.color
+                or fig.data[idx].marker.color
+                or qual_colors[idx % len(qual_colors)]
+            )
+
+            anno = dict(
+                text=last_peak_anno.format(key=key, last_peak=last_peak, units=units),
+                font=dict(color=color),
+                xanchor="right",
+                yshift=idx * -30,  # shift downward with increasing index
+            )
+            fig.add_vline(
+                x=last_peak,
+                line=dict(color=color, dash="dot"),
+                name=f"last phDOS peak {key}",
+                annotation=anno,
+            )
 
     return fig
 

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -484,7 +484,7 @@ def ptable_heatmap_plotly(
     exclude_elements: Sequence[str] = (),
     log: bool = False,
     fill_value: float | None = None,
-    label_map: dict[str, str] | Literal[False] | None = None,
+    label_map: dict[str, str] | Callable[[str], str] | Literal[False] | None = None,
     **kwargs: Any,
 ) -> go.Figure:
     """Create a Plotly figure with an interactive heatmap of the periodic table.
@@ -555,9 +555,10 @@ def ptable_heatmap_plotly(
         log (bool): Whether to use a logarithmic color scale. Defaults to False.
             Piece of advice: colorscale='viridis' and log=True go well together.
         fill_value (float | None): Value to fill in for missing elements. Defaults to 0.
-        label_map (dict[str, str] | None): Map heat values (after string formatting)
-            to target strings. Defaults to dict.fromkeys((np.nan, None, "nan"), " ")
-            so as not to display 'nan' for missing values. Set to False to disable.
+        label_map (dict[str, str] | Callable[[str], str] | None): Map heat values (after
+            string formatting) to target strings. Set to False to disable. Defaults to
+            dict.fromkeys((np.nan, None, "nan"), " ") so as not to display 'nan' for
+            missing values.
         **kwargs: Additional keyword arguments passed to
             plotly.figure_factory.create_annotated_heatmap().
 

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -262,7 +262,8 @@ def annotate_metrics(
     text += suffix
 
     if backend == "matplotlib":
-        ax = (fig.gca() if isinstance(fig, plt.Figure) else fig) or plt.gca()
+        ax = plt.gca()
+        fig = fig or ax.figure
 
         defaults = dict(frameon=False, loc="upper left")
         text_box = AnchoredText(text, **(defaults | kwargs))

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -262,7 +262,7 @@ def annotate_metrics(
     text += suffix
 
     if backend == "matplotlib":
-        ax = fig.axes[0] if fig else plt.gca()
+        ax = (fig.gca() if isinstance(fig, plt.Figure) else fig) or plt.gca()
 
         defaults = dict(frameon=False, loc="upper left")
         text_box = AnchoredText(text, **(defaults | kwargs))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,14 +7,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import plotly.express as px
+import plotly.graph_objects as go
 import pytest
 from pymatgen.core import Lattice, Structure
 
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-
-    import plotly.graph_objects as go
 
 
 # if platform is windows, set matplotlib backend to "Agg" to fix
@@ -89,8 +88,23 @@ def structures() -> list[Structure]:
 
 
 @pytest.fixture()
-def plotly_scatter() -> go.Figure:
+def plotly_scatter_two_ys() -> go.Figure:
     xs = np.arange(7)
     y1 = xs**2
     y2 = xs**0.5
     return px.scatter(x=xs, y=[y1, y2])
+
+
+@pytest.fixture()
+def plotly_scatter() -> go.Figure:
+    fig = go.Figure(go.Scatter(x=[1, 10, 100], y=[10, 100, 1000]))
+    fig.add_scatter(x=[1, 10, 100], y=[1, 10, 100])
+    return fig
+
+
+@pytest.fixture()
+def matplotlib_scatter() -> plt.Figure:
+    fig, ax = plt.subplots()
+    ax.plot([1, 10, 100], [10, 100, 1000])
+    ax.plot([1, 10, 100], [1, 10, 100])
+    return fig

--- a/tests/test_phonons.py
+++ b/tests/test_phonons.py
@@ -73,12 +73,12 @@ def test_prety_sym_point(sym_point: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "units, stack, sigma, normalize",
+    "units, stack, sigma, normalize, last_peak_anno",
     [
-        ("eV", False, 0.01, "max"),
-        ("meV", False, 0.05, "sum"),
-        ("cm-1", True, 0.1, "integral"),
-        ("THz", True, 0.1, None),
+        ("eV", False, 0.01, "max", "{key}={last_peak:.1f}"),
+        ("meV", False, 0.05, "sum", "{key}={last_peak:.4} ({units})"),
+        ("cm-1", True, 0.1, "integral", None),
+        ("THz", True, 0.1, None, ""),
     ],
 )
 def test_plot_phonon_dos(
@@ -87,10 +87,16 @@ def test_plot_phonon_dos(
     stack: bool,
     sigma: float,
     normalize: Literal["max", "sum", "integral"] | None,
+    last_peak_anno: str | None,
 ) -> None:
     fig = plot_phonon_dos(
-        phonon_doses, stack=stack, sigma=sigma, normalize=normalize, units=units
-    )  # test dict
+        phonon_doses,  # test dict
+        stack=stack,
+        sigma=sigma,
+        normalize=normalize,
+        units=units,
+        last_peak_anno=last_peak_anno,
+    )
 
     assert isinstance(fig, go.Figure)
     assert fig.layout.xaxis.title.text == f"Frequency ({units})"
@@ -98,10 +104,11 @@ def test_plot_phonon_dos(
     assert fig.layout.font.size == 16
 
     fig = plot_phonon_dos(
-        phonon_doses["mp-2691-Cd4Se4"],
+        phonon_doses["mp-2691-Cd4Se4"],  # test single
         stack=stack,
         sigma=sigma,
         normalize=normalize,
         units=units,
-    )  # test single
+        last_peak_anno=last_peak_anno,
+    )
     assert isinstance(fig, go.Figure)

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -171,7 +171,7 @@ def test_ptable_heatmap(
     # cbar_fmt as string
     ax = ptable_heatmap(glass_elem_counts, cbar_fmt=".3f")
     cbar_labels = [label.get_text() for label in ax.child_axes[0].get_xticklabels()]
-    assert cbar_labels[:2] == ["0.000", "50.000"]
+    assert cbar_labels[:2] == ["0.000", "25.000"]
 
     # cbar_fmt as function
     ax = ptable_heatmap(glass_elem_counts, fmt=si_fmt)
@@ -187,6 +187,21 @@ def test_ptable_heatmap(
     # tile_size
     ptable_heatmap(df_ptable.atomic_mass, tile_size=1)
     ptable_heatmap(df_ptable.atomic_mass, tile_size=(0.9, 1))
+
+    # bad colorscale should raise ValueError
+    bad_name = "bad color scale"
+    with pytest.raises(
+        ValueError,
+        match=f"{bad_name!r} is not a valid value for name; supported values are "
+        "'Accent', 'Accent_r'",
+    ):
+        ptable_heatmap(glass_formulas, colorscale=bad_name)
+
+    # test text_style
+    ptable_heatmap(glass_formulas, text_style=dict(color="red", fontsize=12))
+
+    # test show_scale (with heat_mode)
+    ptable_heatmap(glass_formulas, heat_mode="percent", show_scale=False)
 
 
 def test_ptable_heatmap_ratio(

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -288,14 +288,14 @@ def test_ptable_heatmap_plotly(glass_formulas: list[str]) -> None:
 @pytest.mark.parametrize(
     "heat_mode, log", [(None, True), ("fraction", False), ("percent", False)]
 )
-@pytest.mark.parametrize("showscale", [False, True])
+@pytest.mark.parametrize("show_scale", [False, True])
 @pytest.mark.parametrize("font_size", [None, 14])
 @pytest.mark.parametrize("font_colors", [["red"], ("black", "white")])
 def test_ptable_heatmap_plotly_kwarg_combos(
     glass_formulas: list[str],
     exclude_elements: Sequence[str],
     heat_mode: Literal["value", "fraction", "percent"] | None,
-    showscale: bool,
+    show_scale: bool,
     font_size: int,
     font_colors: tuple[str] | tuple[str, str],
     log: bool,
@@ -304,7 +304,7 @@ def test_ptable_heatmap_plotly_kwarg_combos(
         glass_formulas,
         exclude_elements=exclude_elements,
         heat_mode=heat_mode,
-        showscale=showscale,
+        show_scale=show_scale,
         font_size=font_size,
         font_colors=font_colors,
         log=log,

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -227,7 +227,14 @@ def test_ptable_heatmap_plotly(glass_formulas: list[str]) -> None:
         glass_formulas,
         hover_data="density = " + df_ptable.density.astype(str) + " g/cm^3",
     )
-    ptable_heatmap_plotly(df_ptable.density, fmt=".1f")
+    # test label_map as dict
+    fig = ptable_heatmap_plotly(df_ptable.density, fmt=".1f", label_map={"0": "zero"})
+    # test label_map as callable
+    ptable_heatmap_plotly(
+        df_ptable.density,
+        fmt=".1f",
+        label_map=lambda x: "meaning of life" if x == 42 else x,
+    )
 
     ptable_heatmap_plotly(glass_formulas, heat_mode="percent")
 

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -217,8 +217,11 @@ def test_ptable_heatmap_plotly(glass_formulas: list[str]) -> None:
         sum(anno.text != "" for anno in fig.layout.annotations) == 118
     ), "no annotations should be empty"
 
+    # test hover_props and show_values=False
     ptable_heatmap_plotly(
-        glass_formulas, hover_props=["atomic_mass", "atomic_number", "density"]
+        glass_formulas,
+        hover_props=("atomic_mass", "atomic_number", "density"),
+        show_values=False,
     )
     ptable_heatmap_plotly(
         glass_formulas,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from datetime import datetime
+from random import random
 from typing import TYPE_CHECKING, Any, Literal
 from unittest.mock import patch
 
@@ -9,9 +10,9 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import plotly.graph_objects as go
 import pytest
-from matplotlib.offsetbox import AnchoredText
 
 from pymatviz.utils import (
+    Backend,
     CrystalSystem,
     add_identity_line,
     annotate_bars,
@@ -22,6 +23,7 @@ from pymatviz.utils import (
     luminance,
     patch_dict,
     pick_bw_for_contrast,
+    pretty_metric_label,
     si_fmt,
     si_fmt_int,
     styled_html_tag,
@@ -33,6 +35,18 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
+def _extract_anno_from_fig(fig: go.Figure | plt.Figure, idx: int = -1) -> str:
+    # get plotly or matplotlib annotation text. idx=-1 gets the most recently
+    # annotation
+    if isinstance(fig, go.Figure):
+        anno_text = fig.layout.annotations[idx].text
+    else:
+        text_box = fig.artists[idx]
+        anno_text = text_box.txt.get_text()
+
+    return anno_text
+
+
 @pytest.mark.parametrize(
     "metrics, fmt",
     [
@@ -40,31 +54,51 @@ if TYPE_CHECKING:
         (["RMSE"], ".1"),
         (("MAPE", "MSE"), ".2"),
         ({"MAE", "R2", "RMSE"}, ".3"),
-        ({"MAE": 1.4, "$R^2$": 0.2, "RMSE": 1.9}, ".0"),
+        ({"MAE": 1.4, "R2": 0.2, "RMSE": 1.9}, ".0"),
     ],
 )
-def test_annotate_metrics(metrics: dict[str, float] | Sequence[str], fmt: str) -> None:
-    text_box = annotate_metrics(y_pred, y_true, metrics=metrics, fmt=fmt)
+def test_annotate_metrics(
+    metrics: dict[str, float] | Sequence[str],
+    fmt: str,
+    plotly_scatter: go.Figure,
+    matplotlib_scatter: plt.Figure,
+) -> None:
+    # randomly switch between plotly and matplotlib
+    fig = plotly_scatter if random() > 0.5 else matplotlib_scatter
 
-    assert isinstance(text_box, AnchoredText)
+    out_fig = annotate_metrics(y_pred, y_true, metrics=metrics, fmt=fmt, fig=fig)
+
+    assert out_fig is fig
+    backend: Backend = "plotly" if isinstance(out_fig, go.Figure) else "matplotlib"
 
     expected = dict(MAE=0.113, R2=0.765, RMSE=0.144, MAPE=0.5900, MSE=0.0206)
 
-    txt = ""
+    expected_text = ""
+    newline = "<br>" if isinstance(out_fig, go.Figure) else "\n"
     if isinstance(metrics, dict):
         for key, val in metrics.items():
-            txt += f"{key} = {val:{fmt}}\n"
+            label = pretty_metric_label(key, backend)
+            if key == "R2":
+                print(f"{label=}")
+            expected_text += f"{label} = {val:{fmt}}{newline}"
     else:
         for key in [metrics] if isinstance(metrics, str) else metrics:
-            txt += f"{key} = {expected[key]:{fmt}}\n"
+            label = pretty_metric_label(key, backend)
+            if key == "R2":
+                print(f"{label=}")
+            expected_text += f"{label} = {expected[key]:{fmt}}{newline}"
 
-    assert text_box.txt.get_text() == txt
+    anno_text = _extract_anno_from_fig(out_fig)
+    assert anno_text == expected_text, f"{anno_text=}"
 
-    prefix, suffix = "Metrics:\n", "\nthe end"
-    text_box = annotate_metrics(
-        y_pred, y_true, metrics=metrics, fmt=fmt, prefix=prefix, suffix=suffix
+    prefix, suffix = f"Metrics:{newline}", f"{newline}the end"
+    out_fig = annotate_metrics(
+        y_pred, y_true, metrics=metrics, fmt=fmt, prefix=prefix, suffix=suffix, fig=fig
     )
-    assert text_box.txt.get_text() == prefix + txt + suffix
+    anno_text_with_fixes = _extract_anno_from_fig(out_fig)
+    assert (
+        anno_text_with_fixes == prefix + expected_text + suffix
+    ), f"{anno_text_with_fixes=}"
 
 
 @pytest.mark.parametrize("metrics", [42, datetime.now()])
@@ -95,21 +129,6 @@ def test_crystal_sys_from_spg_num(spg_num: int, crystal_sys: CrystalSystem) -> N
 def test_crystal_sys_from_spg_num_invalid(spg: int) -> None:
     with pytest.raises(ValueError, match=f"Invalid space group {spg}"):
         crystal_sys_from_spg_num(spg)
-
-
-@pytest.fixture()
-def plotly_scatter() -> go.Figure:
-    fig = go.Figure(go.Scatter(x=[1, 10, 100], y=[10, 100, 1000]))
-    fig.add_scatter(x=[1, 10, 100], y=[1, 10, 100])
-    return fig
-
-
-@pytest.fixture()
-def matplotlib_scatter() -> plt.Figure:
-    fig, ax = plt.subplots()
-    ax.plot([1, 10, 100], [10, 100, 1000])
-    ax.plot([1, 10, 100], [1, 10, 100])
-    return fig
 
 
 @pytest.mark.parametrize("xaxis_type", ["linear", "log"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,12 +36,15 @@ if TYPE_CHECKING:
 
 
 def _extract_anno_from_fig(fig: go.Figure | plt.Figure, idx: int = -1) -> str:
-    # get plotly or matplotlib annotation text. idx=-1 gets the most recently
+    # get plotly or matplotlib annotation text. idx=-1 gets the most recently added
     # annotation
+    if not isinstance(fig, (go.Figure, plt.Figure)):
+        raise TypeError(f"Unexpected {type(fig)=}")
+
     if isinstance(fig, go.Figure):
         anno_text = fig.layout.annotations[idx].text
     else:
-        text_box = fig.artists[idx]
+        text_box = fig.axes[0].artists[idx]
         anno_text = text_box.txt.get_text()
 
     return anno_text


### PR DESCRIPTION
613a38b fix pymatviz_white + pymatviz_black templates using wrong axis_template
f813b5c add keyword show_values: bool = True to ptable_heatmap_plotly
275ef7c test ptable_heatmap_plotly show_values=False
04a3a0e allow ptable_heatmap_plotly label_map to be callable
c5bb796 test ptable_heatmap_plotly label_map as callable
7eab739 use show_values=False in atomic_mass ptable_heatmap_plotly
243d233 add last_peak_anno: str | None = None to plot_phonon_dos()
16189e8 test last_peak_anno in test_plot_phonon_dos
c5cf3e9 remove dependence on unpublished ffonons pkg
65b0eb3 ptable_heatmap add show_scale: bool = True, show_values: bool = True, and text_style: dict[str, Any] | None = None
4611c42 test_ptable_heatmap cover text_style=dict, show_values=False, show_scale=False
1cb4af1 make annotate_metrics backend agnostic, i.e. add support for Plotly figures
09ede68 test_annotate_metrics cover both backends plotly and matplotlib
97f79ce fix param name show_scale in test_ptable_heatmap_plotly_kwarg_combos


Example of `ptable_heatmap_plotly(show_values=False)`.


![ptable-heatmap-plotly-more-hover-data](https://github.com/janosh/pymatviz/assets/30958850/305fe0de-5a8c-44df-b148-c3d364a0baf5)
