### PR TITLE
Support plotting site vectors like forces/magmoms in `structure_(2|3)d_plotly`

### DIFF
--- a/pymatviz/structure_viz/helpers.py
+++ b/pymatviz/structure_viz/helpers.py
@@ -468,7 +468,7 @@ def draw_vector(
         trace with an arrow marker.
     """
     default_arrow_kwargs = dict(
-        color="lightblue",
+        color="white",
         width=5,
         arrow_head_length=0.8,
         arrow_head_angle=30,

--- a/pymatviz/structure_viz/helpers.py
+++ b/pymatviz/structure_viz/helpers.py
@@ -240,7 +240,7 @@ def generate_subplot_title(
     return title_dict
 
 
-def add_site_to_plot(
+def draw_site(
     fig: go.Figure,
     site: PeriodicSite,
     coords: np.ndarray,
@@ -257,6 +257,7 @@ def add_site_to_plot(
     row: int | None = None,
     col: int | None = None,
     scene: str | None = None,
+    **kwargs: Any,
 ) -> None:
     """Add a site (regular or image) to the plot."""
     species = getattr(site, "specie", site.species)
@@ -308,6 +309,7 @@ def add_site_to_plot(
         name=f"Image of {majority_species!s}" if is_image else str(majority_species),
         showlegend=False,
     )
+    scatter_kwargs |= kwargs
 
     if is_3d:
         scatter_kwargs["z"] = [coords[2]]
@@ -429,7 +431,7 @@ def _add_unit_cell(
     return fig
 
 
-def add_vector_arrow(
+def draw_vector(
     fig: go.Figure,
     start: np.ndarray,
     vector: np.ndarray,

--- a/pymatviz/structure_viz/plotly.py
+++ b/pymatviz/structure_viz/plotly.py
@@ -22,9 +22,11 @@ from pymatviz.structure_viz.helpers import (
     _add_unit_cell,
     _angles_to_rotation_matrix,
     add_site_to_plot,
+    add_vector_arrow,
     generate_subplot_title,
     get_atomic_radii,
     get_elem_colors,
+    get_first_matching_site_prop,
     get_image_atoms,
     get_structures,
 )
@@ -55,6 +57,8 @@ def structure_2d_plotly(
     standardize_struct: bool | None = None,
     n_cols: int = 3,
     subplot_title: Callable[[Structure, str | int], str | dict[str, Any]] | None = None,
+    show_site_vectors: str | Sequence[str] = ("force", "magmom"),
+    vector_kwargs: dict[str, dict[str, Any]] | None = None,
 ) -> go.Figure:
     """Plot pymatgen structures in 2D with Plotly.
 
@@ -83,6 +87,20 @@ def structure_2d_plotly(
         n_cols (int, optional): Number of columns for subplots. Defaults to 4.
         subplot_title (Callable[[Structure, str | int], str | dict], optional):
             Function to generate subplot titles. Defaults to None.
+        show_site_vectors (str | Sequence[str], optional): Whether to show vector site
+            quantities such as forces or magnetic moments as arrow heads originating
+            from each site. Pass the key (or sequence of keys) to look for in site
+            properties. Defaults to ("force", "magmom"). If not found as a site
+            property, will look for it in the structure properties as well and assume
+            the key points at a (N, 3) array with N the number of sites. If multiple
+            keys are provided, it plots the first key found in site properties or
+            structure properties in any of the passed structures (if a dict of
+            structures was passed). But it will only plot one vector per site and it
+            will use the same key for all sites and across all structures.
+        vector_kwargs (dict[str, dict[str, Any]], optional): For customizing vector
+            arrows. Keys are property names (e.g., "force", "magmom"), values are
+            dictionaries of arrow customization options. Use key "scale" to adjust
+            vector length.
 
     Returns:
         go.Figure: Plotly figure with the plotted structure(s).
@@ -104,6 +122,17 @@ def structure_2d_plotly(
     _elem_colors = get_elem_colors(elem_colors)
     _atomic_radii = get_atomic_radii(atomic_radii)
 
+    if isinstance(show_site_vectors, str):
+        show_site_vectors = [show_site_vectors]
+
+    # Determine which vector property to plot (calling outside loop ensures we plot the
+    # same prop for all sites in all structures)
+    vector_prop = get_first_matching_site_prop(
+        list(structures.values()),
+        show_site_vectors,
+        warn_if_none=show_site_vectors != ("force", "magmom"),
+    )
+
     for idx, (struct_key, struct_i) in enumerate(structures.items(), start=1):
         row = (idx - 1) // n_cols + 1
         col = (idx - 1) % n_cols + 1
@@ -122,7 +151,7 @@ def structure_2d_plotly(
         rotation_matrix = _angles_to_rotation_matrix(rotation)
         rotated_coords = np.dot(struct_i.cart_coords, rotation_matrix)
 
-        # Plot atoms
+        # Plot atoms and vectors
         if show_sites:
             site_kwargs = dict(line=dict(width=0.3, color="gray"))
             if isinstance(show_sites, dict):
@@ -146,6 +175,25 @@ def structure_2d_plotly(
                     row=row,
                     col=col,
                 )
+
+                # Add vector arrows
+                if vector_prop:
+                    vector = None
+                    if vector_prop in site.properties:
+                        vector = np.array(site.properties[vector_prop])
+                    elif vector_prop in struct_i.properties:
+                        vector = struct_i.properties[vector_prop][site_idx]
+
+                    if vector is not None and np.any(vector):
+                        add_vector_arrow(
+                            fig,
+                            coords,
+                            vector,
+                            is_3d=False,
+                            arrow_kwargs=(vector_kwargs or {}).get(vector_prop, {}),
+                            row=row,
+                            col=col,
+                        )
 
                 # Add image sites
                 if show_image_sites:
@@ -238,6 +286,8 @@ def structure_3d_plotly(
     standardize_struct: bool | None = None,
     n_cols: int = 3,
     subplot_title: Callable[[Structure, str | int], str | dict[str, Any]] | None = None,
+    show_site_vectors: str | Sequence[str] = ("force", "magmom"),
+    vector_kwargs: dict[str, dict[str, Any]] | None = None,
 ) -> go.Figure:
     """Plot pymatgen structures in 3D with Plotly.
 
@@ -264,6 +314,20 @@ def structure_3d_plotly(
         n_cols (int, optional): Number of columns for subplots. Defaults to 3.
         subplot_title (Callable[[Structure, str | int], str | dict], optional):
             Function to generate subplot titles. Defaults to None.
+        show_site_vectors (str | Sequence[str], optional): Whether to show vector site
+            quantities such as forces or magnetic moments as arrow heads originating
+            from each site. Pass the key (or sequence of keys) to look for in site
+            properties. Defaults to ("force", "magmom"). If not found as a site
+            property, will look for it in the structure properties as well and assume
+            the key points at a (N, 3) array with N the number of sites. If multiple
+            keys are provided, it plots the first key found in site properties or
+            structure properties in any of the passed structures (if a dict of
+            structures was passed). But it will only plot one vector per site and it
+            will use the same key for all sites and across all structures.
+        vector_kwargs (dict[str, dict[str, Any]], optional): For customizing vector
+        arrows. Keys are property names (e.g.,
+            "force", "magmom"), values are dictionaries of arrow customization options.
+            Use key "scale" to adjust vector length.
 
     Returns:
         go.Figure: Plotly figure with the plotted 3D structure(s).
@@ -284,6 +348,17 @@ def structure_3d_plotly(
     _elem_colors = get_elem_colors(elem_colors)
     _atomic_radii = get_atomic_radii(atomic_radii)
 
+    if isinstance(show_site_vectors, str):
+        show_site_vectors = [show_site_vectors]
+
+    # Determine which vector property to plot (calling outside loop ensures we plot the
+    # same prop for all sites in all structures)
+    vector_prop = get_first_matching_site_prop(
+        list(structures.values()),
+        show_site_vectors,
+        warn_if_none=show_site_vectors != ("force", "magmom"),
+    )
+
     for idx, (struct_key, struct_i) in enumerate(structures.items(), start=1):
         # Standardize structure if needed
         if standardize_struct is None:
@@ -295,7 +370,7 @@ def structure_3d_plotly(
             except SymmetryUndeterminedError:
                 warnings.warn(NO_SYM_MSG, UserWarning, stacklevel=2)
 
-        # Plot atoms
+        # Plot atoms and vectors
         if show_sites:
             site_kwargs = dict(line=dict(width=0.3, color="gray"))
             if isinstance(show_sites, dict):
@@ -316,6 +391,24 @@ def structure_3d_plotly(
                     is_3d=True,
                     scene=f"scene{idx}",
                 )
+
+                # Add vector arrows
+                if vector_prop:
+                    vector = None
+                    if vector_prop in site.properties:
+                        vector = np.array(site.properties[vector_prop])
+                    elif vector_prop in struct_i.properties:
+                        vector = struct_i.properties[vector_prop][site_idx]
+
+                    if vector is not None and np.any(vector):
+                        add_vector_arrow(
+                            fig,
+                            site.coords,
+                            vector,
+                            is_3d=True,
+                            arrow_kwargs=(vector_kwargs or {}).get(vector_prop, {}),
+                            scene=f"scene{idx}",
+                        )
 
                 # Add image sites
                 if show_image_sites:

--- a/pymatviz/structure_viz/plotly.py
+++ b/pymatviz/structure_viz/plotly.py
@@ -131,6 +131,9 @@ def structure_2d_plotly(
         list(structures.values()),
         show_site_vectors,
         warn_if_none=show_site_vectors != ("force", "magmom"),
+        # check that value is actually a 3-component vector. needs to handle both
+        # (N, 3) and (3,) cases
+        filter_callback=lambda _prop, value: (np.array(value).shape or [None])[-1] == 3,
     )
 
     for idx, (struct_key, struct_i) in enumerate(structures.items(), start=1):
@@ -359,6 +362,9 @@ def structure_3d_plotly(
         list(structures.values()),
         show_site_vectors,
         warn_if_none=show_site_vectors != ("force", "magmom"),
+        # check that value is actually a 3-component vector. needs to handle both
+        # (N, 3) and (3,) cases
+        filter_callback=lambda _prop, value: (np.array(value).shape or [None])[-1] == 3,
     )
 
     for idx, (struct_key, struct_i) in enumerate(structures.items(), start=1):

--- a/pymatviz/structure_viz/plotly.py
+++ b/pymatviz/structure_viz/plotly.py
@@ -21,8 +21,8 @@ from pymatviz.structure_viz.helpers import (
     NO_SYM_MSG,
     _add_unit_cell,
     _angles_to_rotation_matrix,
-    add_site_to_plot,
-    add_vector_arrow,
+    draw_site,
+    draw_vector,
     generate_subplot_title,
     get_atomic_radii,
     get_elem_colors,
@@ -160,7 +160,7 @@ def structure_2d_plotly(
             for site_idx, (site, coords) in enumerate(
                 zip(struct_i, rotated_coords, strict=False)
             ):
-                add_site_to_plot(
+                draw_site(
                     fig,
                     site,
                     coords,
@@ -174,6 +174,7 @@ def structure_2d_plotly(
                     is_3d=False,  # Explicitly set to False for 2D plot
                     row=row,
                     col=col,
+                    name=f"site{site_idx}",
                 )
 
                 # Add vector arrows
@@ -185,7 +186,7 @@ def structure_2d_plotly(
                         vector = struct_i.properties[vector_prop][site_idx]
 
                     if vector is not None and np.any(vector):
-                        add_vector_arrow(
+                        draw_vector(
                             fig,
                             coords,
                             vector,
@@ -193,6 +194,7 @@ def structure_2d_plotly(
                             arrow_kwargs=(vector_kwargs or {}).get(vector_prop, {}),
                             row=row,
                             col=col,
+                            name=f"vector{site_idx}",
                         )
 
                 # Add image sites
@@ -213,7 +215,7 @@ def structure_2d_plotly(
                         rotated_image_atoms = np.dot(image_atoms, rotation_matrix)
 
                         for image_coords in rotated_image_atoms:
-                            add_site_to_plot(
+                            draw_site(
                                 fig,
                                 site,
                                 image_coords,
@@ -377,7 +379,7 @@ def structure_3d_plotly(
                 site_kwargs |= show_sites
 
             for site_idx, site in enumerate(struct_i):
-                add_site_to_plot(
+                draw_site(
                     fig,
                     site,
                     site.coords,
@@ -390,6 +392,7 @@ def structure_3d_plotly(
                     site_kwargs,
                     is_3d=True,
                     scene=f"scene{idx}",
+                    name=f"site{site_idx}",
                 )
 
                 # Add vector arrows
@@ -401,13 +404,14 @@ def structure_3d_plotly(
                         vector = struct_i.properties[vector_prop][site_idx]
 
                     if vector is not None and np.any(vector):
-                        add_vector_arrow(
+                        draw_vector(
                             fig,
                             site.coords,
                             vector,
                             is_3d=True,
                             arrow_kwargs=(vector_kwargs or {}).get(vector_prop, {}),
                             scene=f"scene{idx}",
+                            name=f"vector{site_idx}",
                         )
 
                 # Add image sites
@@ -426,7 +430,7 @@ def structure_3d_plotly(
                     image_atoms = get_image_atoms(site, struct_i.lattice)
                     if len(image_atoms) > 0:  # Only proceed if there are image atoms
                         for image_coords in image_atoms:
-                            add_site_to_plot(
+                            draw_site(
                                 fig,
                                 site,
                                 image_coords,

--- a/tests/structure_viz/test_helpers.py
+++ b/tests/structure_viz/test_helpers.py
@@ -297,7 +297,7 @@ def test_draw_vector_default_values() -> None:
     line_trace = fig.data[0]
     cone_trace = fig.data[1]
 
-    assert line_trace.line.color == "lightblue"
+    assert line_trace.line.color == "white"
     assert line_trace.line.width == 5
     assert cone_trace.sizeref == 0.8
     assert_allclose(cone_trace.x, [1])

--- a/tests/structure_viz/test_helpers.py
+++ b/tests/structure_viz/test_helpers.py
@@ -13,8 +13,8 @@ from pymatviz.structure_viz.helpers import (
     NO_SYM_MSG,
     UNIT_CELL_EDGES,
     _angles_to_rotation_matrix,
-    add_site_to_plot,
-    add_vector_arrow,
+    draw_site,
+    draw_vector,
     generate_subplot_title,
     get_atomic_radii,
     get_elem_colors,
@@ -146,7 +146,7 @@ def test_get_image_atoms(structures: list[Structure]) -> None:
     assert len(image_atoms) == 0
 
 
-def test_add_site_to_plot(structures: list[Structure], mock_figure: Any) -> None:
+def test_draw_site(structures: list[Structure], mock_figure: Any) -> None:
     structure = structures[0]
     site = structure[0]
     coords = site.coords
@@ -161,7 +161,7 @@ def test_add_site_to_plot(structures: list[Structure], mock_figure: Any) -> None
     ]
 
     for case in test_cases:
-        add_site_to_plot(
+        draw_site(
             mock_figure,
             site,
             coords,
@@ -177,7 +177,7 @@ def test_add_site_to_plot(structures: list[Structure], mock_figure: Any) -> None
 
     # Test with custom site labels
     custom_labels = {site.species_string: "Custom"}
-    add_site_to_plot(
+    draw_site(
         mock_figure,
         site,
         coords,
@@ -267,7 +267,7 @@ def test_constants() -> None:
         ),
     ],
 )
-def test_add_vector_arrow(
+def test_draw_vector(
     start: list[float],
     vector: list[float],
     is_3d: bool,
@@ -276,7 +276,7 @@ def test_add_vector_arrow(
 ) -> None:
     fig, start, vector = go.Figure(), np.array(start), np.array(vector)
     initial_trace_count = len(fig.data)
-    add_vector_arrow(fig, start, vector, is_3d=is_3d, arrow_kwargs=arrow_kwargs)
+    draw_vector(fig, start, vector, is_3d=is_3d, arrow_kwargs=arrow_kwargs)
     assert len(fig.data) - initial_trace_count == expected_traces
 
     if is_3d:
@@ -308,11 +308,11 @@ def test_add_vector_arrow(
         assert_allclose(fig.data[-1].y[1], end_point[1])
 
 
-def test_add_vector_arrow_default_values() -> None:
+def test_draw_vector_default_values() -> None:
     fig = go.Figure()
     start = np.array([0, 0, 0])
     vector = np.array([1, 1, 1])
-    add_vector_arrow(fig, start, vector, is_3d=True)
+    draw_vector(fig, start, vector, is_3d=True)
 
     assert len(fig.data) == 2
     line_trace = fig.data[0]

--- a/tests/structure_viz/test_plotly.py
+++ b/tests/structure_viz/test_plotly.py
@@ -15,7 +15,13 @@ from pymatviz.structure_viz.helpers import get_image_atoms
 
 COORDS = [[0, 0, 0], [0.5, 0.5, 0.5]]
 DISORDERED_STRUCT = Structure(
-    lattice := np.eye(3) * 5, species=[{"Fe": 0.75, "C": 0.25}, "O"], coords=COORDS
+    lattice := np.eye(3) * 5,
+    species=[{"Fe": 0.75, "C": 0.25}, "O"],
+    coords=COORDS,
+    site_properties={
+        "magmom": [[0, 0, 1], [0, 0, -1]],  # Vector values for magmom
+        "force": [[1.0, 1.0, 1.0], [-1.0, -1.0, -1.0]],
+    },
 )
 
 
@@ -33,6 +39,7 @@ DISORDERED_STRUCT = Structure(
             "site_labels": "symbol",
             "standardize_struct": None,
             "n_cols": 2,
+            "show_site_vectors": "magmom",
         },
         {
             "rotation": "10x,-10y,0z",
@@ -45,6 +52,7 @@ DISORDERED_STRUCT = Structure(
             "site_labels": "species",
             "standardize_struct": True,
             "n_cols": 4,
+            "show_site_vectors": ("magmom", "force"),
         },
         {
             "rotation": "5x,5y,5z",
@@ -57,6 +65,7 @@ DISORDERED_STRUCT = Structure(
             "site_labels": {"Fe": "Iron"},
             "standardize_struct": False,
             "n_cols": 3,
+            "show_site_vectors": (),
         },
         {
             "rotation": "15x,0y,10z",
@@ -100,15 +109,6 @@ def test_structure_2d_plotly(kwargs: dict[str, Any]) -> None:
     fig = pmv.structure_2d_plotly(DISORDERED_STRUCT, **kwargs)
     assert isinstance(fig, go.Figure)
 
-    # Check if the figure has the correct number of traces
-    expected_traces = 0
-    if show_sites := kwargs.get("show_sites"):
-        expected_traces += len(DISORDERED_STRUCT)
-    if show_unit_cell := kwargs.get("show_unit_cell"):
-        expected_traces += 12  # 12 edges in a cube
-        expected_traces += 8  # 8 nodes in a cube
-    assert len(fig.data) == expected_traces
-
     # Check if the layout properties are set correctly
     assert fig.layout.showlegend is False
     assert fig.layout.paper_bgcolor == "rgba(0,0,0,0)"
@@ -123,8 +123,8 @@ def test_structure_2d_plotly(kwargs: dict[str, Any]) -> None:
         assert axis.constrain == "domain"
 
     # Additional checks based on specific kwargs
-    if isinstance(show_unit_cell, dict):
-        edge_kwargs = show_unit_cell.get("edge", {})
+    if isinstance(kwargs.get("show_unit_cell"), dict):
+        edge_kwargs = kwargs["show_unit_cell"].get("edge", {})
         unit_cell_edge_trace = next(
             (trace for trace in fig.data if trace.mode == "lines"), None
         )
@@ -135,14 +135,32 @@ def test_structure_2d_plotly(kwargs: dict[str, Any]) -> None:
     site_trace = next(
         (trace for trace in fig.data if trace.mode == "markers+text"), None
     )
+    show_sites = kwargs.get("show_sites")
     if (site_labels := kwargs.get("site_labels")) and show_sites is not False:
         assert site_trace is not None
         if isinstance(site_labels, dict):
             assert any(text in site_trace.text for text in site_labels.values())
-        # elif isinstance(kwargs["site_labels"], list):
-        #     assert all(label in site_trace.text for label in kwargs["site_labels"])
         elif site_labels in ("symbol", "species"):
             assert len(site_trace.text) == len(DISORDERED_STRUCT)
+
+    # Check for sites and arrows
+    if show_sites:
+        site_traces = [
+            trace for trace in fig.data if (trace.name or "").startswith("site")
+        ]
+        assert len(site_traces) > 0, "No site traces found when show_sites is True"
+
+        if kwargs.get("show_site_vectors"):
+            vector_traces = [
+                trace for trace in fig.data if (trace.name or "").startswith("vector")
+            ]
+            assert (
+                len(vector_traces) > 0
+            ), "No vector traces found when show_site_vectors is True"
+            for vector_trace in vector_traces:
+                assert vector_trace.mode == "lines+markers"
+                assert vector_trace.marker.symbol == "arrow"
+                assert "angle" in vector_trace.marker
 
 
 def test_structure_2d_plotly_multiple() -> None:
@@ -214,6 +232,7 @@ def test_structure_2d_plotly_invalid_input() -> None:
             "site_labels": "species",
             "standardize_struct": None,
             "n_cols": 3,
+            "show_site_vectors": "magmom",
         },
         {
             "atomic_radii": 0.5,
@@ -226,6 +245,7 @@ def test_structure_2d_plotly_invalid_input() -> None:
             "site_labels": "symbol",
             "standardize_struct": True,
             "n_cols": 2,
+            "show_site_vectors": ("magmom", "force"),
         },
         {
             "atomic_radii": {"Fe": 0.8, "O": 0.6},
@@ -238,6 +258,7 @@ def test_structure_2d_plotly_invalid_input() -> None:
             "site_labels": {"Fe": "Iron", "O": "Oxygen"},
             "standardize_struct": False,
             "n_cols": 4,
+            "show_site_vectors": (),
         },
         {
             "atomic_radii": 1.2,
@@ -256,23 +277,6 @@ def test_structure_2d_plotly_invalid_input() -> None:
 def test_structure_3d_plotly(kwargs: dict[str, Any]) -> None:
     fig = pmv.structure_3d_plotly(DISORDERED_STRUCT, **kwargs)
     assert isinstance(fig, go.Figure)
-
-    # Check if the figure has the correct number of traces
-    expected_traces = 0
-    if kwargs.get("show_sites"):
-        expected_traces += len(DISORDERED_STRUCT)
-    if kwargs.get("show_unit_cell"):
-        expected_traces += 12  # 12 edges in a cube
-        expected_traces += 8  # 8 nodes in a cube
-    if kwargs.get("show_image_sites"):
-        # Instead of assuming 8 image sites per atom, let's count the actual number
-        image_sites = sum(
-            len(get_image_atoms(site, DISORDERED_STRUCT.lattice))
-            for site in DISORDERED_STRUCT
-        )
-        expected_traces += image_sites
-
-    assert len(fig.data) == expected_traces
 
     # Check if the layout properties are set correctly
     assert fig.layout.showlegend is False
@@ -299,7 +303,9 @@ def test_structure_3d_plotly(kwargs: dict[str, Any]) -> None:
 
     if kwargs.get("show_sites"):
         site_traces = [
-            trace for trace in fig.data if trace.mode in ("markers", "markers+text")
+            trace
+            for trace in fig.data
+            if getattr(trace, "mode", None) in ("markers", "markers+text")
         ]
         assert len(site_traces) > 0, "No site traces found when show_sites is True"
         site_trace = site_traces[0]
@@ -318,6 +324,29 @@ def test_structure_3d_plotly(kwargs: dict[str, Any]) -> None:
             assert (
                 site_trace.text is None or len(site_trace.text) == 0
             ), "Unexpected site labels found"
+
+    # Check for sites and arrows
+    if kwargs.get("show_sites"):
+        site_traces = [
+            trace for trace in fig.data if (trace.name or "").startswith("site")
+        ]
+        assert len(site_traces) > 0, "No site traces found when show_sites is True"
+
+        if show_site_vectors := kwargs.get("show_site_vectors"):
+            vector_traces = [
+                trace for trace in fig.data if (trace.name or "").startswith("vector")
+            ]
+            assert (
+                len(vector_traces) > 0
+            ), f"No vector traces even though {show_site_vectors=}"
+            for vector_trace in vector_traces:
+                if vector_trace.type == "scatter3d":
+                    assert vector_trace.mode == "lines"
+                    assert vector_trace.line.color == "lightblue"
+                    assert vector_trace.line.width == 5
+                elif vector_trace.type == "cone":
+                    assert vector_trace.sizemode == "absolute"
+                    assert vector_trace.sizeref == 0.8
 
 
 def test_structure_3d_plotly_multiple() -> None:

--- a/tests/structure_viz/test_plotly.py
+++ b/tests/structure_viz/test_plotly.py
@@ -342,7 +342,7 @@ def test_structure_3d_plotly(kwargs: dict[str, Any]) -> None:
             for vector_trace in vector_traces:
                 if vector_trace.type == "scatter3d":
                     assert vector_trace.mode == "lines"
-                    assert vector_trace.line.color == "lightblue"
+                    assert vector_trace.line.color == "white"
                     assert vector_trace.line.width == 5
                 elif vector_trace.type == "cone":
                     assert vector_trace.sizemode == "absolute"


### PR DESCRIPTION
minimal example with random assignment of +/- directions for absolute magmoms of [mp-1232890](https://materialsproject.org/materials/mp-1232890)

```py
import numpy as np
from mp_api.client import MPRester

import pymatviz as pmv

mp_1232890 = MPRester().get_structure_by_material_id("mp-1232890")

afm_array = np.zeros((len(mp_1232890), 3))
for idx, mag in enumerate(mp_1232890.site_properties["magmom"]):
    # Alternate the direction for adjacent sites
    direction = 1 if idx % 2 == 0 else -1
    afm_array[idx] = [0, 0, direction * abs(mag)]

mp_1232890.add_site_property("magmom", afm_array.tolist())


fig = pmv.structure_3d_plotly(mp_1232890)
fig.show()
pmv.io.save_and_compress_svg(fig, "mp-1232890-afm")
```
![Screenshot 2024-10-04 at 18 33 43](https://github.com/user-attachments/assets/3f7b0859-749e-4485-bd91-586d6f9cad9e)

