### PR TITLE
Moving enums may have broken end users pickle's, reduce to str when pickling to be more backwards compatible going forward.

### DIFF
--- a/pymatviz/enums.py
+++ b/pymatviz/enums.py
@@ -95,8 +95,11 @@ class LabelEnum(StrEnum):
         """Map of labels to descriptions."""
         return {str(val.label): val.description for val in cls.__members__.values()}
 
-    def __reduce_ex__(self, proto: int) -> str:
-        """Return as a string when pickling."""
+    def __reduce_ex__(self, proto: object) -> tuple[type, tuple[str]]:
+        """Return as a string when pickling. Overrides Enum.__reduce_ex__ which returns
+        the tuple self.__class__, (self._value_,). self.__class can cause pickle
+        failures if the corresponding Enum was moved or renamed in the meantime.
+        """
         return str, (self.value,)
 
 

--- a/pymatviz/enums.py
+++ b/pymatviz/enums.py
@@ -95,6 +95,10 @@ class LabelEnum(StrEnum):
         """Map of labels to descriptions."""
         return {str(val.label): val.description for val in cls.__members__.values()}
 
+    def __reduce_ex__(self, proto: int) -> str:
+        """Return as a string when pickling."""
+        return str, (self.value,)
+
 
 small_font = "font-size: 0.9em; font-weight: lighter;"
 eV_per_atom = styled_html_tag("(eV/atom)", style=small_font)  # noqa: N816

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -7,11 +7,12 @@ from pymatviz.enums import Key, Model, StrEnum
 
 
 def test_str_enum() -> None:
+    # ensure all pymatviz Enums classes are subclasses of StrEnum
     assert issubclass(StrEnum, str)
     if sys.version_info >= (3, 11):
-        from enum import StrEnum as StdStrEnum
+        from enum import StrEnum as StdLibStrEnum
 
-        assert StrEnum is StdStrEnum
+        assert StrEnum is StdLibStrEnum
     else:
         assert issubclass(StrEnum, str)
         assert StrEnum.__name__ == "StrEnum"
@@ -24,7 +25,7 @@ def test_model_enum() -> None:
 
 
 def test_key_enum() -> None:
-    # access any attributes to trigger @unique decorator check
+    # access any attribute to trigger @unique decorator check
     assert Key.energy_per_atom == "energy_per_atom"
     assert Key.volume == "volume"
 
@@ -32,9 +33,11 @@ def test_key_enum() -> None:
 def test_pickle_enum() -> None:
     key = Key.energy_per_atom
     pickled_key = pickle.dumps(key)
-    unpickled_key = pickle.loads(pickled_key)
+    unpickled_key = pickle.loads(pickled_key)  # noqa: S301
 
-    assert type(unpickled_key) == str
+    assert isinstance(unpickled_key, str)
     assert unpickled_key == "energy_per_atom"
     assert unpickled_key == Key.energy_per_atom
     assert type(key) == Key
+
+    assert Key.energy.__reduce_ex__(1) == (str, ("energy",))

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import pickle
 import sys
 
 from pymatviz.enums import Key, Model, StrEnum
-import pickle
+
 
 def test_str_enum() -> None:
     assert issubclass(StrEnum, str)

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 
 from pymatviz.enums import Key, Model, StrEnum
-
+import pickle
 
 def test_str_enum() -> None:
     assert issubclass(StrEnum, str)
@@ -26,3 +26,14 @@ def test_key_enum() -> None:
     # access any attributes to trigger @unique decorator check
     assert Key.energy_per_atom == "energy_per_atom"
     assert Key.volume == "volume"
+
+
+def test_pickle_enum() -> None:
+    key = Key.energy_per_atom
+    pickled_key = pickle.dumps(key)
+    unpickled_key = pickle.loads(pickled_key)
+
+    assert type(unpickled_key) == str
+    assert unpickled_key == "energy_per_atom"
+    assert unpickled_key == Key.energy_per_atom
+    assert type(key) == Key


### PR DESCRIPTION
Overwrites the `__reduce_ex__` method in `LabelEnum`