### PR TITLE
Render spheres with hover tooltip on unit cell corners in `pmv.structure_(2|3)d_plotly`

### DIFF
--- a/examples/make_assets/ptable/ptable_plotly.py
+++ b/examples/make_assets/ptable/ptable_plotly.py
@@ -141,6 +141,4 @@ title = (
 fig.layout.title.update(text=title, x=0.4, y=0.92)
 fig.show()
 
-pmv.io.save_and_compress_svg(
-    fig, "ptable-heatmap-plotly-vasp-psp-n-valence-electrons.pdf"
-)
+pmv.io.save_and_compress_svg(fig, "ptable-heatmap-plotly-vasp-psp-n-valence-electrons")

--- a/examples/make_assets/structure_viz.py
+++ b/examples/make_assets/structure_viz.py
@@ -80,7 +80,7 @@ fig = pmv.structure_2d_plotly(
     # show_sites=dict(line=None),
     elem_colors=ElemColorScheme.jmol,
     n_cols=3,
-    subplot_title=lambda _struct, _key: dict(font=dict(color="lightgray")),
+    subplot_title=lambda _struct, _key: dict(font=dict(color="black")),
 )
 
 fig.show()

--- a/examples/make_assets/structure_viz.py
+++ b/examples/make_assets/structure_viz.py
@@ -80,10 +80,8 @@ fig = pmv.structure_2d_plotly(
     # show_sites=dict(line=None),
     elem_colors=ElemColorScheme.jmol,
     n_cols=3,
+    subplot_title=lambda _struct, _key: dict(font=dict(color="lightgray")),
 )
-
-for anno in fig.layout.annotations:
-    anno.update(font=dict(color="white"))
 
 fig.show()
 pmv.io.save_and_compress_svg(fig, "matbench-phonons-structures-2d-plotly")

--- a/examples/make_assets/structure_viz.py
+++ b/examples/make_assets/structure_viz.py
@@ -69,14 +69,14 @@ for mp_id in struct_mp_ids:
 
     ax.figure.set_size_inches(8, 8)
 
-    pmv.io.save_and_compress_svg(ax, f"struct-2d-{mp_id}-{formula}-disordered")
     plt.show()
+    pmv.io.save_and_compress_svg(ax, f"struct-2d-{mp_id}-{formula}-disordered")
 
 
 # %% Plot Matbench phonon structures with plotly
 fig = pmv.structure_2d_plotly(
     df_phonons[Key.structure].head(6).to_dict(),
-    # show_unit_cell=dict(color="white", width=1.5),
+    # show_unit_cell={"edge": dict(color="white", width=1.5)},
     # show_sites=dict(line=None),
     elem_colors=ElemColorScheme.jmol,
     n_cols=3,
@@ -91,7 +91,9 @@ pmv.io.save_and_compress_svg(fig, "matbench-phonons-structures-2d-plotly")
 
 # %% 3d example
 fig = pmv.structure_3d_plotly(
-    df_phonons[Key.structure].head(6).to_dict(), elem_colors=ElemColorScheme.jmol
+    df_phonons[Key.structure].head(6).to_dict(),
+    elem_colors=ElemColorScheme.jmol,
+    # show_unit_cell={"edge": dict(color="white", width=1.5)},
 )
 fig.show()
 pmv.io.save_and_compress_svg(fig, "matbench-phonons-structures-3d-plotly")

--- a/pymatviz/scatter.py
+++ b/pymatviz/scatter.py
@@ -226,7 +226,7 @@ def density_scatter_plotly(
                 group_df, x, y, density, n_bins, bin_counts_col
             )
             binned_df[facet_col] = group_name  # Add the facet column back
-            binned_dfs.append(binned_df)
+            binned_dfs += [binned_df]
 
         # Merge all binned dataframes
         df_plot = pd.concat(binned_dfs, ignore_index=True)

--- a/pymatviz/structure_viz/helpers.py
+++ b/pymatviz/structure_viz/helpers.py
@@ -212,14 +212,31 @@ def generate_subplot_title(
     subplot_title: Callable[[Structure, str | int], str | dict[str, Any]] | None,
 ) -> dict[str, Any]:
     """Generate a subplot title based on the provided function or default logic."""
+    title_dict: dict[str, str | float | dict[str, str | float]] = {
+        "font": {"color": "black"}
+    }
+
     if callable(subplot_title):
         sub_title = subplot_title(struct_i, struct_key)
-        return dict(text=sub_title) if isinstance(sub_title, str) else sub_title
-    if isinstance(struct_key, int):
-        spg_num = struct_i.get_space_group_info()[1]
-        sub_title = f"{struct_i.formula} (spg={spg_num})"
-        return dict(text=f"{idx}. {sub_title}")
-    return dict(text=struct_key)
+        if isinstance(sub_title, str | int | float):
+            title_dict["text"] = str(sub_title)
+        elif isinstance(sub_title, dict):
+            title_dict |= sub_title
+        else:
+            raise TypeError(
+                f"Invalid subplot_title={sub_title}. Must be a str or dict."
+            )
+
+    if not title_dict.get("text"):
+        if isinstance(struct_key, int):
+            spg_num = struct_i.get_space_group_info()[1]
+            title_dict["text"] = f"{idx}. {struct_i.formula} (spg={spg_num})"
+        elif isinstance(struct_key, str):
+            title_dict["text"] = str(struct_key)
+        else:
+            raise TypeError(f"Invalid {struct_key=}. Must be an int or str.")
+
+    return title_dict
 
 
 def add_site_to_plot(

--- a/pymatviz/structure_viz/helpers.py
+++ b/pymatviz/structure_viz/helpers.py
@@ -369,7 +369,8 @@ def _add_unit_cell(
             fig.add_scatter(x=x, y=y, row=row, col=col, **trace_kwargs)
 
     # Add edges
-    edge_kwargs = unit_cell_kwargs.get("edge", {})
+    edge_defaults = dict(color="black", width=1, dash="dash")
+    edge_kwargs = edge_defaults | unit_cell_kwargs.get("edge", {})
     for start, end in UNIT_CELL_EDGES:
         start_point = cart_corners[start]
         end_point = cart_corners[end]
@@ -395,7 +396,8 @@ def _add_unit_cell(
         )
 
     # Add corner spheres
-    node_kwargs = unit_cell_kwargs.get("node", {})
+    node_defaults = dict(size=3, color="black")
+    node_kwargs = node_defaults | unit_cell_kwargs.get("node", {})
     for i, (frac_coord, cart_coord) in enumerate(
         zip(corners, cart_corners, strict=False)
     ):

--- a/pymatviz/structure_viz/helpers.py
+++ b/pymatviz/structure_viz/helpers.py
@@ -316,8 +316,7 @@ def get_structures(
 def _add_unit_cell(
     fig: go.Figure,
     structure: Structure,
-    color: str,
-    width: float,
+    unit_cell_kwargs: dict[str, Any],
     *,
     is_3d: bool = True,
     row: int | None = None,
@@ -353,6 +352,7 @@ def _add_unit_cell(
             fig.add_scatter(x=x, y=y, row=row, col=col, **trace_kwargs)
 
     # Add edges
+    edge_kwargs = unit_cell_kwargs.get("edge", {})
     for start, end in UNIT_CELL_EDGES:
         start_point = cart_corners[start]
         end_point = cart_corners[end]
@@ -373,11 +373,12 @@ def _add_unit_cell(
             y=[start_point[1], mid_point[1], end_point[1]],
             z=[start_point[2], mid_point[2], end_point[2]] if is_3d else None,
             mode="lines",
-            line=dict(color=color, width=width),
+            line=edge_kwargs,
             hovertext=[None, hover_text, None],
         )
 
     # Add corner spheres
+    node_kwargs = unit_cell_kwargs.get("node", {})
     for i, (frac_coord, cart_coord) in enumerate(
         zip(corners, cart_corners, strict=False)
     ):
@@ -393,7 +394,7 @@ def _add_unit_cell(
         hover_text = (
             f"({', '.join(f'{c:.3g}' for c in cart_coord)}) "
             f"[{', '.join(f'{c:.3g}' for c in frac_coord)}]<br>"
-            f"α = {alpha:.2g}°, β = {beta:.2g}°, γ = {gamma:.2g}°"  # noqa: RUF001
+            f"α = {alpha:.3g}°, β = {beta:.3g}°, γ = {gamma:.3g}°"  # noqa: RUF001
         )
 
         add_trace(
@@ -401,7 +402,7 @@ def _add_unit_cell(
             y=[cart_coord[1]],
             z=[cart_coord[2]] if is_3d else None,
             mode="markers",
-            marker=dict(size=3, color=color),
+            marker=node_kwargs,
             hovertext=hover_text,
         )
 

--- a/pymatviz/structure_viz/plotly.py
+++ b/pymatviz/structure_viz/plotly.py
@@ -69,7 +69,8 @@ def structure_2d_plotly(
             or custom color map. Defaults to ElemColorScheme.jmol.
         scale (float, optional): Scaling of the plotted atoms and lines. Defaults to 1.
         show_unit_cell (bool | dict[str, Any], optional): Whether to plot unit cell. If
-            a dict, will be used to customize unit cell appearance. Defaults to True.
+            a dict, will be used to customize unit cell appearance. The dict should have
+            a "node"/"edge" key to customize node/edge appearance. Defaults to True.
         show_sites (bool | dict[str, Any], optional): Whether to plot atomic sites. If
             a dict, will be used to customize site marker appearance. Defaults to True.
         show_image_sites (bool | dict[str, Any], optional): Whether to show image sites
@@ -183,15 +184,20 @@ def structure_2d_plotly(
 
         # Plot unit cell
         if show_unit_cell:
-            unit_cell_kwargs = dict(color="black", width=1)
+            unit_cell_kwargs = dict(
+                edge=dict(color="black", width=1, dash="dash"),
+                node=dict(size=3, color="black"),
+            )
             if isinstance(show_unit_cell, dict):
-                unit_cell_kwargs |= show_unit_cell
+                unit_cell_kwargs = {
+                    "edge": unit_cell_kwargs["edge"] | show_unit_cell.get("edge", {}),
+                    "node": unit_cell_kwargs["node"] | show_unit_cell.get("node", {}),
+                }
 
             _add_unit_cell(
                 fig,
                 struct_i,
-                unit_cell_kwargs["color"],  # type: ignore[arg-type]
-                unit_cell_kwargs["width"],  # type: ignore[arg-type]
+                unit_cell_kwargs,
                 is_3d=False,
                 row=row,
                 col=col,
@@ -252,7 +258,8 @@ def structure_3d_plotly(
             or custom color map. Defaults to ElemColorScheme.jmol.
         scale (float, optional): Scaling of the plotted atoms and lines. Defaults to 1.
         show_unit_cell (bool | dict[str, Any], optional): Whether to plot unit cell. If
-            a dict, will be used to customize unit cell appearance. Defaults to True.
+            a dict, will be used to customize unit cell appearance. The dict should have
+            a "node"/"edge" key to customize node/edge appearance. Defaults to True.
         show_sites (bool | dict[str, Any], optional): Whether to plot atomic sites. If
             a dict, will be used to customize site marker appearance. Defaults to True.
         show_image_sites (bool | dict[str, Any], optional): Whether to show image sites
@@ -352,15 +359,20 @@ def structure_3d_plotly(
 
         # Plot unit cell
         if show_unit_cell:
-            unit_cell_kwargs = dict(color="black", width=2)
+            unit_cell_kwargs = dict(
+                edge=dict(color="black", width=2, dash="dash"),
+                node=dict(size=3, color="black"),
+            )
             if isinstance(show_unit_cell, dict):
-                unit_cell_kwargs |= show_unit_cell
+                unit_cell_kwargs = {
+                    "edge": unit_cell_kwargs["edge"] | show_unit_cell.get("edge", {}),
+                    "node": unit_cell_kwargs["node"] | show_unit_cell.get("node", {}),
+                }
 
             _add_unit_cell(
                 fig,
                 struct_i,
-                unit_cell_kwargs["color"],  # type: ignore[arg-type]
-                unit_cell_kwargs["width"],  # type: ignore[arg-type]
+                unit_cell_kwargs,
                 is_3d=True,
                 scene=f"scene{idx}",
             )

--- a/pymatviz/structure_viz/plotly.py
+++ b/pymatviz/structure_viz/plotly.py
@@ -184,20 +184,12 @@ def structure_2d_plotly(
 
         # Plot unit cell
         if show_unit_cell:
-            unit_cell_kwargs = dict(
-                edge=dict(color="black", width=1, dash="dash"),
-                node=dict(size=3, color="black"),
-            )
-            if isinstance(show_unit_cell, dict):
-                unit_cell_kwargs = {
-                    "edge": unit_cell_kwargs["edge"] | show_unit_cell.get("edge", {}),
-                    "node": unit_cell_kwargs["node"] | show_unit_cell.get("node", {}),
-                }
-
             _add_unit_cell(
                 fig,
                 struct_i,
-                unit_cell_kwargs,
+                unit_cell_kwargs=show_unit_cell
+                if isinstance(show_unit_cell, dict)
+                else {},
                 is_3d=False,
                 row=row,
                 col=col,
@@ -359,20 +351,12 @@ def structure_3d_plotly(
 
         # Plot unit cell
         if show_unit_cell:
-            unit_cell_kwargs = dict(
-                edge=dict(color="black", width=2, dash="dash"),
-                node=dict(size=3, color="black"),
-            )
-            if isinstance(show_unit_cell, dict):
-                unit_cell_kwargs = {
-                    "edge": unit_cell_kwargs["edge"] | show_unit_cell.get("edge", {}),
-                    "node": unit_cell_kwargs["node"] | show_unit_cell.get("node", {}),
-                }
-
             _add_unit_cell(
                 fig,
                 struct_i,
-                unit_cell_kwargs,
+                unit_cell_kwargs=show_unit_cell
+                if isinstance(show_unit_cell, dict)
+                else {},
                 is_3d=True,
                 scene=f"scene{idx}",
             )
@@ -397,7 +381,7 @@ def structure_3d_plotly(
             yaxis=no_axes_kwargs,
             zaxis=no_axes_kwargs,
             aspectmode="data",
-            bgcolor="rgba(90,90,90,0.01)",  # Transparent background
+            bgcolor="rgba(90, 90, 90, 0.01)",  # Transparent background
         )
 
     # Calculate subplot positions with small gap
@@ -415,13 +399,11 @@ def structure_3d_plotly(
         fig.update_layout({f"scene{idx}": dict(domain=domain, aspectmode="data")})
 
     # Update overall layout
-    fig.update_layout(
-        height=400 * n_rows,
-        width=400 * n_cols,
-        showlegend=False,
-        paper_bgcolor="rgba(0,0,0,0)",  # Transparent background
-        plot_bgcolor="rgba(0,0,0,0)",  # Transparent background
-        margin=dict(l=0, r=0, t=0, b=0),  # Minimize margins
-    )
+    fig.layout.height = 400 * n_rows
+    fig.layout.width = 400 * n_cols
+    fig.layout.showlegend = False
+    fig.layout.paper_bgcolor = "rgba(0,0,0,0)"  # Transparent background
+    fig.layout.plot_bgcolor = "rgba(0,0,0,0)"  # Transparent background
+    fig.layout.margin = dict(l=0, r=0, t=0, b=0)  # Minimize margins
 
     return fig

--- a/tests/structure_viz/test_helpers.py
+++ b/tests/structure_viz/test_helpers.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from pymatgen.core import Structure
 
 from pymatviz.enums import ElemColorScheme
@@ -41,7 +42,7 @@ def test_angles_to_rotation_matrix(
 ) -> None:
     rot_matrix = _angles_to_rotation_matrix(angles)
     assert rot_matrix.shape == expected_shape
-    assert np.allclose(np.linalg.det(rot_matrix), 1.0)
+    assert_allclose(np.linalg.det(rot_matrix), 1.0)
 
 
 def test_angles_to_rotation_matrix_invalid_input() -> None:
@@ -63,8 +64,8 @@ def test_get_structures(structures: list[Structure]) -> None:
     assert all(isinstance(s, Structure) for s in result.values())
 
     # Test with dict of structures
-    struct_dict = {f"struct{i}": s for i, s in enumerate(structures)}
-    result = get_structures(struct_dict)
+    structs_dict = {f"struct{i}": struct for i, struct in enumerate(structures)}
+    result = get_structures(structs_dict)
     assert isinstance(result, dict)
     assert len(result) == len(structures)
     assert all(isinstance(s, Structure) for s in result.values())

--- a/tests/structure_viz/test_mpl.py
+++ b/tests/structure_viz/test_mpl.py
@@ -118,21 +118,21 @@ struct4 = Structure(lattice, ["Cu", "O"], coords=COORDS)
 
 def test_structure_2d_multiple() -> None:
     # Test dict[str, Structure]
-    struct_dict = {
+    structs_dict = {
         "struct1": struct1,
         "struct2": struct2,
         "struct3": struct3,
         "struct4": struct4,
     }
-    fig, axs = pmv.structure_2d(struct_dict, n_cols=3)
+    fig, axs = pmv.structure_2d(structs_dict, n_cols=3)
     assert isinstance(fig, plt.Figure)
     assert isinstance(axs, np.ndarray)
     assert axs.shape == (2, 3)
-    sub_titles = [f"{idx + 1}. {key}" for idx, key in enumerate(struct_dict)]
+    sub_titles = [f"{idx + 1}. {key}" for idx, key in enumerate(structs_dict)]
     assert [ax.get_title() for ax in axs.flat] == sub_titles + [""] * 2
 
     # Test pandas.Series[Structure]
-    struct_series = pd.Series(struct_dict)
+    struct_series = pd.Series(structs_dict)
     fig, axs = pmv.structure_2d(struct_series)
     assert axs.shape == (4,)  # default n_cols=4
     assert [ax.get_title() for ax in axs.flat] == sub_titles
@@ -141,7 +141,7 @@ def test_structure_2d_multiple() -> None:
     assert axs.shape == (1, 4)  # default n_cols=4
 
     # Test list[Structure]
-    fig, axs = pmv.structure_2d(list(struct_dict.values()), n_cols=2)
+    fig, axs = pmv.structure_2d(list(structs_dict.values()), n_cols=2)
     assert axs.shape == (2, 2)
     assert axs.flat[0].get_title() == f"1. {struct1.properties['id']}"
     assert axs.flat[1].get_title() == f"2. {struct2.properties[Key.mat_id]}"
@@ -156,7 +156,7 @@ def test_structure_2d_multiple() -> None:
     fig, axs = pmv.structure_2d(struct_series, subplot_title=subplot_title)
     sub_titles = [
         f"{idx}. {subplot_title(struct, key)}"
-        for idx, (key, struct) in enumerate(struct_dict.items(), start=1)
+        for idx, (key, struct) in enumerate(structs_dict.items(), start=1)
     ]
     assert [ax.get_title() for ax in axs.flat] == sub_titles
 

--- a/tests/structure_viz/test_plotly.py
+++ b/tests/structure_viz/test_plotly.py
@@ -155,13 +155,13 @@ def test_structure_2d_plotly_multiple() -> None:
     struct4 = Structure(lattice, ["Cu", "O"], coords=COORDS)
 
     # Test dict[str, Structure]
-    struct_dict = {
+    structs_dict = {
         "struct1": struct1,
         "struct2": struct2,
         "struct3": struct3,
         "struct4": struct4,
     }
-    fig = pmv.structure_2d_plotly(struct_dict, n_cols=3)
+    fig = pmv.structure_2d_plotly(structs_dict, n_cols=3)
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == 4 * (
         len(COORDS) + 12 + 8
@@ -169,14 +169,14 @@ def test_structure_2d_plotly_multiple() -> None:
     assert len(fig.layout.annotations) == 4
 
     # Test pandas.Series[Structure]
-    struct_series = pd.Series(struct_dict)
+    struct_series = pd.Series(structs_dict)
     fig = pmv.structure_2d_plotly(struct_series)
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == 4 * (len(COORDS) + 12 + 8)
     assert len(fig.layout.annotations) == 4
 
     # Test list[Structure]
-    fig = pmv.structure_2d_plotly(list(struct_dict.values()), n_cols=2)
+    fig = pmv.structure_2d_plotly(list(structs_dict.values()), n_cols=2)
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == 4 * (len(COORDS) + 12 + 8)
     assert len(fig.layout.annotations) == 4
@@ -189,7 +189,7 @@ def test_structure_2d_plotly_multiple() -> None:
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == 4 * (len(COORDS) + 12 + 8)
     assert len(fig.layout.annotations) == 4
-    for idx, (key, struct) in enumerate(struct_dict.items(), start=1):
+    for idx, (key, struct) in enumerate(structs_dict.items(), start=1):
         assert fig.layout.annotations[idx - 1].text == f"{key} - {struct.formula}"
 
 
@@ -330,17 +330,17 @@ def test_structure_3d_plotly_multiple() -> None:
     struct4 = Structure(lattice, ["Cu", "O"], COORDS)
 
     # Test dict[str, Structure]
-    struct_dict = {
+    structs_dict = {
         "struct1": struct1,
         "struct2": struct2,
         "struct3": struct3,
         "struct4": struct4,
     }
-    fig = pmv.structure_3d_plotly(struct_dict, n_cols=2)
+    fig = pmv.structure_3d_plotly(structs_dict, n_cols=2)
     assert isinstance(fig, go.Figure)
 
     expected_traces = 0
-    for struct in struct_dict.values():
+    for struct in structs_dict.values():
         expected_traces += len(struct)  # sites
         expected_traces += 12  # unit cell edges
         expected_traces += 8  # unit cell nodes
@@ -353,14 +353,14 @@ def test_structure_3d_plotly_multiple() -> None:
     assert len(fig.layout.annotations) == 4
 
     # Test pandas.Series[Structure]
-    struct_series = pd.Series(struct_dict)
+    struct_series = pd.Series(structs_dict)
     fig = pmv.structure_3d_plotly(struct_series)
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == expected_traces
     assert len(fig.layout.annotations) == 4
 
     # Test list[Structure]
-    fig = pmv.structure_3d_plotly(list(struct_dict.values()), n_cols=3)
+    fig = pmv.structure_3d_plotly(list(structs_dict.values()), n_cols=3)
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == expected_traces
     assert len(fig.layout.annotations) == 4
@@ -373,7 +373,7 @@ def test_structure_3d_plotly_multiple() -> None:
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == expected_traces
     assert len(fig.layout.annotations) == 4
-    for idx, (key, struct) in enumerate(struct_dict.items(), start=1):
+    for idx, (key, struct) in enumerate(structs_dict.items(), start=1):
         assert fig.layout.annotations[idx - 1].text == f"{key} - {struct.formula}"
 
 
@@ -387,7 +387,7 @@ def test_structure_3d_plotly_invalid_input() -> None:
 def test_structure_3d_plotly_subplot_title_override() -> None:
     struct1 = Structure(lattice, ["Fe", "O"], COORDS)
     struct2 = Structure(lattice, ["Co", "O"], COORDS)
-    struct_dict = {"struct1": struct1, "struct2": struct2}
+    structs_dict = {"struct1": struct1, "struct2": struct2}
 
     def custom_subplot_title(struct: Structure, key: str | int) -> dict[str, Any]:
         return {  # Overriding default font, y position, etc.
@@ -397,12 +397,12 @@ def test_structure_3d_plotly_subplot_title_override() -> None:
             "yanchor": "bottom",
         }
 
-    fig = pmv.structure_3d_plotly(struct_dict, subplot_title=custom_subplot_title)
+    fig = pmv.structure_3d_plotly(structs_dict, subplot_title=custom_subplot_title)
 
     assert isinstance(fig, go.Figure)
     assert len(fig.layout.annotations) == 2
 
-    for idx, (key, struct) in enumerate(struct_dict.items()):
+    for idx, (key, struct) in enumerate(structs_dict.items()):
         annotation = fig.layout.annotations[idx]
         assert annotation.text == f"Custom {key} - {struct.formula}"
         assert annotation.font.size == 16

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -149,8 +149,8 @@ def test_element_pair_rdfs_consistency(structures: list[Structure]) -> None:
         fig1 = element_pair_rdfs(structure, cutoff=5, bin_size=0.1)
         fig2 = element_pair_rdfs(structure, cutoff=5, bin_size=0.1)
         for trace1, trace2 in zip(fig1.data, fig2.data, strict=True):
-            assert np.allclose(trace1.x, trace2.x)
-            assert np.allclose(trace1.y, trace2.y)
+            assert_allclose(trace1.x, trace2.x)
+            assert_allclose(trace1.y, trace2.y)
 
 
 @pytest.mark.parametrize("structs_type", ["dict", "list"])


### PR DESCRIPTION
Node tooltips show adjacent angles, cartesian and fraction coords.

unit cell edge tooltips where moved to be anchored midway along the edge and show Cartesian and frac coords of start and end point as well as the edge length

![matbench-phonons-structures-2d-plotly](https://github.com/user-attachments/assets/178903be-ff2a-4703-ba0f-b80303075050)
