### PR TITLE
`structure_(2|3)d_plotly` now support ASE Atoms and sequences of them

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.0
+    rev: v0.9.1
     hooks:
       - id: ruff
         args: [--fix]
@@ -65,7 +65,7 @@ repos:
         exclude: ^(site/src/figs/.+\.svelte|data/wbm/20.+\..+|site/src/(routes|figs).+\.(yaml|json)|changelog.md)$
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.17.0
+    rev: v9.18.0
     hooks:
       - id: eslint
         types: [file]

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -1,4 +1,4 @@
-"""I/O utilities for saving figures and dataframes to various image formats."""
+"""I/O utilities for saving figures and dataframes to various image formats."""  # noqa: A005
 
 from __future__ import annotations
 

--- a/pymatviz/structure_viz/plotly.py
+++ b/pymatviz/structure_viz/plotly.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
     from typing import Any, Literal
 
+    import ase.atoms
     import plotly.graph_objects as go
     from pymatgen.core import PeriodicSite, Structure
 
@@ -39,7 +40,10 @@ if TYPE_CHECKING:
 
 
 def structure_2d_plotly(
-    struct: Structure | Sequence[Structure],
+    struct: Structure
+    | Sequence[Structure]
+    | ase.atoms.Atoms
+    | Sequence[ase.atoms.Atoms],
     *,
     rotation: str = "10x,8y,3z",
     atomic_radii: float | dict[str, float] | None = None,
@@ -310,7 +314,10 @@ def structure_2d_plotly(
 
 
 def structure_3d_plotly(
-    struct: Structure | Sequence[Structure],
+    struct: Structure
+    | Sequence[Structure]
+    | ase.atoms.Atoms
+    | Sequence[ase.atoms.Atoms],
     *,
     atomic_radii: float | dict[str, float] | None = None,
     atom_size: float = 20,

--- a/pymatviz/sunburst.py
+++ b/pymatviz/sunburst.py
@@ -5,7 +5,7 @@ E.g. for crystal symmetry distributions.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pandas as pd
 import plotly.express as px
@@ -18,15 +18,17 @@ from pymatviz.enums import Key
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Any, Literal
+    from typing import Any
 
     import plotly.graph_objects as go
+
+ShowCounts = Literal["value", "percent", "value+percent", False]
 
 
 def spacegroup_sunburst(
     data: Sequence[int | str] | pd.Series,
     *,
-    show_counts: Literal["value", "percent", False] = False,
+    show_counts: ShowCounts = "value",
     **kwargs: Any,
 ) -> go.Figure:
     """Generate a sunburst plot with crystal systems as the inner ring for a list of
@@ -38,8 +40,8 @@ def spacegroup_sunburst(
     Args:
         data (list[int] | pd.Series): A sequence (list, tuple, pd.Series) of
             space group strings or numbers (from 1 - 230) or pymatgen structures.
-        show_counts ("value" | "percent" | False): Whether to display values below each
-            labels on the sunburst.
+        show_counts ("value" | "percent" | "value+percent" | False): Whether to display
+            values below each labels on the sunburst.
         color_discrete_sequence (list[str]): A list of 7 colors, one for each crystal
             system. Defaults to plotly.express.colors.qualitative.G10.
         **kwargs: Additional keyword arguments passed to plotly.express.sunburst.
@@ -82,8 +84,15 @@ def spacegroup_sunburst(
         fig.data[0].textinfo = "label+percent entry"
     elif show_counts == "value":
         fig.data[0].textinfo = "label+value"
+        fig.data[0].texttemplate = "%{label}<br>N=%{value}"
+    elif show_counts == "value+percent":
+        fig.data[0].textinfo = "label+value+percent entry"
+        fig.data[0].texttemplate = "%{label}<br>N=%{value}<br>%{percentEntry}"
     elif show_counts is not False:
-        raise ValueError(f"Invalid {show_counts=}")
+        raise ValueError(
+            f"Invalid {show_counts=}, must be 'value', 'percent', 'value+percent', "
+            "or False"
+        )
 
     fig.layout.margin = dict(l=10, r=10, b=10, pad=10)
     fig.layout.paper_bgcolor = "rgba(0, 0, 0, 0)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ def spg_symbols() -> list[str]:
 
 
 @pytest.fixture
-def structures() -> list[Structure]:
+def structures() -> tuple[Structure, Structure]:
     coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
     lattice = [[3.8, 0, 0], [1.9, 3.3, 0], [0, -2.2, 3.1]]
     si2_struct = Structure(lattice, ["Si4+", "Si4+"], coords)
@@ -89,7 +89,7 @@ def structures() -> list[Structure]:
     ]
     lattice = Lattice.tetragonal(4.192, 6.88)
     si2_ru2_pr2_struct = Structure(lattice, "Si Si Ru Ru Pr Pr".split(), coords)
-    return [si2_struct, si2_ru2_pr2_struct]
+    return si2_struct, si2_ru2_pr2_struct
 
 
 @pytest.fixture

--- a/tests/structure_viz/test_structure_viz_plotly.py
+++ b/tests/structure_viz/test_structure_viz_plotly.py
@@ -537,3 +537,38 @@ def test_hover_text(
             assert re.search(
                 rf"Coordinates \({re_3_coords}\) \[{re_3_coords}\]", site_hover_text
             ), f"{site_hover_text=}"
+
+
+@pytest.mark.parametrize(
+    "plot_function", [pmv.structure_2d_plotly, pmv.structure_3d_plotly]
+)
+def test_structure_plotly_ase_atoms(
+    plot_function: Callable[[Structure], go.Figure], structures: list[Structure]
+) -> None:
+    """Test that structure_2d_plotly works with ASE Atoms."""
+    pytest.importorskip("ase")
+
+    pmg_struct = structures[0]
+    # Create a simple ASE Atoms object
+
+    # Test single Atoms object
+    fig_ase = plot_function(pmg_struct.to_ase_atoms())
+    assert isinstance(fig_ase, go.Figure)
+
+    # Test equivalence with pymatgen Structure
+    fig_pmg = plot_function(pmg_struct)
+
+    # Compare figures
+    for trace_ase, trace_pmg in zip(fig_ase.data, fig_pmg.data, strict=True):
+        assert trace_ase.type == trace_pmg.type, f"{trace_ase.type=}, {trace_pmg.type=}"
+        assert trace_ase.mode == trace_pmg.mode, f"{trace_ase.mode=}, {trace_pmg.mode=}"
+        assert trace_ase.name == trace_pmg.name, f"{trace_ase.name=}, {trace_pmg.name=}"
+        n_x_ase, n_y_ase = len(trace_ase.x), len(trace_ase.y)
+        n_x_pmg, n_y_pmg = len(trace_pmg.x), len(trace_pmg.y)
+        assert n_x_ase == n_x_pmg, f"{n_x_ase=}, {n_x_pmg=}"
+        assert n_y_ase == n_y_pmg, f"{n_y_ase=}, {n_y_pmg=}"
+
+    # Test sequence of Atoms objects
+    atoms_list = [struct.to_ase_atoms() for struct in structures]
+    fig = plot_function(atoms_list)
+    assert isinstance(fig, go.Figure)

--- a/tests/test_sunburst.py
+++ b/tests/test_sunburst.py
@@ -1,43 +1,78 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, get_args
 
+import pandas as pd
 import plotly.graph_objects as go
 import pytest
 
-from pymatviz.sunburst import spacegroup_sunburst
+import pymatviz as pmv
+from pymatviz.sunburst import ShowCounts, spacegroup_sunburst
 
 
 if TYPE_CHECKING:
-    from typing import Literal
-
     from pymatgen.core import Structure
 
 
-@pytest.mark.parametrize("show_counts", ["value", "percent", False])
-def test_spacegroup_sunburst(
-    spg_symbols: list[str],
-    structures: list[Structure],
-    show_counts: Literal["value", "percent", False],
-) -> None:
+@pytest.mark.parametrize("show_counts", get_args(ShowCounts))
+def test_spacegroup_sunburst(show_counts: ShowCounts) -> None:
     # spg numbers
     fig = spacegroup_sunburst(range(1, 231), show_counts=show_counts)
 
     assert isinstance(fig, go.Figure)
-    assert set(fig.data[0].parents) == {
-        "",
-        "cubic",
-        "trigonal",
-        "triclinic",
-        "orthorhombic",
-        "tetragonal",
-        "hexagonal",
-        "monoclinic",
-    }
+    assert set(fig.data[0].parents) == {"", *get_args(pmv.typing.CrystalSystem)}
     assert fig.data[0].branchvalues == "total"
 
-    # spg symbols
-    spacegroup_sunburst(spg_symbols, show_counts=show_counts)
+    if show_counts == "value":
+        assert "texttemplate" in fig.data[0]
+        assert "N=" in fig.data[0].texttemplate
 
-    # pmg structures
-    spacegroup_sunburst(structures, show_counts=show_counts)
+    elif show_counts == "value+percent":
+        assert "texttemplate" in fig.data[0]
+        assert "N=" in fig.data[0].texttemplate
+        assert "percentEntry" in fig.data[0].texttemplate
+
+    elif show_counts == "percent":
+        assert "textinfo" in fig.data[0]
+        assert "percent" in fig.data[0].textinfo
+
+    elif show_counts is False:
+        assert fig.data[0].textinfo is None
+
+
+def test_spacegroup_sunburst_invalid_show_counts() -> None:
+    """Test that invalid show_counts values raise ValueError."""
+    show_counts = "invalid"
+    with pytest.raises(ValueError, match=f"Invalid {show_counts=}"):
+        spacegroup_sunburst([1], show_counts=show_counts)  # type: ignore[arg-type]
+
+
+def test_spacegroup_sunburst_single_item() -> None:
+    """Test with single-item input."""
+    fig = spacegroup_sunburst([1], show_counts="value")
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data[0].ids) == 2  # one for crystal system, one for spg number
+
+    fig = spacegroup_sunburst(["P1"], show_counts="value+percent")
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data[0].ids) == 2
+
+
+def test_spacegroup_sunburst_other_types(
+    spg_symbols: list[str], structures: list[Structure]
+) -> None:
+    """Test with other types of input."""
+    # test with pandas series
+    series = pd.Series([*[1] * 3, *[2] * 10, *[3] * 5])
+    fig = spacegroup_sunburst(series, show_counts="value")
+    assert isinstance(fig, go.Figure)
+    values = [*map(int, fig.data[0].values)]
+    assert values == [3, 10, 5, 5, 13], f"actual {values=}"
+
+    # test with strings of space group symbols
+    fig = spacegroup_sunburst(spg_symbols)
+    assert isinstance(fig, go.Figure)
+
+    # test with pymatgen structures
+    fig = spacegroup_sunburst(structures)
+    assert isinstance(fig, go.Figure)


### PR DESCRIPTION
previously only (nested) `pymatgen.Structure` supported

- via improved `get_structures` function to handle ASE Atoms detection and conversion
- new test cases to validate single and multiple ASE Atoms work in `structure_2d_plotly` and `structure_3d_plotly`
- add show_counts="value+percent" option to spacegroup_sunburst