### PR TITLE
Split `coordination.py` module into `plotly.py` and `helpers.py`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.7.2
     hooks:
       - id: ruff
         args: [--fix]
@@ -48,7 +48,7 @@ repos:
         args: [--ignore-words-list, "hist,mape,te,nd,fpr", --check-filenames]
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.8.0
     hooks:
       - id: nbstripout
         args: [--drop-empty-cells, --keep-output]
@@ -73,7 +73,7 @@ repos:
         exclude: ^(site/src/figs/.+\.svelte|data/wbm/20.+\..+|site/src/(routes|figs).+\.(yaml|json)|changelog.md)$
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.13.0
+    rev: v9.14.0
     hooks:
       - id: eslint
         stages: [manual] # TODO: skip eslint for now
@@ -88,6 +88,6 @@ repos:
           - typescript-eslint
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.386
+    rev: v1.1.387
     hooks:
       - id: pyright

--- a/examples/make_assets/coordination.py
+++ b/examples/make_assets/coordination.py
@@ -7,7 +7,7 @@ from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 import pymatviz as pmv
-from pymatviz.coordination import SplitMode
+from pymatviz.coordination import CnSplitMode
 from pymatviz.enums import Key
 from pymatviz.utils import TEST_FILES
 
@@ -87,7 +87,7 @@ pmv.io.save_and_compress_svg(fig, "coordination-hist-multiple")
 
 
 # %% By element example (now default, but explicitly specified for clarity)
-fig = pmv.coordination_hist(structures[key1], split_mode=SplitMode.by_element)
+fig = pmv.coordination_hist(structures[key1], split_mode=CnSplitMode.by_element)
 fig.layout.margin.t = 50
 fig.layout.title = dict(
     text=f"Coordination Histogram by Element: {key1}", x=0.5, y=0.98
@@ -111,7 +111,7 @@ pmv.io.save_and_compress_svg(fig, "coordination-hist-multiple-by-element")
 # %% Multiple structures with by_structure split
 fig = pmv.coordination_hist(
     {key1: structures[key1], key2: structures[key2], key3: structures[key3]},
-    split_mode=SplitMode.by_structure,
+    split_mode=CnSplitMode.by_structure,
 )
 fig.layout.margin.t = 50
 fig.layout.title = dict(text="Coordination Histogram by Structure", x=0.5, y=0.98)
@@ -122,7 +122,7 @@ pmv.io.save_and_compress_svg(fig, "coordination-hist-by-structure")
 # %% Multiple structures with by_structure_and_element split
 fig = pmv.coordination_hist(
     {key1: structures[key1], key2: structures[key2], key3: structures[key3]},
-    split_mode=SplitMode.by_structure_and_element,
+    split_mode=CnSplitMode.by_structure_and_element,
 )
 fig.layout.margin.t = 60
 fig.layout.title = dict(
@@ -164,10 +164,10 @@ fig.show()
 pmv.io.save_and_compress_svg(fig, "coordination-hist-multiple-by-element-custom-colors")
 
 
-# %% Example with split_mode=SplitMode.none
+# %% Example with split_mode=CnSplitMode.none
 fig = pmv.coordination_hist(
     {key1: structures[key1], key2: structures[key2], key3: structures[key3]},
-    split_mode=SplitMode.none,
+    split_mode=CnSplitMode.none,
 )
 fig.layout.margin.t = 50
 fig.layout.title = dict(
@@ -177,10 +177,10 @@ fig.show()
 pmv.io.save_and_compress_svg(fig, "coordination-hist-all-combined")
 
 
-# %% Example with split_mode=SplitMode.none and side-by-side bars
+# %% Example with split_mode=CnSplitMode.none and side-by-side bars
 fig = pmv.coordination_hist(
     {key1: structures[key1], key2: structures[key2], key3: structures[key3]},
-    split_mode=SplitMode.none,
+    split_mode=CnSplitMode.none,
     bar_mode="group",
     bar_kwargs=dict(width=0.2),
 )

--- a/pymatviz/coordination/__init__.py
+++ b/pymatviz/coordination/__init__.py
@@ -1,3 +1,4 @@
 """Coordination number analysis and visualization."""
 
+from pymatviz.coordination.helpers import CnSplitMode
 from pymatviz.coordination.plotly import coordination_hist, coordination_vs_cutoff_line

--- a/pymatviz/coordination/__init__.py
+++ b/pymatviz/coordination/__init__.py
@@ -1,0 +1,3 @@
+"""Coordination number analysis and visualization."""
+
+from pymatviz.coordination.plotly import coordination_hist, coordination_vs_cutoff_line

--- a/pymatviz/coordination/helpers.py
+++ b/pymatviz/coordination/helpers.py
@@ -1,0 +1,84 @@
+"""Visualizations of coordination numbers distributions."""
+
+from __future__ import annotations
+
+from inspect import isclass
+from typing import TYPE_CHECKING
+
+from pymatgen.analysis.local_env import NearNeighbors
+
+from pymatviz.enums import LabelEnum
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
+    from pymatgen.core import PeriodicSite, Structure
+
+
+class CnSplitMode(LabelEnum):
+    """How to split the coordination number histogram into subplots."""
+
+    none = "none"
+    by_element = "by element"
+    by_structure = "by structure"
+    by_structure_and_element = "by structure and element"
+
+
+def create_hover_text(
+    struct_key: str,
+    elem_symbol: str,
+    cn: int,
+    count: int,
+    hover_data: dict[str, str],
+    data: dict[str, Any],
+    is_single_structure: bool,  # noqa: FBT001
+) -> str:
+    """Create hover text for a single bar in the histogram."""
+    hover_text = f"Formula: {struct_key}<br>" if not is_single_structure else ""
+    hover_text += f"Element: {elem_symbol}<br>" if elem_symbol else ""
+    hover_text += f"Coordination number: {cn}<br>Count: {count}"
+
+    if hover_data:
+        hover_text += "<br>" + "<br>".join(
+            f"{label}: {data['hover_data'][key][idx] if idx < len(data['hover_data'][key]) else 'N/A'}"  # noqa: E501
+            for idx, (key, label) in enumerate(hover_data.items())
+        )
+
+    return hover_text
+
+
+def normalize_get_neighbors(
+    strategy: float | NearNeighbors | type[NearNeighbors],
+) -> Callable[[PeriodicSite, Structure], list[dict[str, Any]]]:
+    """Normalize get_neighbors function."""
+    # Prepare the neighbor-finding strategy
+    if isinstance(strategy, int | float):
+        cutoff = strategy
+        return lambda site, structure: structure.get_neighbors(site, r=cutoff)
+    if isinstance(strategy, NearNeighbors):
+        return lambda site, structure: strategy.get_nn_info(
+            structure, structure.index(site)
+        )
+
+    if isclass(strategy) and issubclass(strategy, NearNeighbors):
+        nn_instance = strategy()
+        return lambda site, structure: nn_instance.get_nn_info(
+            structure, structure.index(site)
+        )
+    raise TypeError(
+        f"Invalid {strategy=}. Expected float, NearNeighbors instance, or "
+        "NearNeighbors subclass."
+    )
+
+
+def calculate_average_cn(
+    structure: Structure,
+    element: str,
+    get_neighbors: Callable[[PeriodicSite, Structure], list[dict[str, Any]]],
+) -> float:
+    """Calculate the average coordination number for a given element in a structure."""
+    element_sites = [site for site in structure if site.specie.symbol == element]
+    cn_sum = sum(len(get_neighbors(site, structure)) for site in element_sites)
+    return cn_sum / len(element_sites) if element_sites else 0

--- a/pymatviz/enums.py
+++ b/pymatviz/enums.py
@@ -133,6 +133,7 @@ eV_per_kelvin = html_tag("(eV/K)", style="small")  # noqa: N816
 angstrom = html_tag("(Å)", style="small")
 angstrom_per_atom = html_tag("(Å/atom)", style="small")
 cubic_angstrom = html_tag("(Å<sup>3</sup>)", style="small")
+degrees = html_tag("(°)", style="small")
 gram_per_cm3 = html_tag("(g/cm³)", style="small")
 kelvin = html_tag("(K)", style="small")
 pascal = html_tag("(Pa)", style="small")
@@ -147,18 +148,14 @@ class Key(LabelEnum):
     """Keys used to access dataframes columns, organized by semantic groups."""
 
     # Structural
-    crystal_system = "crystal_system", "Crystal System"
-    spg_num = "space_group_number", "Space Group Number"
-    spg_symbol = "space_group_symbol", "Space Group Symbol"
     n_sites = "n_sites", "Number of Sites"
-    n_wyckoff = "n_wyckoff", "Number of Wyckoff Positions"
     structure = "structure", "Structure"
     init_struct = "initial_structure", "Initial Structure"
     final_struct = "final_structure", "Final Structure"
     cell = "cell", "Cell"
     lattice = "lattice", "Lattice"
     lattice_vectors = "lattice_vectors", "Lattice Vectors"
-    lattice_angles = "lattice_angles", "Lattice Angles (°)"
+    lattice_angles = "lattice_angles", f"Lattice Angles {degrees}"
     lattice_lens = "lattice_lengths", f"Lattice Lengths {angstrom}"
     init_volume = "initial_volume", f"Initial Volume {cubic_angstrom}"
     final_volume = "final_volume", f"Final Volume {cubic_angstrom}"
@@ -166,24 +163,30 @@ class Key(LabelEnum):
     vol_per_atom = "volume_per_atom", f"Volume per Atom {cubic_angstrom}"
     density = "density", f"Density {gram_per_cm3}"
     pressure = "pressure", f"Pressure {pascal}"
-    symmetry = "symmetry", "Symmetry"
-    point_group = "point_group", "Point Group"
     lattice_params = "lattice_parameters", "Lattice Parameters"
     supercell = "supercell", "Supercell"
     atom_nums = "atom_nums", "Atomic Numbers", "Atomic numbers for each crystal site"
     coord_num = "coordination_number", "Coordination Number"
     bond_lens = "bond_lengths", f"Bond Lengths {angstrom}"
-    bond_angles = "bond_angles", "Bond Angles (°)"
+    bond_angles = "bond_angles", f"Bond Angles {degrees}"
     packing_fraction = "packing_fraction", "Packing Fraction"
     max_pair_dist = "max_pair_dist", f"Maximum Pair Distance {angstrom}"
 
     # Crystal Symmetry Properties
+    crystal_system = "crystal_system", "Crystal System"
+    spg_num = "space_group_number", "Space Group Number"
+    spg_symbol = "space_group_symbol", "Space Group Symbol"
     choice_symbol = "choice_symbol", "Choice symbol"
     hall_num = "hall_num", "Hall number"
     hall_symbol = "hall_symbol", "Hall symbol"
-    n_rot_ops = "n_rot_ops", "Number of rotational operations"
-    n_sym_ops = "n_sym_ops", "Total number of symmetry operations"
-    n_trans_ops = "n_trans_ops", "Number of translational operations"
+    translations = "translations", "Translations"
+    rotations = "rotations", "Rotations"
+    symmetry = "symmetry", "Symmetry"
+    point_group = "point_group", "Point Group"
+    n_wyckoff = "n_wyckoff", "Number of Wyckoff Positions"
+    n_rot_syms = "n_rot_syms", "Number of rotational symmetries"
+    n_trans_syms = "n_trans_syms", "Number of translational symmetries"
+    n_sym_ops = "n_sym_ops", "Total number of symmetries"
     wyckoff = "wyckoff", "AFLOW-style Label with Chemical System"
     wyckoff_spglib = "wyckoff_spglib", "Wyckoff Label (spglib)"
     wyckoff_symbol = "wyckoff_symbol", "Wyckoff Symbol"
@@ -297,6 +300,7 @@ class Key(LabelEnum):
     bandgap_true = "bandgap_true", f"Actual Band Gap {eV}"
     bandgap_pred = "bandgap_pred", f"Predicted Band Gap {eV}"
     fermi_energy = "fermi_energy", f"Fermi Energy {eV}"
+    electronic_structure = "electronic_structure", "Electronic Structure"
     electron_affinity = "electron_affinity", f"Electron Affinity {eV}"
     work_function = "work_function", f"Work Function {eV}"
     dos = "density_of_states", "Density of States"
@@ -519,6 +523,7 @@ class Key(LabelEnum):
     mse = "MSE", "Mean Squared Error"
     rmse = "RMSE", "Root Mean Squared Error"
     rmsd = "rmsd", "Root Mean Square Deviation"
+    structure_rmsd = "structure_rmsd", f"Structure RMSD {angstrom}"
     mape = "MAPE", "Mean Absolute Percentage Error"
     srme = "SRME", "Symmetric Relative Mean Error"
     sre = "SRE", "Symmetric Relative Error"

--- a/pymatviz/utils.py
+++ b/pymatviz/utils.py
@@ -684,14 +684,15 @@ def normalize_to_dict(
         obj, "formula", type(obj).__name__
     ),
 ) -> dict[str, T]:
-    """Normalize input to a dictionary of objects.
+    """Normalize any kind of object or dict/list/tuple of them into to a dictionary.
 
     Args:
         inputs: A single object, a sequence of objects, or a dictionary of objects.
         cls (type[T], optional): The class of the objects to normalize. Defaults to
             pymatgen.core.Structure.
         key_gen (Callable[[T], str], optional): A function that generates a key for
-            each object. Defaults to using the object's formula.
+            each object. Defaults to using the object's formula, assuming the objects
+            are pymatgen.core.(Structure|Molecule).
 
     Returns:
         A dictionary of objects with keys as object formulas or given keys.
@@ -718,6 +719,8 @@ def normalize_to_dict(
         return out_dict
     if isinstance(inputs, dict):
         return inputs
+    if isinstance(inputs, pd.Series):
+        return inputs.to_dict()
 
     cls_name = cls.__name__
     raise TypeError(

--- a/readme.md
+++ b/readme.md
@@ -135,13 +135,13 @@ See [`pymatviz/rdf/plotly.py`](pymatviz/rdf/plotly.py).
 
 ## Coordination
 
-See [`pymatviz/coordination.py`](pymatviz/coordination.py).
+See [`pymatviz/coordination/plotly.py`](pymatviz/coordination/plotly.py).
 
-|             [`coordination_hist(struct_dict)`](pymatviz/coordination.py)              |     [`coordination_hist(struct_dict, by_element=True)`](pymatviz/coordination.py)     |
-| :-----------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------: |
-|                              ![coordination-hist-single]                              |                     ![coordination-hist-by-structure-and-element]                     |
-| [`coordination_vs_cutoff_line(struct_dict, strategy=None)`](pymatviz/coordination.py) | [`coordination_vs_cutoff_line(struct_dict, strategy=None)`](pymatviz/coordination.py) |
-|                           ![coordination-vs-cutoff-single]                            |                          ![coordination-vs-cutoff-multiple]                           |
+|             [`coordination_hist(struct_dict)`](pymatviz/coordination/plotly.py)              |     [`coordination_hist(struct_dict, by_element=True)`](pymatviz/coordination/plotly.py)     |
+| :------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------: |
+|                                 ![coordination-hist-single]                                  |                        ![coordination-hist-by-structure-and-element]                         |
+| [`coordination_vs_cutoff_line(struct_dict, strategy=None)`](pymatviz/coordination/plotly.py) | [`coordination_vs_cutoff_line(struct_dict, strategy=None)`](pymatviz/coordination/plotly.py) |
+|                               ![coordination-vs-cutoff-single]                               |                              ![coordination-vs-cutoff-multiple]                              |
 
 [coordination-hist-single]: assets/coordination-hist-single.svg
 [coordination-hist-by-structure-and-element]: assets/coordination-hist-by-structure-and-element.svg

--- a/tests/coordination/test_helpers.py
+++ b/tests/coordination/test_helpers.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+from pymatgen.analysis.local_env import CrystalNN, VoronoiNN
+from pymatgen.core import Lattice, Structure
+
+from pymatviz.coordination.helpers import (
+    CnSplitMode,
+    calculate_average_cn,
+    normalize_get_neighbors,
+)
+from pymatviz.enums import LabelEnum
+
+
+def test_cn_split_mode_values() -> None:
+    """Test that CnSplitMode enum has the expected values."""
+    assert issubclass(CnSplitMode, LabelEnum)
+    assert CnSplitMode.none.value == "none"
+    assert CnSplitMode.by_element.value == "by element"
+    assert CnSplitMode.by_structure.value == "by structure"
+    assert CnSplitMode.by_structure_and_element.value == "by structure and element"
+
+
+def test_normalize_get_neighbors_with_float() -> None:
+    """Test normalize_get_neighbors with float cutoff."""
+    # Create a simple cubic structure
+    lattice = Lattice.cubic(4.0)
+    struct = Structure(lattice, ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+
+    get_neighbors = normalize_get_neighbors(strategy=3.5)
+    neighbors = get_neighbors(struct[0], struct)
+
+    assert len(neighbors) == 8  # Simple cubic should have 8 nearest neighbors
+
+
+def test_normalize_get_neighbors_with_nn_instance() -> None:
+    """Test normalize_get_neighbors with NearNeighbors instance."""
+    struct = Structure(Lattice.cubic(4.0), ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+
+    voronoi = VoronoiNN()
+    get_neighbors = normalize_get_neighbors(strategy=voronoi)
+    neighbors = get_neighbors(struct[0], struct)
+
+    assert isinstance(neighbors, list)
+    assert all(isinstance(n, dict) for n in neighbors)
+
+
+def test_normalize_get_neighbors_with_nn_class() -> None:
+    """Test normalize_get_neighbors with NearNeighbors class."""
+    lattice = Lattice.cubic(4.0)
+    struct = Structure(lattice, ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+
+    get_neighbors = normalize_get_neighbors(strategy=CrystalNN)
+    neighbors = get_neighbors(struct[0], struct)
+
+    assert isinstance(neighbors, list)
+    assert all(isinstance(n, dict) for n in neighbors)
+
+
+def test_normalize_get_neighbors_invalid_input() -> None:
+    """Test normalize_get_neighbors with invalid input."""
+    with pytest.raises(TypeError, match="Invalid strategy="):
+        normalize_get_neighbors(strategy="invalid")
+
+
+def test_calculate_average_cn() -> None:
+    """Test calculate_average_cn function."""
+    # Create a simple cubic structure where Na should have 6 neighbors
+    lattice = Lattice.cubic(4.0)
+    struct = Structure(
+        lattice,
+        ["Na", "Na", "Cl", "Cl"],
+        [[0, 0, 0], [0.5, 0, 0], [0.5, 0.5, 0.5], [0, 0.5, 0.5]],
+    )
+
+    get_neighbors = normalize_get_neighbors(strategy=3.0)
+    avg_cn = calculate_average_cn(struct, "Na", get_neighbors)
+
+    assert avg_cn == 6.0  # Each Na should have 6 neighbors in simple cubic
+
+
+def test_calculate_average_cn_empty_element() -> None:
+    """Test calculate_average_cn with non-existent element."""
+    lattice = Lattice.cubic(4.0)
+    structure = Structure(lattice, ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+
+    get_neighbors = normalize_get_neighbors(strategy=3.0)
+    avg_cn = calculate_average_cn(structure, "K", get_neighbors)
+
+    assert avg_cn == 0  # No K atoms in structure

--- a/tests/coordination/test_plotly.py
+++ b/tests/coordination/test_plotly.py
@@ -8,12 +8,9 @@ from pymatgen.analysis.local_env import CrystalNN, NearNeighbors, VoronoiNN
 from pymatgen.core import Lattice, Structure
 
 from pymatviz.colors import ELEM_COLORS_JMOL
-from pymatviz.coordination import (
-    ElemColorScheme,
-    SplitMode,
-    coordination_hist,
-    coordination_vs_cutoff_line,
-)
+from pymatviz.coordination import coordination_hist, coordination_vs_cutoff_line
+from pymatviz.coordination.helpers import CnSplitMode
+from pymatviz.enums import ElemColorScheme
 
 
 if TYPE_CHECKING:
@@ -52,18 +49,18 @@ def test_coordination_hist_multiple_structures(structures: Sequence[Structure]) 
     assert len(fig.data) == expected_traces
 
 
-@pytest.mark.parametrize("split_mode", list(SplitMode))
+@pytest.mark.parametrize("split_mode", list(CnSplitMode))
 def test_coordination_hist_split_modes(
-    structures: Sequence[Structure], split_mode: SplitMode
+    structures: Sequence[Structure], split_mode: CnSplitMode
 ) -> None:
     """Test coordination_hist with different split modes."""
     fig = coordination_hist(structures[0], split_mode=split_mode)
 
-    if split_mode in (SplitMode.none, SplitMode.by_element):
+    if split_mode in (CnSplitMode.none, CnSplitMode.by_element):
         assert len(fig.data) == len({site.specie.symbol for site in structures[0]})
-    elif split_mode == SplitMode.by_structure:
+    elif split_mode == CnSplitMode.by_structure:
         assert len(fig.data) == 1
-    elif split_mode == SplitMode.by_structure_and_element:
+    elif split_mode == CnSplitMode.by_structure_and_element:
         assert len(fig.data) == len({site.specie.symbol for site in structures[0]})
 
 
@@ -93,7 +90,7 @@ def test_coordination_hist_custom_strategy(
     assert len(fig_multi.data) >= len(fig.data)
 
     # Test different split modes
-    for split_mode in SplitMode:
+    for split_mode in CnSplitMode:
         fig_split = coordination_hist(
             structures[:2], strategy=strategy, split_mode=split_mode
         )
@@ -263,14 +260,14 @@ def test_coordination_hist_subplot_layout(structures: Sequence[Structure]) -> No
     struct_dict = {f"s{i}": struct for i, struct in enumerate(structures[:3])}
 
     # Test by_structure layout
-    fig = coordination_hist(struct_dict, split_mode=SplitMode.by_structure)
+    fig = coordination_hist(struct_dict, split_mode=CnSplitMode.by_structure)
     assert len(fig.layout.annotations) == len(struct_dict)  # subplot titles
 
     # Test by_element layout
     elements = {
         site.specie.symbol for struct in struct_dict.values() for site in struct
     }
-    fig_elem = coordination_hist(struct_dict, split_mode=SplitMode.by_element)
+    fig_elem = coordination_hist(struct_dict, split_mode=CnSplitMode.by_element)
     assert len(fig_elem.layout.annotations) == len(elements)
 
 


### PR DESCRIPTION
slightly breaking since `SplitMode` was renamed to `CnSplitMode` for clarity (very new module though, so likely no one affected)