### PR TITLE
add scaling_factor to pymatviz/ptable/ptable_plotly.py

### DIFF
--- a/pymatviz/ptable/ptable_plotly.py
+++ b/pymatviz/ptable/ptable_plotly.py
@@ -316,9 +316,9 @@ def ptable_heatmap_plotly(
         plot_bgcolor="rgba(0, 0, 0, 0)",
         xaxis=dict(zeroline=False, showgrid=False),
         yaxis=dict(zeroline=False, showgrid=False, scaleanchor="x"),
-        font_size=font_size*scaling_factor if font_size else 12*scaling_factor,
-        width=1000*scaling_factor,
-        height=500*scaling_factor,
+        font_size=font_size * scaling_factor if font_size else 12 * scaling_factor,
+        width=1000 * scaling_factor,
+        height=500 * scaling_factor,
         title=dict(x=0.4, y=0.95),
     )
 

--- a/pymatviz/ptable/ptable_plotly.py
+++ b/pymatviz/ptable/ptable_plotly.py
@@ -44,7 +44,7 @@ def ptable_heatmap_plotly(
     fill_value: float | None = None,
     label_map: dict[str, str] | Callable[[str], str] | Literal[False] | None = None,
     border: dict[str, Any] | None | Literal[False] = None,
-    scaling_factor: float = 1.0,
+    scale: float = 1.0,
     **kwargs: Any,
 ) -> go.Figure:
     """Create a Plotly figure with an interactive heatmap of the periodic table.
@@ -125,7 +125,7 @@ def ptable_heatmap_plotly(
             dict(width=1, color="gray"). Other allowed keys are arguments of go.Heatmap
             which is (mis-)used to draw the borders as a 2nd heatmap below the main one.
             Pass False to disable borders.
-        scaling_factor (float): scaling factor for all figure layout
+        scale (float): Scaling factor for whole figure layout. Defaults to 1.
         **kwargs: Additional keyword arguments passed to
             plotly.figure_factory.create_annotated_heatmap().
 
@@ -199,9 +199,7 @@ def ptable_heatmap_plotly(
                 label = label_map(label)
             elif isinstance(label_map, dict):
                 label = label_map.get(label, label)
-        style = (
-            f"font-weight: bold; font-size: {1.5 * (font_size or 12*scaling_factor)};"
-        )
+        style = f"font-weight: bold; font-size: {1.5 * (font_size or 12 * scale)};"
         tile_text = f"<span {style=}>{symbol}</span>"
         if show_values and label:
             tile_text += f"<br>{label}"
@@ -316,9 +314,9 @@ def ptable_heatmap_plotly(
         plot_bgcolor="rgba(0, 0, 0, 0)",
         xaxis=dict(zeroline=False, showgrid=False),
         yaxis=dict(zeroline=False, showgrid=False, scaleanchor="x"),
-        font_size=font_size * scaling_factor if font_size else 12 * scaling_factor,
-        width=1000 * scaling_factor,
-        height=500 * scaling_factor,
+        font_size=font_size * scale if font_size else 12 * scale,
+        width=900 * scale,
+        height=500 * scale,
         title=dict(x=0.4, y=0.95),
     )
 

--- a/pymatviz/ptable/ptable_plotly.py
+++ b/pymatviz/ptable/ptable_plotly.py
@@ -316,15 +316,9 @@ def ptable_heatmap_plotly(
         plot_bgcolor="rgba(0, 0, 0, 0)",
         xaxis=dict(zeroline=False, showgrid=False),
         yaxis=dict(zeroline=False, showgrid=False, scaleanchor="x"),
-<<<<<<< HEAD
-        font_size=12 * scaling_factor,
-        width=1000 * scaling_factor,
-        height=500 * scaling_factor,
-=======
         font_size=font_size*scaling_factor if font_size else 12*scaling_factor,
         width=1000*scaling_factor,
         height=500*scaling_factor,
->>>>>>> 378865d (add scaling_factor)
         title=dict(x=0.4, y=0.95),
     )
 

--- a/pymatviz/ptable/ptable_plotly.py
+++ b/pymatviz/ptable/ptable_plotly.py
@@ -316,9 +316,15 @@ def ptable_heatmap_plotly(
         plot_bgcolor="rgba(0, 0, 0, 0)",
         xaxis=dict(zeroline=False, showgrid=False),
         yaxis=dict(zeroline=False, showgrid=False, scaleanchor="x"),
+<<<<<<< HEAD
         font_size=12 * scaling_factor,
         width=1000 * scaling_factor,
         height=500 * scaling_factor,
+=======
+        font_size=font_size*scaling_factor if font_size else 12*scaling_factor,
+        width=1000*scaling_factor,
+        height=500*scaling_factor,
+>>>>>>> 378865d (add scaling_factor)
         title=dict(x=0.4, y=0.95),
     )
 

--- a/pymatviz/ptable/ptable_plotly.py
+++ b/pymatviz/ptable/ptable_plotly.py
@@ -199,7 +199,9 @@ def ptable_heatmap_plotly(
                 label = label_map(label)
             elif isinstance(label_map, dict):
                 label = label_map.get(label, label)
-        style = f"font-weight: bold; font-size: {1.5 * (font_size or 12*scaling_factor)};"
+        style = (
+            f"font-weight: bold; font-size: {1.5 * (font_size or 12*scaling_factor)};"
+        )
         tile_text = f"<span {style=}>{symbol}</span>"
         if show_values and label:
             tile_text += f"<br>{label}"
@@ -314,9 +316,9 @@ def ptable_heatmap_plotly(
         plot_bgcolor="rgba(0, 0, 0, 0)",
         xaxis=dict(zeroline=False, showgrid=False),
         yaxis=dict(zeroline=False, showgrid=False, scaleanchor="x"),
-        font_size=12*scaling_factor,
-        width=1000*scaling_factor,
-        height=500*scaling_factor,
+        font_size=12 * scaling_factor,
+        width=1000 * scaling_factor,
+        height=500 * scaling_factor,
         title=dict(x=0.4, y=0.95),
     )
 

--- a/pymatviz/ptable/ptable_plotly.py
+++ b/pymatviz/ptable/ptable_plotly.py
@@ -44,6 +44,7 @@ def ptable_heatmap_plotly(
     fill_value: float | None = None,
     label_map: dict[str, str] | Callable[[str], str] | Literal[False] | None = None,
     border: dict[str, Any] | None | Literal[False] = None,
+    scaling_factor: float = 1.0,
     **kwargs: Any,
 ) -> go.Figure:
     """Create a Plotly figure with an interactive heatmap of the periodic table.
@@ -124,6 +125,7 @@ def ptable_heatmap_plotly(
             dict(width=1, color="gray"). Other allowed keys are arguments of go.Heatmap
             which is (mis-)used to draw the borders as a 2nd heatmap below the main one.
             Pass False to disable borders.
+        scaling_factor (float): scaling factor for all figure layout
         **kwargs: Additional keyword arguments passed to
             plotly.figure_factory.create_annotated_heatmap().
 
@@ -197,7 +199,7 @@ def ptable_heatmap_plotly(
                 label = label_map(label)
             elif isinstance(label_map, dict):
                 label = label_map.get(label, label)
-        style = f"font-weight: bold; font-size: {1.5 * (font_size or 12)};"
+        style = f"font-weight: bold; font-size: {1.5 * (font_size or 12*scaling_factor)};"
         tile_text = f"<span {style=}>{symbol}</span>"
         if show_values and label:
             tile_text += f"<br>{label}"
@@ -312,9 +314,9 @@ def ptable_heatmap_plotly(
         plot_bgcolor="rgba(0, 0, 0, 0)",
         xaxis=dict(zeroline=False, showgrid=False),
         yaxis=dict(zeroline=False, showgrid=False, scaleanchor="x"),
-        font_size=font_size,
-        width=1000,
-        height=500,
+        font_size=12*scaling_factor,
+        width=1000*scaling_factor,
+        height=500*scaling_factor,
         title=dict(x=0.4, y=0.95),
     )
 

--- a/pymatviz/ptable/ptable_plotly.py
+++ b/pymatviz/ptable/ptable_plotly.py
@@ -199,7 +199,7 @@ def ptable_heatmap_plotly(
                 label = label_map(label)
             elif isinstance(label_map, dict):
                 label = label_map.get(label, label)
-        style = f"font-weight: bold; font-size: {1.5 * (font_size or 12 * scale)};"
+        style = f"font-weight: bold; font-size: {1.5 * (font_size or 12) * scale};"
         tile_text = f"<span {style=}>{symbol}</span>"
         if show_values and label:
             tile_text += f"<br>{label}"
@@ -314,21 +314,29 @@ def ptable_heatmap_plotly(
         plot_bgcolor="rgba(0, 0, 0, 0)",
         xaxis=dict(zeroline=False, showgrid=False),
         yaxis=dict(zeroline=False, showgrid=False, scaleanchor="x"),
-        font_size=font_size * scale if font_size else 12 * scale,
+        font_size=(font_size or 12) * scale,
         width=900 * scale,
         height=500 * scale,
         title=dict(x=0.4, y=0.95),
     )
 
-    if color_bar.get("orientation") == "h":
-        dct = dict(x=0.4, y=0.75, titleside="top", len=0.4)
-        color_bar = {**dct, **color_bar}
+    horizontal_cbar = color_bar.get("orientation") == "h"
+    if horizontal_cbar:
+        defaults = dict(
+            x=0.4,
+            y=0.72,
+            titleside="top",
+            len=0.4,
+            title_font_size=scale * 1.2 * (font_size or 12),
+        )
+        color_bar = defaults | color_bar
     else:  # make title vertical
-        dct = dict(titleside="right", len=0.87)
-        color_bar = {**dct, **color_bar}
-        if title := color_bar.get("title"):
-            # <br><br> to increase title offset
-            color_bar["title"] = f"<br><br>{title}"
+        defaults = dict(titleside="right", len=0.87)
+        color_bar = defaults | color_bar
+
+    if title := color_bar.get("title"):
+        # <br> to increase title standoff
+        color_bar["title"] = f"{title}<br>" if horizontal_cbar else f"<br><br>{title}"
 
     if log:
         orig_min = np.floor(min(non_nan_values))


### PR DESCRIPTION
Hi @janosh, 

First off, these tools are fantastic! I wanted to contribute by adding a small but useful feature.

Rationale: 
Currently, the layout has a fixed width, height, and font size, which limits flexibility when designing Dash apps. A more dynamic sizing approach would improve usability.

Solution:
Introduce `scaling_factor`. 

As demonstrated in the attached image, I've applied scaling_factor = 0.3 and scaling_factor = 0.5 to two subplots while maintaining the integrity.
<img width="467" alt="Screenshot 2024-09-26 at 11 07 20 AM" src="https://github.com/user-attachments/assets/994cf89c-79d1-4f51-a118-08439e1449fe">

Let me know your thoughts! Thanks!










