### PR TITLE
`structure_(2|3)d_plotly` enable gradient-colored bonds

### DIFF
--- a/assets/scripts/structure_viz/structure_3d_plotly.py
+++ b/assets/scripts/structure_viz/structure_3d_plotly.py
@@ -32,9 +32,13 @@ batio3 = Structure(
     species=["Ba", "Ti", "O", "O", "O"],
     coords=[(0, 0, 0), (0.5, 0.5, 0.5), (0.5, 0.5, 0), (0.5, 0, 0.5), (0, 0.5, 0.5)],
 )
+# Add oxidation states to help with bond determination
+batio3.add_oxidation_state_by_element({"Ba": 2, "Ti": 4, "O": -2})
 
 fig = pmv.structure_3d_plotly(
-    batio3, show_unit_cell={"edge": dict(color="white", width=2)}
+    batio3,
+    show_unit_cell={"edge": dict(color="white", width=2)},
+    show_bonds=True,
 )
 fig.show()
 # pmv.io.save_and_compress_svg(fig, "bato3-structure-3d-plotly")

--- a/pymatviz/structure_viz/helpers.py
+++ b/pymatviz/structure_viz/helpers.py
@@ -648,6 +648,8 @@ def draw_bonds(
         ):
             rgb_values = [int(255 * val) for val in color]
             return f"rgb({rgb_values[0]}, {rgb_values[1]}, {rgb_values[2]})"
+        if color is True:  # Handle the case where color is True
+            return "rgb(128, 128, 128)"  # Default to gray
         red, green, blue = to_rgb(color)
         return f"rgb({int(red * 255)}, {int(green * 255)}, {int(blue * 255)})"
 
@@ -742,7 +744,11 @@ def draw_bonds(
 
                 trace_kwargs = dict(
                     mode="lines",
-                    line=dict(width=bond_kwargs.get("width", 2), color=segment_color),
+                    line=dict(
+                        width=bond_kwargs.get("width", 2),
+                        color=segment_color,
+                        dash=bond_kwargs.get("dash"),
+                    ),
                     showlegend=False,
                     hoverinfo="skip",
                     name=f"bond {site_idx}-{neighbor['site_index']} segment "

--- a/pymatviz/structure_viz/plotly.py
+++ b/pymatviz/structure_viz/plotly.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     import plotly.graph_objects as go
     from pymatgen.core import PeriodicSite, Structure
 
-    from pymatviz.typing import RgbColorType
+    from pymatviz.typing import ColorType
 
 
 def structure_2d_plotly(
@@ -48,7 +48,7 @@ def structure_2d_plotly(
     rotation: str = "10x,8y,3z",
     atomic_radii: float | dict[str, float] | None = None,
     atom_size: float = 40,
-    elem_colors: ElemColorScheme | dict[str, RgbColorType] = ElemColorScheme.jmol,
+    elem_colors: ElemColorScheme | dict[str, ColorType] = ElemColorScheme.jmol,
     scale: float = 1,
     show_unit_cell: bool | dict[str, Any] = True,
     show_sites: bool | dict[str, Any] = True,
@@ -70,13 +70,13 @@ def structure_2d_plotly(
 
     Args:
         struct (Structure | Sequence[Structure]): Pymatgen Structure(s) to plot.
-        rotation (str, optional): Euler angles in degrees in the form '10x,20y,30z'
-            describing angle at which to view structure. Defaults to "10x,8y,3z".
+        rotation (str, optional): Rotation angles in degrees in the form '10x,20y,30z'
+            from which to view the structure. Defaults to "10x,8y,3z".
         atomic_radii (float | dict[str, float], optional): Either a scaling factor for
             default radii or map from element symbol to atomic radii. Defaults to None.
         atom_size (float, optional): Scaling factor for atom sizes. Defaults to 40.
-        elem_colors (ElemColorScheme | dict[str, str], optional): Element color scheme
-            or custom color map. Defaults to ElemColorScheme.jmol.
+        elem_colors (ElemColorScheme | dict[str, ColorType], optional): Element color
+            scheme or custom color map. Defaults to ElemColorScheme.jmol.
         scale (float, optional): Scaling of the plotted atoms and lines. Defaults to 1.
         show_unit_cell (bool | dict[str, Any], optional): Whether to plot unit cell. If
             a dict, will be used to customize unit cell appearance. The dict should have
@@ -123,7 +123,7 @@ def structure_2d_plotly(
             values. Defaults to None.
 
     Returns:
-        go.Figure: Plotly figure with the plotted structure(s).
+        go.Figure: Plotly figure showing the 2D structure(s).
     """
     structures = get_structures(struct)
 
@@ -199,6 +199,7 @@ def structure_2d_plotly(
                 col=col,
                 visible_image_atoms=visible_image_atoms,
                 rotation_matrix=rotation_matrix,
+                elem_colors=_elem_colors,
             )
 
         # Plot atoms and vectors
@@ -339,11 +340,11 @@ def structure_3d_plotly(
     *,
     atomic_radii: float | dict[str, float] | None = None,
     atom_size: float = 20,
-    elem_colors: ElemColorScheme | dict[str, RgbColorType] = ElemColorScheme.jmol,
+    elem_colors: ElemColorScheme | dict[str, ColorType] = ElemColorScheme.jmol,
     scale: float = 1,
     show_unit_cell: bool | dict[str, Any] = True,
     show_sites: bool | dict[str, Any] = True,
-    show_image_sites: bool = True,
+    show_image_sites: bool | dict[str, Any] = True,
     show_bonds: bool | NearNeighbors = False,
     site_labels: Literal["symbol", "species", False]
     | dict[str, str]
@@ -414,7 +415,7 @@ def structure_3d_plotly(
             values. Defaults to None.
 
     Returns:
-        go.Figure: Plotly figure with the plotted 3D structure(s).
+        go.Figure: Plotly figure showing the 3D structure(s).
     """
     structures = get_structures(struct)
 
@@ -478,6 +479,7 @@ def structure_3d_plotly(
                 bond_kwargs=bond_kwargs,
                 scene=f"scene{idx}",
                 visible_image_atoms=visible_image_atoms,
+                elem_colors=_elem_colors,
             )
 
         # Plot atoms and vectors

--- a/tests/structure_viz/test_structure_viz_helpers.py
+++ b/tests/structure_viz/test_structure_viz_helpers.py
@@ -560,14 +560,14 @@ def bond_test_structure_extended() -> Structure:
     ("is_3d", "bond_kwargs", "visible_image_atoms"),
     [
         (True, None, None),
-        (True, {"color": "blue", "width": 0.2}, {(1, 1, 1)}),
-        (False, {"color": "red", "width": 2}, {(3.0, 3.0, 3.0)}),
+        (True, {"color": "rgb(0, 0, 255)", "width": 0.2}, {(1, 1, 1)}),
+        (False, {"color": "rgb(255, 0, 0)", "width": 2}, {(3.0, 3.0, 3.0)}),
         (
             True,
-            {"color": "blue", "width": 3, "dash": "dot"},
+            {"color": "rgb(0, 0, 255)", "width": 3, "dash": "dot"},
             {(3.0, 3.0, 3.0), (-3.0, -3.0, -3.0)},
         ),
-        (False, {"color": "green", "width": 1}, None),
+        (False, {"color": "rgb(0, 128, 0)", "width": 1}, None),
     ],
 )
 def test_draw_bonds(


### PR DESCRIPTION
- Add support for gradient bond coloring using interpolating between colors of connected atoms or custom color lists
- handles various color formats and interpolation
- add unit tests for various bond coloring strategies

example:

```py
from matminer.datasets import load_dataset

import pymatviz as pmv
from pymatviz.enums import ElemColorScheme, Key, SiteCoords


df_phonons = load_dataset("matbench_phonons")

fig = pmv.structure_3d_plotly(
    df_phonons[Key.structure].iloc[4].make_supercell(2, in_place=False),
    elem_colors=ElemColorScheme.jmol,
    hover_text=SiteCoords.cartesian_fractional,
    show_bonds=True,
)
fig.show()
```

![Screenshot 2025-03-10 at 3 21 31 PM](https://github.com/user-attachments/assets/cba2314c-0a7f-43c7-a172-1360c839ac0f)
