### PR TITLE
Fix `PTableProjector.hide_f_block` property

### DIFF
--- a/examples/dataset_exploration/matpes/eda.py
+++ b/examples/dataset_exploration/matpes/eda.py
@@ -59,7 +59,7 @@ fig.add_histogram(x=df_pbe[Key.energy], name="pbe", opacity=0.8)
 fig.update_layout(xaxis_title=Key.energy.label, margin=dict(l=5, r=5, t=5, b=5))
 fig.layout.legend.update(x=0, y=1)
 fig.show()
-# save_fig(fig, "matpes-energy-hist.pdf")
+# save_fig(fig, "energy-hist.pdf")
 
 # @janosh 2024-05-15: initially surprised by the difference in r2scan/pbe energy distros
 # how could energy differences between two similar chemistries always be similar across
@@ -98,7 +98,7 @@ fig.update_layout(xaxis_title=total_force_col, margin=dict(l=5, r=5, t=5, b=5))
 fig.layout.legend.update(x=0, y=1)
 fig.update_yaxes(type="log")
 fig.show()
-# save_fig(fig, "matpes-forces-hist.pdf")
+# save_fig(fig, "forces-hist.pdf")
 
 
 # %% plot element counts
@@ -107,6 +107,10 @@ if r2scan_elem_counts is None:
     r2scan_elem_counts = count_elements(df_r2scan[Key.formula])
 ax = ptable_heatmap(r2scan_elem_counts)
 
+save_fig(ax, "r2scan-element-counts-ptable.pdf")
+
+
+# %%
 pbe_elem_counts = locals().get("pbe_elem_counts")
 if pbe_elem_counts is None:
     pbe_elem_counts = count_elements(df_pbe[Key.formula])
@@ -158,7 +162,7 @@ ax = ptable_heatmap(
     cbar_title="Fraction of missing PBE calcs missing r2SCAN",
 )
 
-save_fig(ax, "matpes-missing-r2scan-data-ptable.pdf")
+save_fig(ax, "ptable-has-pbe-but-no-r2scan.pdf")
 
 
 # %% per-elem mean abs magmoms
@@ -170,26 +174,26 @@ df_per_elem_magmoms = pd.DataFrame(
 ax = ptable_heatmap(
     df_per_elem_magmoms, cbar_title=r"Mean |magmom| ($\mu_B$)", fmt=".1f"
 )
-save_fig(ax, "matpes-magmoms-ptable.pdf")
+save_fig(ax, "magmoms-ptable.pdf")
 
 
 # %% spacegroup distribution
-df_r2scan[Key.spacegroup] = [
-    struct.get_space_group_info()[1]
-    for struct in tqdm(df_r2scan[Key.structure], desc="r2scan spacegroups")
-]
+for label, df in (
+    ("r2scan", df_r2scan),
+    # ("pbe", df_pbe),
+):
+    df[Key.spacegroup] = [
+        struct.get_space_group_info()[1]
+        for struct in tqdm(df[Key.structure], desc=f"{label} spacegroups")
+    ]
 
 
-# %%
-fig = spacegroup_sunburst(
-    df_r2scan[Key.spacegroup],
-    title="r2SCAN spacegroup distribution",
-    show_counts="percent",
-)
-fig.layout.title.update(text=f"{n_r2scan:,} r2SCAN spacegroups", x=0.5, y=0.97)
+# %% high-temperate MLMD frames are expected to have low symmetry (mostly triclinic)
+fig = spacegroup_sunburst(df_r2scan[Key.spacegroup], show_counts="percent")
+fig.layout.title.update(text=f"{n_r2scan:,} r2SCAN spacegroups", x=0.5, y=0.98)
 fig.layout.margin = dict(l=0, r=0, b=0, t=30)
 fig.show()
-save_fig(fig, "matpes-r2scan-spacegroup-sunburst.pdf")
+save_fig(fig, "r2scan-spacegroup-sunburst.pdf")
 
 
 # %% spacegroup histogram
@@ -197,11 +201,43 @@ fig = spacegroup_hist(
     df_r2scan[Key.spacegroup], title="r2SCAN spacegroup histogram", log=True
 )
 fig.show()
-save_fig(fig, "matpes-r2scan-spacegroup-hist.pdf")
+save_fig(fig, "r2scan-spacegroup-hist.pdf")
+
+
+# %% most calcs missing r2SCAN results have 4 sites, almost all 2 or 3-site r2scan calcs
+# completed
+fig = go.Figure()
+
+fig.add_histogram(x=df_r2scan[Key.n_sites], name="r2scan", opacity=0.8)
+fig.add_histogram(x=df_pbe[Key.n_sites], name="pbe", opacity=0.8)
+
+fig.layout.legend.update(x=0, y=1)
+fig.layout.xaxis.title = Key.n_sites.label
+fig.layout.yaxis.title = "count"
+fig.show()
+
+
+# %% plot absolute forces projected onto elements
+df_r2scan[Key.forces] = df_r2scan[Key.forces].map(np.abs)
+df_pbe[Key.forces] = df_pbe[Key.forces].map(np.abs)
+
+df_r2scan_elem_forces = pd.DataFrame(
+    {site.specie.symbol: np.linalg.norm(force) for site, force in zip(struct, forces)}
+    for struct, forces in zip(df_r2scan[Key.structure], df_r2scan[Key.forces])
+).mean()
+
+df_pbe_elem_forces = pd.DataFrame(
+    {site.specie.symbol: np.linalg.norm(force) for site, force in zip(struct, forces)}
+    for struct, forces in zip(df_pbe[Key.structure], df_pbe[Key.forces])
+).mean()
 
 
 # %%
-df_pbe[Key.spacegroup] = [
-    struct.get_space_group_info()[1]
-    for struct in tqdm(df_pbe[Key.structure], desc="pbe spacegroups")
-]
+fig = ptable_heatmap_splits(
+    {
+        elem: [df_r2scan_elem_forces[elem], df_pbe_elem_forces[elem]]
+        for elem in df_r2scan_elem_forces.index
+    },
+    cbar_title="Mean |force| (eV/Å)",
+    # hide_f_block=False,
+)

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -241,12 +241,12 @@ class PTableProjector:
     def data(self, data: SupportedDataType) -> None:
         """Set and preprocess the data. Also set normalizer."""
         # Preprocess data
-        self._data: pd.DataFrame = preprocess_ptable_data(data)
+        self._data = preprocess_ptable_data(data)
 
         # Normalize data for colorbar
-        self._norm: Normalize = Normalize(
-            vmin=self._data.attrs["vmin"], vmax=self._data.attrs["vmax"]
-        )
+        vmin = self._data.attrs["vmin"]
+        vmax = self._data.attrs["vmax"]
+        self._norm = Normalize(vmin=vmin, vmax=vmax)
 
     @property
     def norm(self) -> Normalize:
@@ -269,7 +269,7 @@ class PTableProjector:
                 if (elem := Element.from_Z(atom_num).symbol) in self.data.index
                 and len(self.data.loc[elem, Key.heat_val]) > 0
             }
-            self._hide_f_block = bool(f_block_elements_with_data)
+            self._hide_f_block = not bool(f_block_elements_with_data)
 
         else:
             self._hide_f_block = hide_f_block

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -47,7 +47,7 @@ class TestPTableProjector:
         "Al": {-1, 2.3},  # mixed int/float set
     }
 
-    def test_property_elem_types(self) -> None:
+    def test_elem_types(self) -> None:
         projector = PTableProjector(data=self.test_dict)
         assert projector.elem_types == {
             "Noble Gas",
@@ -56,6 +56,16 @@ class TestPTableProjector:
             "Nonmetal",
             "Alkali Metal",
         }
+
+    def test_hide_f_block(self) -> None:
+        # check default is True if no f-block elements in data
+        assert PTableProjector(data=self.test_dict).hide_f_block is True
+        assert PTableProjector(data={"H": 1}).hide_f_block is True
+        # check default is False if f-block elements in data
+        assert PTableProjector(data=self.test_dict | {"La": 1}).hide_f_block is False
+        assert PTableProjector(data={"La": 1}).hide_f_block is False
+        # check override
+        assert PTableProjector(data={"La": 1}, hide_f_block=True).hide_f_block is True
 
     def test_get_elem_type_color(self) -> None:
         projector = PTableProjector(data=self.test_dict)


### PR DESCRIPTION
defaulted to the inverse of what it should be when plot data didn't contain f-block elements