### PR TITLE
`add_ecdf_line()` utility for plotting empirical cumulative distribution functions

### DIFF
--- a/pymatviz/correlation.py
+++ b/pymatviz/correlation.py
@@ -33,11 +33,11 @@ def marchenko_pastur_pdf(x: float, gamma: float, sigma: float = 1) -> float:
     lambda_m = (sigma * (1 - np.sqrt(1 / gamma))) ** 2  # Largest eigenvalue
     lambda_p = (sigma * (1 + np.sqrt(1 / gamma))) ** 2  # Smallest eigenvalue
 
-    prefac = gamma / (2 * np.pi * sigma**2 * x)
+    pre_fac = gamma / (2 * np.pi * sigma**2 * x)
     root = np.sqrt((lambda_p - x) * (x - lambda_m))
     unit_step = x > lambda_p or x < lambda_m
 
-    return prefac * root * (0 if unit_step else 1)
+    return pre_fac * root * (0 if unit_step else 1)
 
 
 def marchenko_pastur(
@@ -70,17 +70,17 @@ def marchenko_pastur(
     """
     ax = ax or plt.gca()
 
-    # use eigvalsh for speed since correlation matrix is symmetric
-    evals = np.linalg.eigvalsh(matrix)
+    # use eigvalsh (over eigvals) for speed since correlation matrix is symmetric
+    eigen_vals = np.linalg.eigvalsh(matrix)
 
     lambda_m = (sigma * (1 - np.sqrt(1 / gamma))) ** 2  # Largest eigenvalue
     lambda_p = (sigma * (1 + np.sqrt(1 / gamma))) ** 2  # Smallest eigenvalue
 
     if filter_high_evals:
         # Remove eigenvalues larger than those expected in a purely random matrix
-        evals = evals[evals <= lambda_p + 1]
+        eigen_vals = eigen_vals[eigen_vals <= lambda_p + 1]
 
-    ax.hist(evals, bins=50, edgecolor="black", density=True)
+    ax.hist(eigen_vals, bins=50, edgecolor="black", density=True)
 
     # Plot the theoretical density
     mp_pdf = np.vectorize(lambda x: marchenko_pastur_pdf(x, gamma, sigma))
@@ -92,11 +92,7 @@ def marchenko_pastur(
     rank = np.linalg.matrix_rank(matrix)
     n_rows = len(matrix)
 
-    plt.text(
-        *[0.95, 0.9],
-        f"rank deficiency: {rank}/{n_rows} {'(None)' if n_rows == rank else ''}",
-        transform=ax.transAxes,
-        ha="right",
-    )
+    rank_str = f"rank deficiency: {rank}/{n_rows} {'(None)' if n_rows == rank else ''}"
+    plt.text(*[0.95, 0.9], rank_str, transform=ax.transAxes, ha="right")
 
     return ax

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -343,7 +343,8 @@ def add_identity_line(
     """
     valid_types = (go.Figure, plt.Figure, plt.Axes)
     if not isinstance(fig, valid_types):
-        raise TypeError(f"fig must be instance of {valid_types}, got {type(fig)}")
+        type_names = " | ".join(f"{t.__module__}.{t.__qualname__}" for t in valid_types)
+        raise TypeError(f"{fig=} must be instance of {type_names}")
 
     if isinstance(fig, (plt.Figure, plt.Axes)):  # handle matplotlib
         ax = fig if isinstance(fig, plt.Axes) else fig.gca()

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import plotly.express as px
 import plotly.graph_objects as go
 import scipy.stats
 import sklearn
@@ -409,6 +410,64 @@ def add_identity_line(
         line=line_defaults | (line_kwds or {}),
         **kwargs,
     )
+
+    return fig
+
+
+def add_ecdf_line(
+    fig: go.Figure,
+    values: ArrayLike = (),
+    trace_idx: int = 0,
+    trace_kwargs: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> go.Figure:
+    """Add an empirical cumulative distribution function (ECDF) line to a plotly figure.
+
+    Support for matplotlib planned but not implemented. PRs welcome.
+
+    Args:
+        fig (go.Figure): plotly figure to add the ECDF line to.
+        values (array, optional): Values to compute the ECDF from. Defaults to () which
+            means use the x-values of trace at trace_idx in fig.
+        trace_idx (int, optional): Index of the trace whose x-values to use for
+            computing the ECDF. Defaults to 0. Unused if values is not empty.
+        trace_kwargs (dict[str, Any], optional): Passed to trace_ecdf.update().
+            Defaults to None. Use e.g. to set trace name (default "Cumulative") or
+            line_color (default "gray").
+        **kwargs: Passed to fig.add_trace().
+
+    Returns:
+        Figure: Figure with added ECDF line.
+    """
+    valid_types = (go.Figure,)
+    if not isinstance(fig, valid_types):
+        type_names = " | ".join(f"{t.__module__}.{t.__qualname__}" for t in valid_types)
+        raise TypeError(f"{fig=} must be instance of {type_names}")
+
+    ecdf = px.ecdf(values if len(values) else fig.data[trace_idx].x).data[0]
+
+    # if fig has facets, add ECDF to all subplots
+    add_trace_defaults = {} if fig._grid_ref is None else dict(row="all", col="all")  # noqa: SLF001
+
+    fig.add_trace(ecdf, **add_trace_defaults | kwargs)
+    # move ECDF line to secondary y-axis
+    # set color to darkened version of primary y-axis color
+    trace_defaults = dict(yaxis="y2", name="Cumulative", line=dict(color="gray"))
+    trace_kwargs = trace_defaults | (trace_kwargs or {})
+    fig.data[-1].update(**trace_kwargs)
+
+    color = trace_kwargs.get("line_color", trace_kwargs.get("line", {}).get("color"))
+
+    yaxis_defaults = dict(
+        title=trace_kwargs["name"],
+        side="right",
+        overlaying="y",
+        range=(0, 1),
+        showgrid=False,
+        color=color,
+        linecolor=color,
+    )
+    fig.layout.yaxis2 = yaxis_defaults | getattr(fig.layout, "yaxis2", {})
 
     return fig
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -188,6 +188,16 @@ def test_add_identity_matplotlib(
     assert line.get_color() == expected_line_color
 
 
+def test_add_identity_raises() -> None:
+    for fig in (None, "foo", 42.0):
+        with pytest.raises(
+            TypeError,
+            match=f"{fig=} must be instance of plotly.graph_objs._figure.Figure | "
+            f"matplotlib.figure.Figure | matplotlib.axes._axes.Axes",
+        ):
+            add_identity_line(fig)
+
+
 def test_df_to_arrays() -> None:
     df_regr = pd.DataFrame([y_true, y_pred]).T
     x1, y1 = df_to_arrays(None, y_true, y_pred)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ import pytest
 from pymatviz.utils import (
     Backend,
     CrystalSystem,
+    add_ecdf_line,
     add_identity_line,
     annotate_bars,
     annotate_metrics,
@@ -496,3 +497,36 @@ def test_styled_html_tag(text: str, tag: str, style: str) -> None:
     assert (
         styled_html_tag(text, tag=tag, style=style) == f"<{tag} {style=}>{text}</{tag}>"
     )
+
+
+@pytest.mark.parametrize(
+    "trace_kwargs",
+    [None, {}, {"name": "foo", "line_color": "red"}],
+)
+def test_add_ecdf_line(
+    plotly_scatter: go.Figure,
+    trace_kwargs: dict[str, str] | None,
+) -> None:
+    fig = add_ecdf_line(plotly_scatter, trace_kwargs=trace_kwargs)
+    assert isinstance(fig, go.Figure)
+
+    trace_kwargs = trace_kwargs or {}
+
+    ecdf = fig.data[-1]  # retrieve ecdf line
+    expected_name = trace_kwargs.get("name", "Cumulative")
+    expected_color = trace_kwargs.get("line_color", "gray")
+    assert ecdf.name == expected_name
+    assert ecdf.line.color == expected_color
+    assert ecdf.yaxis == "y2"
+    assert fig.layout.yaxis2.range == (0, 1)
+    assert fig.layout.yaxis2.title.text == expected_name
+    assert fig.layout.yaxis2.color == expected_color
+
+
+def test_add_ecdf_line_raises() -> None:
+    for fig in (None, "foo", 42.0):
+        with pytest.raises(
+            TypeError,
+            match=f"{fig=} must be instance of plotly.graph_objs._figure.Figure",
+        ):
+            add_ecdf_line(fig)


### PR DESCRIPTION
42f0d6a add `test_add_identity_raises`
107c926 implement `add_ecdf_line()` in `pymatviz/utils.py`
426238c `test_add_ecdf_line` and `test_add_ecdf_line_raises`