### PR TITLE
Fix `phonon_bands` for band structures with different paths in k-space

### DIFF
--- a/pymatviz/typing.py
+++ b/pymatviz/typing.py
@@ -37,6 +37,9 @@ T = TypeVar("T")  # generic type for input validation
 P = ParamSpec("P")  # generic type for function parameters
 R = TypeVar("R")  # generic type for return value
 
+SetMode: TypeAlias = Literal["union", "intersection", "strict"]
+SET_MODE = SET_UNION, SET_INTERSECTION, SET_STRICT = get_args(SetMode)
+
 
 VALID_FIG_TYPES = get_args(AxOrFig)
 VALID_FIG_NAMES: str = " | ".join(


### PR DESCRIPTION
- breaking: `branch_mode` renamed to `path_mode` in `phonon_bands()`
- Add new `"strict"` option to `path_mode` for handling k-path mismatches
- Fix issue where k-path segments were incorrectly overlaid when band structures had different paths (unseen k-path segments are now appended to the right edge of the band structure plot)
- Add more unit tests for `path_mode` functionality
