### PR TITLE
Fix and test `ptable_heatmap` text color logic 

### DIFF
--- a/examples/dataset_exploration/boltztrap_mp/explore_boltztrap_mp.py
+++ b/examples/dataset_exploration/boltztrap_mp/explore_boltztrap_mp.py
@@ -42,13 +42,13 @@ df_boltz.describe()
 
 # %%
 ax = ptable_heatmap(df_boltz[Key.formula], log=True)
-ax.set_title("Elements in BoltzTraP MP dataset")
+ax.set(title="Elements in BoltzTraP MP dataset")
 save_fig(ax, "boltztrap_mp-ptable-heatmap.pdf")
 
 
 # %%
 ax = ptable_heatmap(df_boltz.sort_values("pf_n").tail(100)[Key.formula])
-ax.set_title("Elements of top 100 n-type powerfactors in BoltzTraP MP dataset")
+ax.set(title="Elements of top 100 n-type powerfactors in BoltzTraP MP dataset")
 save_fig(ax, "boltztrap_mp-ptable-heatmap-top-100-nPF.pdf")
 
 

--- a/examples/dataset_exploration/camd_2022/explore_camd_2022.py
+++ b/examples/dataset_exploration/camd_2022/explore_camd_2022.py
@@ -47,7 +47,7 @@ df_camd.hist(bins=50)
 # %%
 elem_counts = count_elements(df_camd.reduced_formula)
 ax = ptable_heatmap(elem_counts, log=True)
-ax.set_title("Elements in CAMD 2022 dataset")
+ax.set(title="Elements in CAMD 2022 dataset")
 save_fig(ax, "camd-2022-ptable-heatmap.pdf")
 
 

--- a/examples/diatomics/plot.py
+++ b/examples/diatomics/plot.py
@@ -42,9 +42,8 @@ def plot_on_ax(
 
     ax.plot(distances, energy, marker=".")
     ax.axhline(0, color="tab:gray")
-    # ax.set_title(f"{formula}, shift: {shift:.4f}")
     ax.set_title(f"{formula}", fontsize=28)
-    ax.set_ylim(-20, 20)
+    ax.set(ylim=(-20, 20))
 
 
 def plot_homo_nuclear(model_size: str) -> None:

--- a/examples/matbench_dielectric_eda.ipynb
+++ b/examples/matbench_dielectric_eda.ipynb
@@ -90,7 +90,7 @@
     "df_diel[Key.formula] = df_diel[Key.structure].map(lambda cryst: cryst.formula)\n",
     "\n",
     "ax = ptable_heatmap(df_diel[Key.formula], log=True)\n",
-    "ax.set_title(\"Elements in Matbench Dielectric\")"
+    "ax.set(title=\"Elements in Matbench Dielectric\")"
    ]
   },
   {

--- a/examples/matbench_perovskites_eda.ipynb
+++ b/examples/matbench_perovskites_eda.ipynb
@@ -160,7 +160,7 @@
    "source": [
     "ax = df_perov[Key.crystal_system].value_counts().plot.bar(rot=\"horizontal\")\n",
     "\n",
-    "ax.set_title(\"Crystal systems in Matbench Perovskites\")\n",
+    "ax.set(title=\"Crystal systems in Matbench Perovskites\")\n",
     "\n",
     "annotate_bars(ax, v_offset=250)"
    ]

--- a/pymatviz/correlation.py
+++ b/pymatviz/correlation.py
@@ -96,6 +96,6 @@ def marchenko_pastur(
     n_rows = len(matrix)
 
     rank_str = f"rank deficiency: {rank}/{n_rows} {'(None)' if n_rows == rank else ''}"
-    plt.text(*[0.95, 0.9], rank_str, transform=ax.transAxes, ha="right")
+    ax.text(*[0.95, 0.9], rank_str, transform=ax.transAxes, ha="right")
 
     return ax

--- a/pymatviz/cumulative.py
+++ b/pymatviz/cumulative.py
@@ -66,9 +66,7 @@ def cumulative_residual(
 def cumulative_error(
     abs_err: ArrayLike, ax: plt.Axes | None = None, **kwargs: Any
 ) -> plt.Axes:
-    """Plot the empirical cumulative distribution of the absolute errors.
-
-    abs(y_true - y_pred).
+    """Plot the empirical cumulative distribution of abs(y_true - y_pred).
 
     Args:
         abs_err (array): Absolute error between y_true and y_pred, i.e.

--- a/pymatviz/histograms.py
+++ b/pymatviz/histograms.py
@@ -437,15 +437,13 @@ def plot_histogram(
         fig = go.Figure(**fig_kwargs)
         for label, vals in data.items():
             hist_vals, _ = np.histogram(vals, bins=bin_edges, density=density)
-            fig.add_trace(
-                go.Bar(
-                    x=bin_edges[:-1],
-                    y=hist_vals,
-                    name=label,
-                    opacity=0.7,
-                    width=bin_width * (bin_edges[1] - bin_edges[0]),
-                    marker_line_width=0,
-                )
+            fig.add_bar(
+                x=bin_edges[:-1],
+                y=hist_vals,
+                name=label,
+                opacity=0.7,
+                width=bin_width * (bin_edges[1] - bin_edges[0]),
+                marker_line_width=0,
             )
 
         y_title = "Density" if density else "Count"

--- a/pymatviz/histograms.py
+++ b/pymatviz/histograms.py
@@ -51,9 +51,9 @@ def spacegroup_hist(
             (from 1 - 230) or pymatgen structures.
         show_counts (bool, optional): Whether to count the number of items
             in each crystal system. Defaults to True.
-        xticks ('all' | 'crys_sys_edges' | int, optional): Where to add x-ticks. An
+        xticks ("all" | "crys_sys_edges" | int, optional): Where to add x-ticks. An
             integer will add ticks below that number of tallest bars. Defaults to 20.
-            'all' will show below all bars, 'crys_sys_edges' only at the edge from one
+            "all" will show below all bars, "crys_sys_edges" only at the edge from one
             crystal system to another.
         show_empty_bins (bool, optional): Whether to include a 0-height bar for missing
             space groups missing from the data. Currently only implemented for numbers,
@@ -294,14 +294,14 @@ def elements_hist(
 
     Args:
         formulas (list[str]): compositional strings, e.g. ["Fe2O3", "Bi2Te3"].
-        count_mode ('composition' | 'fractional_composition' | 'reduced_composition'):
+        count_mode ("composition" | "fractional_composition" | "reduced_composition"):
             Reduce or normalize compositions before counting. See count_elements() for
             details. Only used when formulas is list of composition strings/objects.
         log (bool, optional): Whether y-axis is log or linear. Defaults to False.
         keep_top (int | None): Display only the top n elements by prevalence.
         ax (Axes): matplotlib Axes on which to plot. Defaults to None.
-        bar_values ('percent'|'count'|None): 'percent' (default) annotates bars with the
-            percentage each element makes up in the total element count. 'count'
+        bar_values ("percent"|"count"|None): "percent" (default) annotates bars with the
+            percentage each element makes up in the total element count. "count"
             displays count itself. None removes bar labels.
         h_offset (int): Horizontal offset for bar height labels. Defaults to 0.
         v_offset (int): Vertical offset for bar height labels. Defaults to 10.

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -262,8 +262,8 @@ def normalize_and_crop_pdf(
 
     Args:
         file_path (str | Path): Path to the PDF file.
-        on_gs_not_found ('ignore' | 'warn' | 'error', optional): What to do if
-            Ghostscript is not found in PATH. Defaults to 'warn'.
+        on_gs_not_found ("ignore" | "warn" | "error", optional): What to do if
+            Ghostscript is not found in PATH. Defaults to "warn".
     """
     if which("gs") is None:
         if on_gs_not_found == "ignore":

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -785,7 +785,7 @@ def ptable_heatmap(
         zero_symbol (str | float): Symbol to use for elements with value zero.
             Defaults to "-".
         text_style (dict[str, Any]): Additional keyword arguments passed to
-            plt.text(). Defaults to dict(
+            ax.text(). Defaults to dict(
                 ha="center", fontsize=label_font_size, fontweight="semibold"
             )
         label_font_size (int): Font size for element symbols. Defaults to 16.
@@ -931,7 +931,7 @@ def ptable_heatmap(
         else:
             _text_color = text_color
 
-        symbol_text = plt.text(
+        symbol_text = ax.text(
             column + 0.5 * tile_width,
             # 0.45 needed to achieve vertical centering, not sure why 0.5 is off
             period + (0.5 if show_values else 0.45) * tile_height,
@@ -940,7 +940,7 @@ def ptable_heatmap(
         )
 
         if heat_mode is not None and show_values:
-            plt.text(
+            ax.text(
                 column + 0.5 * tile_width,
                 period + 0.1 * tile_height,
                 label,
@@ -1044,7 +1044,7 @@ def ptable_heatmap_splits(
         symbol_pos (tuple[float, float]): Position of element symbols
             relative to the lower left corner of each tile.
             Defaults to (0.5, 0.5). (1, 1) is the upper right corner.
-        symbol_kwargs (dict): Keyword arguments passed to plt.text() for
+        symbol_kwargs (dict): Keyword arguments passed to ax.text() for
             element symbols. Defaults to None.
 
         cbar_title (str): Colorbar title. Defaults to "Values".
@@ -1505,7 +1505,7 @@ def ptable_hists(
             right corner.
         symbol_text (str | Callable[[Element], str]): Text to display for each element
             symbol. Defaults to lambda elem: elem.symbol.
-        symbol_kwargs (dict): Keyword arguments passed to plt.text() for element
+        symbol_kwargs (dict): Keyword arguments passed to ax.text() for element
             symbols. Defaults to None.
 
         color_elem_strategy ("symbol" | "background" | "both" | "off"): Whether to
@@ -1643,7 +1643,7 @@ def ptable_scatters(
         symbol_pos (tuple[float, float]): Position of element symbols
             relative to the lower left corner of each tile.
             Defaults to (0.5, 0.5). (1, 1) is the upper right corner.
-        symbol_kwargs (dict): Keyword arguments passed to plt.text() for
+        symbol_kwargs (dict): Keyword arguments passed to ax.text() for
             element symbols. Defaults to None.
 
         color_elem_strategy ("symbol" | "background" | "both" | "off"): Whether to
@@ -1760,7 +1760,7 @@ def ptable_lines(
         symbol_pos (tuple[float, float]): Position of element symbols
             relative to the lower left corner of each tile.
             Defaults to (0.5, 0.5). (1, 1) is the upper right corner.
-        symbol_kwargs (dict): Keyword arguments passed to plt.text() for
+        symbol_kwargs (dict): Keyword arguments passed to ax.text() for
             element symbols. Defaults to None.
 
         color_elem_strategy ("symbol" | "background" | "both" | "off"): Whether to

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -655,7 +655,7 @@ class ChildPlotters:
             ax (plt.axes): The axis to plot on.
             data (SupportedValueType): The values for the child plotter.
             cmap (Colormap): Colormap.
-            cbar_axis (Literal["x", "y"]): The axis colormap
+            cbar_axis ("x" | "y"): The axis colormap
                 would be based on.
             child_kwargs: kwargs to pass to the child plotter call.
             tick_kwargs (dict): kwargs to pass to ax.tick_params().
@@ -741,7 +741,7 @@ def ptable_heatmap(
             also take any matplotlib.colors.Normalize subclass such as SymLogNorm as
             custom color scale. Defaults to False.
         ax (Axes, optional): matplotlib Axes on which to plot. Defaults to None.
-        count_mode ('composition' | 'fractional_composition' | 'reduced_composition'):
+        count_mode ("composition" | "fractional_composition" | "reduced_composition"):
             Reduce or normalize compositions before counting. See count_elements() for
             details. Only used when values is list of composition strings/objects.
         cbar_title (str, optional): Color bar title. Defaults to "Element Count".
@@ -1028,7 +1028,7 @@ def ptable_heatmap_splits(
                 and the split proceeds counter-clockwise (0 refers to
                 the x-axis). Defaults to 135 degrees.
         colormap (str): Matplotlib colormap name to use.
-        on_empty ('hide' | 'show'): Whether to show or hide tiles for elements without
+        on_empty ("hide" | "show"): Whether to show or hide tiles for elements without
             data. Defaults to "hide".
         hide_f_block (bool): Hide f-block (Lanthanum and Actinium series). Defaults to
             None, meaning hide if no data is provided for f-block elements.
@@ -1206,7 +1206,7 @@ def ptable_heatmap_plotly(
             Reduce or normalize compositions before counting. See count_elements() for
             details. Only used when values is list of composition strings/objects.
         colorscale (str | list[str] | list[tuple[float, str]]): Color scale for heatmap.
-            Defaults to 'viridis'. See plotly.com/python/builtin-colorscales for names
+            Defaults to "viridis". See plotly.com/python/builtin-colorscales for names
             of other builtin color scales. Note "YlGn" and px.colors.sequential.YlGn are
             equivalent. Custom scales are specified as ["blue", "red"] or
             [[0, "rgb(0,0,255)"], [0.5, "rgb(0,255,0)"], [1, "rgb(255,0,0)"]].
@@ -1257,14 +1257,14 @@ def ptable_heatmap_plotly(
         cscale_range (tuple[float | None, float | None]): Colorbar range. Defaults to
             (None, None) meaning the range is automatically determined from the data.
         exclude_elements (list[str]): Elements to exclude from the heatmap. E.g. if
-            oxygen overpowers everything, you can do exclude_elements=['O'].
+            oxygen overpowers everything, you can do exclude_elements=["O"].
             Defaults to ().
         log (bool): Whether to use a logarithmic color scale. Defaults to False.
-            Piece of advice: colorscale='viridis' and log=True go well together.
+            Piece of advice: colorscale="viridis" and log=True go well together.
         fill_value (float | None): Value to fill in for missing elements. Defaults to 0.
         label_map (dict[str, str] | Callable[[str], str] | None): Map heat values (after
             string formatting) to target strings. Set to False to disable. Defaults to
-            dict.fromkeys((np.nan, None, "nan"), " ") so as not to display 'nan' for
+            dict.fromkeys((np.nan, None, "nan"), " ") so as not to display "nan" for
             missing values.
         **kwargs: Additional keyword arguments passed to
             plotly.figure_factory.create_annotated_heatmap().
@@ -1491,7 +1491,7 @@ def ptable_hists(
         child_kwargs (dict): Keywords passed to ax.hist() for each histogram.
             Defaults to None.
 
-        cbar_axis (Literal["x", "y"]): The axis colormap would be based on.
+        cbar_axis ("x" | "y"): The axis colormap would be based on.
         cbar_title (str): Color bar title. Defaults to "Histogram Value".
         cbar_title_kwargs (dict): Keyword arguments passed to cbar.ax.set_title().
             Defaults to dict(fontsize=12, pad=10).
@@ -1617,9 +1617,9 @@ def ptable_scatters(
             If pd.Series, index is element symbols and values lists.
             If pd.DataFrame, column names are element symbols,
             plots are created from each column.
-        colormap (str): Matplotlib colormap name to use. Defaults to None'. See
+        colormap (str): Matplotlib colormap name to use. Defaults to None. See
             options at https://matplotlib.org/stable/users/explain/colors/colormaps.
-        on_empty ('hide' | 'show'): Whether to show or hide tiles for elements without
+        on_empty ("hide" | "show"): Whether to show or hide tiles for elements without
             data. Defaults to "hide".
         hide_f_block (bool): Hide f-block (Lanthanum and Actinium series). Defaults to
             None, meaning hide if no data is provided for f-block elements.
@@ -1741,7 +1741,7 @@ def ptable_lines(
             If pd.DataFrame, column names are element symbols,
             plots are created from each column.
 
-        on_empty ('hide' | 'show'): Whether to show or hide tiles for elements without
+        on_empty ("hide" | "show"): Whether to show or hide tiles for elements without
             data. Defaults to "hide".
         hide_f_block (bool): Hide f-block (Lanthanum and Actinium series). Defaults to
             None, meaning hide if no data is provided for f-block elements.

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -919,26 +919,24 @@ def ptable_heatmap(
             text_style.setdefault("verticalalignment", "center")
 
         if symbol in exclude_elements:
-            text_clr = "black"
+            _text_color = "black"
         elif text_color == "auto":
             if isinstance(color, (tuple, list)) and len(color) >= 3:
                 # treat color as RGB tuple and choose black or white text for contrast
-                text_clr = pick_bw_for_contrast(color)
+                _text_color = pick_bw_for_contrast(color)
             else:
-                text_clr = "black"
+                _text_color = "black"
         elif isinstance(text_color, (tuple, list)):
-            text_clr = text_color[0] if norm(tile_value) > 0.5 else text_color[1]
+            _text_color = text_color[0] if norm(tile_value) > 0.5 else text_color[1]
         else:
-            text_clr = text_color
+            _text_color = text_color
 
-        text_style.setdefault("color", text_clr)
-
-        plt.text(
+        symbol_text = plt.text(
             column + 0.5 * tile_width,
             # 0.45 needed to achieve vertical centering, not sure why 0.5 is off
             period + (0.5 if show_values else 0.45) * tile_height,
             symbol,
-            **text_style,
+            **{"color": _text_color} | text_style,
         )
 
         if heat_mode is not None and show_values:
@@ -948,7 +946,7 @@ def ptable_heatmap(
                 label,
                 fontsize=value_font_size,
                 horizontalalignment="center",
-                color=text_clr,
+                color=symbol_text.get_color(),
             )
 
         ax.add_patch(rect)

--- a/pymatviz/ptable.py
+++ b/pymatviz/ptable.py
@@ -577,8 +577,7 @@ class ChildPlotters:
         rect = Rectangle((-0.5, -0.5), 1, 1, fc="none", ec="none")
         ax.set_clip_path(rect)
 
-        ax.set_xlim(-0.5, 0.5)
-        ax.set_ylim(-0.5, 0.5)
+        ax.set(xlim=(-0.5, 0.5), ylim=(-0.5, 0.5))
 
     @staticmethod
     def scatter(
@@ -691,15 +690,13 @@ class ChildPlotters:
 
         # Set tick labels
         ax.tick_params(**tick_kwargs)
-        ax.set_yticklabels([])
-        ax.set_yticks([])
+        ax.set(yticklabels=(), yticks=())
+        # Set x-ticks to min/max only
+        ax.set(xticks=[math.floor(x_range[0]), math.ceil(x_range[1])])
 
         # Hide the right, left and top spines
         ax.axis("on")
         ax.spines[["right", "top", "left"]].set_visible(False)
-
-        # Set x-ticks to min/max only
-        ax.set_xticks([math.floor(x_range[0]), math.ceil(x_range[1])])
 
 
 def ptable_heatmap(

--- a/tests/test_powerups.py
+++ b/tests/test_powerups.py
@@ -305,8 +305,8 @@ def test_add_ecdf_line_stacked() -> None:
     y2 = [2, 3, 4]
 
     fig = go.Figure()
-    fig.add_trace(go.Bar(x=x, y=y1, name="Group 1"))
-    fig.add_trace(go.Bar(x=x, y=y2, name="Group 2"))
+    fig.add_bar(x=x, y=y1, name="Group 1")
+    fig.add_bar(x=x, y=y2, name="Group 2")
     fig.update_layout(barmode="stack")
 
     fig = add_ecdf_line(fig, values=np.concatenate([y1, y2]))
@@ -322,10 +322,8 @@ def test_add_ecdf_line_faceted() -> None:
     fig = make_subplots(rows=2, cols=2)
     for row in range(1, 3):
         for col in range(1, 3):
-            fig.add_trace(
-                go.Scatter(x=[1, 2, 3], y=[4, 5, 6], name=f"Trace {row}{col}"),
-                row=row,
-                col=col,
+            fig.add_scatter(
+                x=[1, 2, 3], y=[4, 5, 6], name=f"Trace {row}{col}", row=row, col=col
             )
 
     fig = add_ecdf_line(fig)

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -392,7 +392,7 @@ def test_ptable_heatmap_ratio(
     )
     assert isinstance(ax, plt.Axes)
 
-    # check presence of legend handles 'not in numerator' and 'not in denominator'
+    # check presence of legend handles "not in numerator" and "not in denominator"
     legend = ax.get_legend()
     assert legend is None
     # get text annotations

--- a/tests/test_ptable.py
+++ b/tests/test_ptable.py
@@ -288,6 +288,58 @@ def test_ptable_heatmap(
     ptable_heatmap(glass_formulas, heat_mode="percent", show_scale=False)
 
 
+def test_ptable_heatmap_text_color_consistency(glass_formulas: list[str]) -> None:
+    ax = ptable_heatmap(glass_formulas)
+    check_text_color_consistency(ax)
+
+    ax = ptable_heatmap(glass_formulas, log=True)
+    check_text_color_consistency(ax)
+
+    ax = ptable_heatmap(glass_formulas, text_color=("red", "blue"))
+    check_text_color_consistency(ax)
+
+    ax = ptable_heatmap(glass_formulas, heat_mode="percent")
+    check_text_color_consistency(ax)
+
+    ax = ptable_heatmap(glass_formulas, show_values=False)
+    check_text_color_consistency(ax)
+
+
+def check_text_color_consistency(ax: plt.Axes) -> None:
+    """Check that in every element tile of a matplotlib ptable_heatmap, the element
+    symbol text color matches the heatmap value's text color."""
+    rectangles = [patch for patch in ax.patches if isinstance(patch, plt.Rectangle)]
+
+    assert len(ax.texts) > 0, "No text elements found in the plot"
+    assert len(rectangles) > 0, "No rectangle elements found in the plot"
+
+    for rect in rectangles:
+        x, y = rect.get_xy()
+        width, height = rect.get_width(), rect.get_height()
+
+        # Find texts within this rectangle
+        rect_texts = [
+            text
+            for text in ax.texts
+            if x <= text.get_position()[0] <= x + width
+            and y <= text.get_position()[1] <= y + height
+        ]
+        symbol = rect_texts[0].get_text()
+        n_rects = len(rect_texts)
+        assert n_rects in {1, 2}, (
+            f"Unexpected number of text elements={n_rects} in element tile at "
+            f"{(symbol, x, y)}, should be 1 or 2 (depending on show_values)"
+        )
+
+        if len(rect_texts) == 2:  # Element symbol and value
+            symbol_text, value_text = rect_texts
+            assert (
+                symbol_text.get_color() == value_text.get_color()
+            ), f"Text color mismatch for element at position {(x, y)}"
+        elif len(rect_texts) == 1:  # Only element symbol (when show_values=False)
+            pass
+
+
 @pytest.mark.parametrize("hide_f_block", [None, False, True])
 def test_ptable_heatmap_splits(hide_f_block: bool) -> None:
     """Test ptable_heatmap_splits with arbitrary data length."""


### PR DESCRIPTION
to ensure consistent color for element symbol and heatmap value text
| Before | After |
|--------|-------|
| ![before](https://github.com/janosh/pymatviz/assets/30958850/684a977a-8704-4239-9c07-f9200647dea0) | ![after](https://github.com/janosh/pymatviz/assets/30958850/8c74f78f-1b2f-43a8-b85c-406d6c0e67e9) |