### PR TITLE
Remove hard-coded `gridsize` in `density_hexbin`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.3
     hooks:
       - id: ruff
         args: [--fix]
@@ -40,7 +40,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
       - id: codespell
         stages: [pre-commit, commit-msg]
@@ -80,7 +80,7 @@ repos:
           - "@stylistic/eslint-plugin"
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.391
+    rev: v1.1.392.post0
     hooks:
       - id: pyright
 

--- a/assets/scripts/scatter/density_hexbin.py
+++ b/assets/scripts/scatter/density_hexbin.py
@@ -13,5 +13,6 @@ ax = pmv.density_hexbin(
     dummy_data.y_pred,
     dummy_data.y_true,
     best_fit_line={"annotate_params": {"loc": "lower center"}},
+    gridsize=40,
 )
 pmv.io.save_and_compress_svg(ax, "density-scatter-hex")

--- a/pymatviz/scatter.py
+++ b/pymatviz/scatter.py
@@ -465,7 +465,9 @@ def density_hexbin(
     ax = ax or plt.gca()
 
     # the scatter plot
-    hexbin = ax.hexbin(xs, ys, gridsize=gridsize, mincnt=1, bins="log", C=weights, **kwargs)
+    hexbin = ax.hexbin(
+        xs, ys, gridsize=gridsize, mincnt=1, bins="log", C=weights, **kwargs
+    )
 
     cb_ax = ax.inset_axes(cbar_coords)
     plt.colorbar(hexbin, cax=cb_ax)

--- a/pymatviz/scatter.py
+++ b/pymatviz/scatter.py
@@ -423,6 +423,7 @@ def density_hexbin(
     df: pd.DataFrame | None = None,
     ax: plt.Axes | None = None,
     weights: ArrayLike | None = None,
+    gridsize: int = 75,
     identity_line: bool | dict[str, Any] = True,
     best_fit_line: bool | dict[str, Any] = True,
     xlabel: str = "Actual",
@@ -443,6 +444,8 @@ def density_hexbin(
         weights (array, optional): If given, these values are accumulated in the bins.
             Otherwise, every point has value 1. Must be of the same length as x and y.
             Defaults to None.
+        gridsize (int, optional): Number of hexagons in the x and y directions.
+            Defaults to 75.
         identity_line (bool | dict[str, Any], optional): Whether to add an parity line
             (y = x). Defaults to True. Pass a dict to customize line properties.
         best_fit_line (bool | dict[str, Any], optional): Whether to add a best-fit line.
@@ -462,7 +465,7 @@ def density_hexbin(
     ax = ax or plt.gca()
 
     # the scatter plot
-    hexbin = ax.hexbin(xs, ys, gridsize=75, mincnt=1, bins="log", C=weights, **kwargs)
+    hexbin = ax.hexbin(xs, ys, gridsize=gridsize, mincnt=1, bins="log", C=weights, **kwargs)
 
     cb_ax = ax.inset_axes(cbar_coords)
     plt.colorbar(hexbin, cax=cb_ax)

--- a/pymatviz/scatter.py
+++ b/pymatviz/scatter.py
@@ -488,6 +488,7 @@ def density_hexbin(
     pmv.powerups.annotate_metrics(xs, ys, fig=ax, loc="upper left")
 
     ax.set(xlabel=xlabel, ylabel=ylabel)
+    ax.set_aspect("equal")
 
     return ax
 

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -78,19 +78,29 @@ def test_density_scatter_with_hist(df_or_arrays: DfOrArrays) -> None:
 
 
 @pytest.mark.parametrize(
-    ("cbar_label", "cbar_coords"),
-    [("foo", (0.95, 0.03, 0.03, 0.7)), (None, (1, 1, 1, 1))],
+    ("cbar_label", "cbar_coords", "gridsize"),
+    [("foo", (0.95, 0.03, 0.03, 0.7), 50), (None, (1, 1, 1, 1), 100)],
 )
 def test_density_hexbin(
     df_or_arrays: DfOrArrays,
     cbar_label: str | None,
     cbar_coords: tuple[float, float, float, float],
+    gridsize: int,
 ) -> None:
     df, x, y = df_or_arrays
     ax = pmv.density_hexbin(
-        df=df, x=x, y=y, cbar_label=cbar_label, cbar_coords=cbar_coords
+        df=df,
+        x=x,
+        y=y,
+        cbar_label=cbar_label,
+        cbar_coords=cbar_coords,
+        gridsize=gridsize,
     )
     assert isinstance(ax, plt.Axes)
+
+    assert len(ax.collections) == 1
+    hexbin = ax.collections[0]
+    assert len(hexbin.get_offsets()) > 0
 
 
 def test_density_hexbin_with_hist(df_or_arrays: DfOrArrays) -> None:

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -8,15 +8,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 import pytest
 
-from pymatviz.scatter import (
-    density_hexbin,
-    density_hexbin_with_hist,
-    density_scatter,
-    density_scatter_plotly,
-    density_scatter_with_hist,
-    residual_vs_actual,
-    scatter_with_err_bar,
-)
+import pymatviz as pmv
 from tests.conftest import df_regr, np_rng
 
 
@@ -48,7 +40,7 @@ def test_density_scatter_mpl(
     kwargs: dict[str, Any],
 ) -> None:
     df, x, y = df_or_arrays
-    ax = density_scatter(
+    ax = pmv.density_scatter(
         df=df,
         x=x,
         y=y,
@@ -68,13 +60,13 @@ def test_density_scatter_raises_on_bad_stats_type(stats: Any) -> None:
 
     vals = [1, 2, 3]
     with pytest.raises(TypeError, match=match):
-        density_scatter(x=vals, y=vals, stats=stats)
+        pmv.density_scatter(x=vals, y=vals, stats=stats)
 
 
 def test_density_scatter_uses_series_name_as_label() -> None:
     x = pd.Series(np_rng.random(5), name="x")
     y = pd.Series(np_rng.random(5), name="y")
-    ax = density_scatter(x=x, y=y, log_density=False)
+    ax = pmv.density_scatter(x=x, y=y, log_density=False)
 
     assert ax.get_xlabel() == "x"
     assert ax.get_ylabel() == "y"
@@ -82,7 +74,7 @@ def test_density_scatter_uses_series_name_as_label() -> None:
 
 def test_density_scatter_with_hist(df_or_arrays: DfOrArrays) -> None:
     df, x, y = df_or_arrays
-    density_scatter_with_hist(df=df, x=x, y=y)
+    pmv.density_scatter_with_hist(df=df, x=x, y=y)
 
 
 @pytest.mark.parametrize(
@@ -95,24 +87,27 @@ def test_density_hexbin(
     cbar_coords: tuple[float, float, float, float],
 ) -> None:
     df, x, y = df_or_arrays
-    density_hexbin(df=df, x=x, y=y, cbar_label=cbar_label, cbar_coords=cbar_coords)
+    ax = pmv.density_hexbin(
+        df=df, x=x, y=y, cbar_label=cbar_label, cbar_coords=cbar_coords
+    )
+    assert isinstance(ax, plt.Axes)
 
 
 def test_density_hexbin_with_hist(df_or_arrays: DfOrArrays) -> None:
     df, x, y = df_or_arrays
-    density_hexbin_with_hist(df=df, x=x, y=y)
+    pmv.density_hexbin_with_hist(df=df, x=x, y=y)
 
 
 def test_scatter_with_err_bar(df_or_arrays: DfOrArrays) -> None:
     df, x, y = df_or_arrays
     err = abs(df[x] - df[y]) if df is not None else abs(x - y)  # type: ignore[operator]
-    scatter_with_err_bar(df=df, x=x, y=y, yerr=err)
-    scatter_with_err_bar(df=df, x=x, y=y, xerr=err)
+    pmv.scatter_with_err_bar(df=df, x=x, y=y, yerr=err)
+    pmv.scatter_with_err_bar(df=df, x=x, y=y, xerr=err)
 
 
 def test_residual_vs_actual(df_or_arrays: DfOrArrays) -> None:
     df, x, y = df_or_arrays
-    residual_vs_actual(df=df, y_true=x, y_pred=y)
+    pmv.residual_vs_actual(df=df, y_true=x, y_pred=y)
 
 
 @pytest.mark.parametrize(
@@ -140,7 +135,7 @@ def test_density_scatter_plotly(
     df, x, y = df_or_arrays
     if df is None:
         return
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=df,
         x=x,
         y=y,
@@ -166,7 +161,7 @@ def test_density_scatter_plotly(
 
 
 def test_density_scatter_plotly_hover_template() -> None:
-    fig = density_scatter_plotly(df=df_regr, x=X_COL, y=Y_COL, log_density=True)
+    fig = pmv.density_scatter_plotly(df=df_regr, x=X_COL, y=Y_COL, log_density=True)
     hover_template = fig.data[0].hovertemplate
     assert "Point Density" in hover_template
     assert "color" not in hover_template  # Ensure log-count values are not displayed
@@ -175,17 +170,17 @@ def test_density_scatter_plotly_hover_template() -> None:
 @pytest.mark.parametrize("stats", [1, (1,), "foo"])
 def test_density_scatter_plotly_raises_on_bad_stats_type(stats: Any) -> None:
     with pytest.raises(TypeError, match="stats must be bool or dict"):
-        density_scatter_plotly(df=df_regr, x=X_COL, y=Y_COL, stats=stats)
+        pmv.density_scatter_plotly(df=df_regr, x=X_COL, y=Y_COL, stats=stats)
 
 
 def test_density_scatter_plotly_empty_dataframe() -> None:
     empty_df = pd.DataFrame({X_COL: [], Y_COL: []})
     with pytest.raises(ValueError, match="input should have multiple elements"):
-        density_scatter_plotly(df=empty_df, x=X_COL, y=Y_COL)
+        pmv.density_scatter_plotly(df=empty_df, x=X_COL, y=Y_COL)
 
 
 def test_density_scatter_plotly_facet() -> None:
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS, x="total_bill", y="tip", facet_col="smoker"
     )
 
@@ -195,7 +190,7 @@ def test_density_scatter_plotly_facet() -> None:
 
 
 def test_density_scatter_plotly_facet_log_density() -> None:
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS, x="total_bill", y="tip", facet_col="smoker", log_density=True
     )
 
@@ -204,7 +199,7 @@ def test_density_scatter_plotly_facet_log_density() -> None:
 
 
 def test_density_scatter_plotly_facet_stats() -> None:
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS, x="total_bill", y="tip", facet_col="smoker", stats=True
     )
 
@@ -216,7 +211,7 @@ def test_density_scatter_plotly_facet_stats() -> None:
 
 
 def test_density_scatter_plotly_facet_best_fit_line() -> None:
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS, x="total_bill", y="tip", facet_col="smoker", best_fit_line=True
     )
 
@@ -230,7 +225,7 @@ def test_density_scatter_plotly_facet_best_fit_line() -> None:
 
 
 def test_density_scatter_plotly_facet_custom_bins() -> None:
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS, x="total_bill", y="tip", facet_col="smoker", n_bins=10
     )
 
@@ -241,7 +236,7 @@ def test_density_scatter_plotly_facet_custom_bins() -> None:
 
 
 def test_density_scatter_plotly_facet_custom_color() -> None:
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS,
         x="total_bill",
         y="tip",
@@ -250,16 +245,15 @@ def test_density_scatter_plotly_facet_custom_color() -> None:
     )
 
     # Check the colorscale is Viridis
-    assert [
-        color for _val, color in fig.layout.coloraxis.colorscale
-    ] == px.colors.sequential.Viridis
+    color_scale = fig.layout.coloraxis.colorscale
+    assert [color for _val, color in color_scale] == px.colors.sequential.Viridis
 
 
 @pytest.mark.parametrize("density", ["kde", "empirical"])
 def test_density_scatter_plotly_facet_density_methods(
     density: Literal["kde", "empirical"],
 ) -> None:
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS, x="total_bill", y="tip", facet_col="smoker", density=density
     )
 
@@ -268,7 +262,7 @@ def test_density_scatter_plotly_facet_density_methods(
 
 
 def test_density_scatter_plotly_facet_size() -> None:
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS, x="total_bill", y="tip", size="size", facet_col="smoker"
     )
 
@@ -277,13 +271,15 @@ def test_density_scatter_plotly_facet_size() -> None:
 
 
 def test_density_scatter_plotly_facet_multiple_categories() -> None:
-    fig = density_scatter_plotly(df=DF_TIPS, x="total_bill", y="tip", facet_col="day")
+    fig = pmv.density_scatter_plotly(
+        df=DF_TIPS, x="total_bill", y="tip", facet_col="day"
+    )
 
     assert len(fig.data) == DF_TIPS["day"].nunique()
 
 
 def test_density_scatter_plotly_facet_identity_line() -> None:
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS, x="total_bill", y="tip", facet_col="smoker", identity_line=True
     )
 
@@ -291,7 +287,7 @@ def test_density_scatter_plotly_facet_identity_line() -> None:
 
 
 def test_density_scatter_plotly_facet_hover_template() -> None:
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS, x="total_bill", y="tip", facet_col="smoker"
     )
 
@@ -303,7 +299,7 @@ def test_density_scatter_plotly_facet_hover_template() -> None:
 def test_density_scatter_plotly_colorbar_kwargs() -> None:
     colorbar_kwargs = {"title": "Custom Title", "thickness": 30, "len": 0.8, "x": 1.1}
 
-    fig = density_scatter_plotly(
+    fig = pmv.density_scatter_plotly(
         df=DF_TIPS, x="total_bill", y="tip", colorbar_kwargs=colorbar_kwargs
     )
 


### PR DESCRIPTION
custom `gridsize` example:

```py
import pymatviz as pmv

dummy_data = pmv.data.regression()
pmv.utils.apply_matplotlib_template()

ax = pmv.density_hexbin(
    dummy_data.y_pred,
    dummy_data.y_true,
    best_fit_line={"annotate_params": {"loc": "lower center"}},
    gridsize=40,
)
```
![density-scatter-hex](https://github.com/user-attachments/assets/6cf596ae-9fe0-4d82-a073-8855a1394c14)

