### PR TITLE
Multi-trace `plotly` powerups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ examples/**/*.pt
 examples/dataset_exploration/**/*.pdf
 gnome
 assets/scripts/pmv-used-by-list-*.yaml*
+.cursor

--- a/assets/scripts/histogram/histogram.py
+++ b/assets/scripts/histogram/histogram.py
@@ -14,8 +14,6 @@ gauss1 = np_rng.normal(5, 4, rand_regression_size)
 gauss2 = np_rng.normal(10, 2, rand_regression_size)
 
 fig = pmv.histogram({"Gaussian 1": gauss1, "Gaussian 2": gauss2}, bins=100)
-for idx in range(len(fig.data)):
-    pmv.powerups.add_ecdf_line(fig, trace_idx=idx)
+pmv.powerups.add_ecdf_line(fig)
 fig.show()
-
-pmv.io.save_and_compress_svg(fig, "histogram-ecdf")
+# pmv.io.save_and_compress_svg(fig, "histogram-ecdf")

--- a/assets/scripts/powerups/plotly_powerups.py
+++ b/assets/scripts/powerups/plotly_powerups.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 
 import pymatviz as pmv
 from pymatviz.powerups.plotly import (
@@ -27,18 +28,11 @@ gauss1 = np_rng.normal(5, 4, rand_regression_size)
 gauss2 = np_rng.normal(10, 2, rand_regression_size)
 
 
-# %%
-fig = pmv.histogram({"Gaussian 1": gauss1, "Gaussian 2": gauss2}, bins=200)
-for idx in range(len(fig.data)):
-    add_ecdf_line(fig, trace_idx=idx)
-fig.show()
-
-
 # %% ECDF line
 fig = pmv.histogram({"Gaussian 1": gauss1, "Gaussian 2": gauss2}, bins=200)
-for idx in range(len(fig.data)):
-    add_ecdf_line(fig, trace_idx=idx)
-fig.layout.title = "Histogram with ECDF Lines"
+add_ecdf_line(fig)
+fig.layout.title.update(text="Histogram with ECDF Lines", x=0.5)
+fig.layout.margin.t = 50
 fig.show()
 
 
@@ -46,15 +40,9 @@ fig.show()
 x = np.logspace(0, 3, 100)
 y = np.exp(x / 100)
 fig = go.Figure(go.Scatter(x=x, y=y, mode="lines+markers"))
-fig.layout.title = "Exponential Growth"
+fig.layout.title.update(text="Exponential Growth", x=0.5)
+fig.layout.margin.t = 50
 fig.layout.updatemenus = [toggle_log_linear_x_axis]
-fig.show()
-
-
-# %% Toggle log/linear y-axis
-fig = go.Figure(go.Scatter(x=x, y=y, mode="lines+markers"))
-fig.layout.title = "Exponential Growth"
-fig.layout.updatemenus = [toggle_log_linear_y_axis]
 fig.show()
 
 
@@ -62,8 +50,10 @@ fig.show()
 t = np.linspace(0, 10, 100)
 x = np.cos(t)
 y = np.sin(t)
+
 fig = go.Figure(go.Scatter(x=x, y=y, mode="lines"))
-fig.layout.title = "Parametric Curve (cos(t), sin(t))"
+fig.layout.title.update(text="Parametric Curve (cos(t), sin(t))", x=0.5)
+fig.layout.margin.t = 50
 fig.layout.updatemenus = [toggle_grid]
 fig.show()
 
@@ -71,9 +61,9 @@ fig.show()
 # %% Toggle colorscale
 z = np.random.default_rng(seed=0).standard_normal((50, 50))
 fig = go.Figure(data=go.Heatmap(z=z))
-fig.layout.title = "Random Heatmap with Colorscale Toggle"
+fig.layout.title.update(text="Random Heatmap with Colorscale Toggle", x=0.5)
+fig.layout.margin.t = 50
 fig.layout.updatemenus = [select_colorscale]
-
 fig.show()
 
 
@@ -81,9 +71,9 @@ fig.show()
 t = np.linspace(0, 10, 50)
 y = np.sin(t)
 fig = go.Figure(go.Scatter(x=t, y=y))
-fig.layout.title = "Sine Wave with Plot Type Toggle"
+fig.layout.title.update(text="Sine Wave with Plot Type Toggle", x=0.5)
+fig.layout.margin.t = 50
 fig.layout.updatemenus = [select_marker_mode]
-
 fig.show()
 
 
@@ -98,7 +88,8 @@ fig = px.scatter(
     hover_name="country",
     size_max=60,
 )
-fig.layout.title = dict(text="Gapminder 2007: GDP per Capita vs Life Expectancy", x=0.5)
+fig.layout.title.update(text="Gapminder 2007: GDP per Capita vs Life Expectancy", x=0.5)
+fig.layout.margin.t = 50
 fig.layout.updatemenus = [
     toggle_log_linear_x_axis | dict(x=1.2, y=0.12, xanchor="right", yanchor="bottom"),
     toggle_log_linear_y_axis | dict(x=1.2, y=0.02, xanchor="right", yanchor="bottom"),
@@ -110,8 +101,134 @@ fig.show()
 # %%
 fig = px.scatter(x=gauss1, y=gauss2)
 pmv.powerups.enhance_parity_plot(fig)
+fig.layout.title.update(x=0.5)
+fig.layout.margin.t = 50
+fig.show()
 
 
 # closer agreement between xs and ys to see stats
 fig = px.scatter(x=np.arange(100), y=np.arange(100) + 10 * np_rng.random(100))
 pmv.powerups.enhance_parity_plot(fig)
+fig.layout.title.update(x=0.5)
+fig.layout.margin.t = 50
+fig.show()
+
+
+# %% Multi-trace parity plot with per-trace stats
+# Create a multi-trace figure with different synthetic datasets
+np_rng = np.random.default_rng(seed=42)
+x1 = np.arange(0, 100)
+y1 = x1 * 0.8 + 5 + np_rng.normal(0, 8, len(x1))  # Linear with positive slope and noise
+x2 = np.arange(0, 100)
+y2 = (
+    100 - x2 * 0.7 + np_rng.normal(0, 10, len(x2))
+)  # Linear with negative slope and noise
+x3 = np.arange(0, 100)
+y3 = x3 + np_rng.normal(0, 20, len(x3))  # Perfect correlation with high noise
+
+
+# %% Multi-trace parity plot with combined stats
+# Use the same data as above but show overall stats
+fig = go.Figure()
+fig.add_scatter(
+    x=x1, y=y1, mode="markers", name="Positive Slope", marker=dict(color="blue")
+)
+fig.add_scatter(
+    x=x2, y=y2, mode="markers", name="Negative Slope", marker=dict(color="red")
+)
+fig.add_scatter(
+    x=x3,
+    y=y3,
+    mode="markers",
+    name="Perfect with Noise",
+    marker=dict(color="green"),
+)
+title = "Multi-trace Parity Plot with Combined Stats"
+fig.update_layout(title=title, xaxis_title="X Values", yaxis_title="Y Values")
+pmv.powerups.enhance_parity_plot(
+    fig,
+    traces=slice(None),
+    annotation_mode="combined",
+    stats=dict(x=0.02, y=0.02, xanchor="left", yanchor="bottom"),
+)
+fig.layout.title.update(x=0.5)
+fig.layout.margin.t = 50
+fig.show()
+
+
+# %% Multi-trace parity plot with custom styling
+# Create a new dataset
+x4 = np.linspace(0, 100, 80)
+y4 = x4 * 1.2 - 10 + np_rng.normal(0, 5, len(x4))
+
+
+# %% Faceted parity plot with 2x1 subplots
+fig = make_subplots(
+    rows=2, cols=1, subplot_titles=["Dataset 1", "Dataset 2"], vertical_spacing=0.1
+)
+
+# Add traces to each subplot
+fig.add_scatter(x=x1, y=y1, mode="markers", name="Dataset 1", row=1, col=1)
+fig.add_scatter(x=x4, y=y4, mode="markers", name="Dataset 2", row=2, col=1)
+
+fig.update_layout(title="Parity Plot with Faceted Subplots", showlegend=False)
+
+# Apply identity lines and best-fit lines to each subplot
+# Note: These will be applied automatically to each subplot
+pmv.powerups.enhance_parity_plot(fig, annotation_mode="per_trace")
+fig.layout.title.update(x=0.5)
+fig.layout.margin.t = 50
+fig.show()
+
+
+# %% Custom regression metrics example
+fig = px.scatter(x=x1, y=y1, title="Parity Plot with Custom Metrics")
+
+# Apply parity plot with custom metrics
+pmv.powerups.enhance_parity_plot(
+    fig,
+    stats=dict(
+        prefix="Model Performance:\n",
+        suffix=f"N={len(x1)}",
+        fmt=".4f",  # More precision
+        x=0.02,
+        y=0.8,
+        xanchor="left",
+        yanchor="bottom",
+    ),
+)
+fig.layout.title.update(x=0.5)
+fig.layout.margin.t = 50
+fig.show()
+
+
+# %% More complex trace filtering example
+# Create multi-trace figure with various marker sizes
+fig = go.Figure()
+# Add points with different marker sizes
+for size, color, name in zip(
+    [5, 10, 15], ["blue", "red", "green"], ["Small", "Medium", "Large"], strict=False
+):
+    # Add different amount of noise based on size
+    noise = np_rng.normal(0, size / 2, 100)
+    fig.add_scatter(
+        x=np.arange(100),
+        y=np.arange(100) + noise,
+        mode="markers",
+        marker=dict(size=size, color=color),
+        name=name,
+    )
+
+fig.update_layout(title="Filter Traces by Marker Properties")
+
+# Add parity plot enhancements only to traces with marker size > 7
+pmv.powerups.enhance_parity_plot(
+    fig,
+    traces=lambda trace: hasattr(trace, "marker")
+    and hasattr(trace.marker, "size")
+    and trace.marker.size > 7,
+    annotation_mode="per_trace",
+)
+fig.layout.title.update(x=0.5)
+fig.layout.margin.t = 50
+fig.show()

--- a/pymatviz/classify/confusion_matrix.py
+++ b/pymatviz/classify/confusion_matrix.py
@@ -114,7 +114,7 @@ def confusion_matrix(
             if len(label) > 15:
                 # Split at space closest to middle
                 mid = len(label) // 2
-                spaces = [i for i, c in enumerate(label) if c == " "]
+                spaces = [idx for idx, char in enumerate(label) if char == " "]
                 if spaces:
                     split_point = min(spaces, key=lambda x: abs(x - mid))
                     label = f"{label[:split_point]}<br>{label[split_point + 1 :]}"  # noqa: PLW2901

--- a/pymatviz/phonons/plotly.py
+++ b/pymatviz/phonons/plotly.py
@@ -63,7 +63,7 @@ def phonon_bands(
         line_kwargs (dict | dict[str, dict] | Callable): Line style configuration. Can
             be one of:
             - A single dict applied to all lines with Plotly line properties
-              (e.g., dict(width=2, color="red", dash="solid"))
+              (e.g. dict(width=2, color="red", dash="solid"))
             - A dict with keys "acoustic" and "optical" containing style dicts for each
               mode type
             - A callable taking (frequencies: np.ndarray, band_idx: int) and returning

--- a/pymatviz/powerups/both.py
+++ b/pymatviz/powerups/both.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -13,7 +13,6 @@ from sklearn.metrics import mean_absolute_percentage_error as mape
 from sklearn.metrics import r2_score
 
 from pymatviz.typing import (
-    BACKENDS,
     MATPLOTLIB,
     PLOTLY,
     VALID_FIG_NAMES,
@@ -32,11 +31,11 @@ from pymatviz.utils import (
 
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Any
-
     from matplotlib.offsetbox import AnchoredText
     from numpy.typing import ArrayLike
+
+TracePredicate = Callable[[go.Scatter], bool]
+TraceSelector = int | slice | Sequence[int] | TracePredicate
 
 
 @validate_fig
@@ -74,7 +73,7 @@ def annotate_metrics(
     """
     if isinstance(metrics, str):
         metrics = [metrics]
-    if not isinstance(metrics, dict | list | tuple | set):
+    if not isinstance(metrics, (dict, list, tuple, set)):
         raise TypeError(
             f"metrics must be dict|list|tuple|set, not {type(metrics).__name__}"
         )
@@ -139,12 +138,12 @@ def add_identity_line(
     fig: go.Figure | plt.Figure | plt.Axes,
     *,
     line_kwargs: dict[str, Any] | None = None,
-    trace_idx: int = 0,
+    traces: TraceSelector = lambda _: True,
     retain_xy_limits: bool = False,
     **kwargs: Any,
-) -> go.Figure:
+) -> go.Figure | plt.Figure | plt.Axes:
     """Add a line shape to the background layer of a plotly figure spanning
-    from smallest to largest x/y values in the trace specified by trace_idx.
+    from smallest to largest x/y values in the trace specified by traces.
 
     Args:
         fig (go.Figure | plt.Figure | plt.Axes): plotly/matplotlib figure or axes to
@@ -152,23 +151,21 @@ def add_identity_line(
         line_kwargs (dict[str, Any], optional): Keyword arguments for customizing the
             line shape will be passed to fig.add_shape(line=line_kwargs). Defaults to
             dict(color="gray", width=1, dash="dash").
-        trace_idx (int, optional): Index of the trace to use for measuring x/y limits.
-            Defaults to 0. Unused if kaleido package is installed and the figure's
-            actual x/y-range can be obtained from fig.full_figure_for_development().
-            Applies only to plotly figures.
+        traces (TraceSelector, optional): Which trace(s) to use for determining
+            the x/y range. Can be int, slice, sequence of ints, or a function that takes
+            a trace and returns True/False. By default, applies to all traces.
         retain_xy_limits (bool, optional): If True, the x/y-axis limits will be retained
             after adding the identity line. Defaults to False.
         **kwargs: Additional arguments are passed to fig.add_shape().
 
     Raises:
         TypeError: If fig is neither a plotly nor a matplotlib figure or axes.
-        ValueError: If fig is a plotly figure and kaleido is not installed and trace_idx
-            is out of range.
+        ValueError: If fig is a plotly figure and no valid traces are found.
 
     Returns:
         Figure: Figure with added identity line.
     """
-    (x_min, x_max), (y_min, y_max) = get_fig_xy_range(fig=fig, trace_idx=trace_idx)
+    (x_min, x_max), (y_min, y_max) = get_fig_xy_range(fig=fig, traces=traces)
 
     if isinstance(fig, plt.Figure | plt.Axes):  # handle matplotlib
         ax = fig if isinstance(fig, plt.Axes) else fig.gca()
@@ -185,14 +182,21 @@ def add_identity_line(
             kwargs.setdefault("row", "all")
             kwargs.setdefault("col", "all")
 
-        line_defaults = dict(color="gray", width=1, dash="dash") | kwargs.pop(
-            "line", {}
-        )
+        # Prepare line properties
+        line_defaults = dict(color="gray", width=1, dash="dash")
+        if "line" in kwargs:
+            line_defaults.update(kwargs.pop("line"))
+        if line_kwargs:
+            line_defaults.update(line_kwargs)
+
         fig.add_shape(
             type="line",
-            **dict(x0=xy_min_min, y0=xy_min_min, x1=xy_max_min, y1=xy_max_min),
+            x0=xy_min_min,
+            y0=xy_min_min,
+            x1=xy_max_min,
+            y1=xy_max_min,
             layer="below",
-            line=line_defaults | (line_kwargs or {}),
+            line=line_defaults,
             **kwargs,
         )
         if retain_xy_limits:
@@ -204,43 +208,125 @@ def add_identity_line(
     raise TypeError(f"{fig=} must be instance of {VALID_FIG_NAMES}")
 
 
+AnnotationMode = Literal["per_trace", "combined", "none"]
+
+
+def _get_valid_traces(
+    fig: go.Figure,
+    traces: TraceSelector,
+    validate_trace: Callable[[go.Scatter], bool] | None = None,
+) -> list[int]:
+    """Helper to get valid trace indices from a trace selector.
+
+    Args:
+        fig: The figure containing traces to filter
+        traces: Trace selector (int, slice, sequence, or callable)
+        validate_trace: Optional function to validate if a trace is usable.
+            If not provided, requires both x and y data.
+
+    Returns:
+        list[int]: valid trace indices
+    """
+    # Select traces
+    selected_traces: list[int] = []
+    if isinstance(traces, int):
+        if 0 <= traces < len(fig.data):
+            selected_traces = [traces]
+        else:
+            raise ValueError(
+                f"Trace index {traces} out of bounds (0-{len(fig.data) - 1})"
+            )
+    elif isinstance(traces, slice):
+        selected_traces = list(range(*traces.indices(len(fig.data))))
+    elif isinstance(traces, (list, tuple)):
+        selected_traces = [idx for idx in traces if 0 <= idx < len(fig.data)]
+        if not selected_traces:
+            valid_range = f"0-{len(fig.data) - 1}"
+            raise ValueError(f"No valid trace indices in {traces}, {valid_range=}")
+    elif callable(traces):
+        selected_traces = [idx for idx, trace in enumerate(fig.data) if traces(trace)]
+        if not selected_traces:
+            raise ValueError("No traces matched the filtering function")
+    else:
+        actual = type(traces).__name__
+        raise TypeError(
+            f"traces must be int, slice, sequence, or callable, got {actual}"
+        )
+
+    # Default validator: trace needs both x and y
+    if validate_trace is None:
+        validate_trace = lambda trace: (
+            hasattr(trace, "x")
+            and hasattr(trace, "y")
+            and trace.x is not None
+            and trace.y is not None
+            and len(trace.x) > 0
+            and len(trace.y) > 0
+        )
+
+    # Filter for traces with valid data according to validator
+    valid_traces = [idx for idx in selected_traces if validate_trace(fig.data[idx])]
+
+    if not valid_traces:
+        raise ValueError("No valid traces with required data found")
+
+    return valid_traces
+
+
+def _get_trace_color(trace: go.Scatter, default_color: str = "navy") -> str:
+    """Extract color from trace, first checking marker then line."""
+    if (
+        hasattr(trace, "marker")
+        and hasattr(trace.marker, "color")
+        and not isinstance(trace.marker.color, list)
+    ):
+        return trace.marker.color
+    if hasattr(trace, "line") and hasattr(trace.line, "color"):
+        return trace.line.color
+    return default_color
+
+
 def add_best_fit_line(
     fig: go.Figure | plt.Figure | plt.Axes,
     *,
     xs: ArrayLike = (),
     ys: ArrayLike = (),
-    trace_idx: int | None = None,
+    traces: TraceSelector = lambda _: True,
     line_kwargs: dict[str, Any] | None = None,
     annotate_params: bool | dict[str, Any] = True,
-    warn: bool = True,
+    annotation_mode: AnnotationMode = "per_trace",
     **kwargs: Any,
-) -> go.Figure:
+) -> go.Figure | plt.Figure | plt.Axes:
     """Add line of best fit according to least squares to a plotly or matplotlib figure.
 
     Args:
         fig (go.Figure | plt.Figure | plt.Axes): plotly/matplotlib figure or axes to
             add the best fit line to.
         xs (array, optional): x-values to use for fitting. Defaults to () which
-            means use the x-values of trace at trace_idx in fig.
+            means use the x-values of traces selected by the traces parameter.
         ys (array, optional): y-values to use for fitting. Defaults to () which
-            means use the y-values of trace at trace_idx in fig.
-        trace_idx (int, optional): Index of the trace to use for measuring x/y values
-            for fitting if xs and ys are not provided. Defaults to 0.
+            means use the y-values of traces selected by the traces parameter.
+        traces (TraceSelector, optional): Which trace(s) to use. Can be int, slice,
+            sequence of ints, or a function that takes a trace and returns True/False.
+            By default, applies to all traces. Only used when xs and ys not provided.
         line_kwargs (dict[str, Any], optional): Keyword arguments for customizing the
             line shape. For plotly, will be passed to fig.add_shape(line=line_kwargs).
             For matplotlib, will be passed to ax.plot(). Defaults to None.
-        annotate_params (dict[str, Any], optional): Pass dict to customize
+        annotate_params (bool | dict[str, Any], optional): Pass dict to customize
             the annotation of the best fit line. Set to False to disable annotation.
             Defaults to True.
-        warn (bool, optional): If True, print a warning if trace_idx is unspecified
-            and the figure has multiple traces. Defaults to True.
+        annotation_mode (AnnotationMode, optional): How to display annotations. Options:
+            - "per_trace": Each selected trace gets its own annotation
+            - "combined": All selected traces get a combined annotation
+            - "none": No annotations shown
+            Defaults to "per_trace".
         **kwargs: Additional arguments are passed to fig.add_shape() for plotly or
             ax.plot() for matplotlib.
 
     Raises:
         TypeError: If fig is neither a plotly nor a matplotlib figure or axes.
         ValueError: If fig is a plotly figure and xs and ys are not provided and
-            trace_idx is out of range.
+            no valid traces are found.
 
     Returns:
         Figure: Figure with added best fit line.
@@ -248,131 +334,196 @@ def add_best_fit_line(
     if not isinstance(fig, VALID_FIG_TYPES):
         raise TypeError(f"{fig=} must be instance of {VALID_FIG_NAMES}")
 
-    backend = PLOTLY if isinstance(fig, go.Figure) else MATPLOTLIB
+    # Determine backend and set up basic styling
+    backend: Backend = PLOTLY if isinstance(fig, go.Figure) else MATPLOTLIB
     default_color = "navy" if luminance(get_font_color(fig)) < 0.7 else "lightskyblue"
-    # let annotate_params override line_color (also used for annotation)
-    line_color = kwargs.setdefault(
+    line_color = kwargs.pop(
         "color",
         annotate_params.get("color", default_color)
         if isinstance(annotate_params, dict)
         else default_color,
     )
 
-    is_faceted = backend == PLOTLY and any(
-        getattr(trace, "xaxis", None) not in ("x", None) for trace in fig.data
-    )
-    if trace_idx is None:
-        n_traces = (
-            len(fig.data) if isinstance(fig, go.Figure) else len(fig.get_children())
+    # Clear existing LS fit annotations for plotly
+    annotation_count = 0
+    if (
+        backend == PLOTLY
+        and hasattr(fig.layout, "annotations")
+        and fig.layout.annotations
+        and any("LS fit: y =" in str(ann.text) for ann in fig.layout.annotations)
+        and annotation_mode != "none"
+    ):
+        # Count existing annotations
+        annotation_count = sum(
+            1 for ann in fig.layout.annotations if "LS fit: y =" in str(ann.text)
         )
-        if n_traces > 1 and warn and not is_faceted:
-            # for a faceted plot, multiple traces are expected so doesn't make sense to
-            # warn even if user may have wanted to specify trace_idx. we can't know
-            warnings.warn(
-                f"add_best_fit_line Warning: {trace_idx=} but figure has {n_traces}"
-                " traces, defaulting to trace_idx=0. Check fig.data[0] to make sure"
-                " this is the expected trace.",
-                stacklevel=2,
-            )
-        trace_idx = 0
+        if annotation_mode == "combined":
+            # Remove all existing annotations when in combined mode
+            fig.layout.annotations = [
+                ann
+                for ann in fig.layout.annotations
+                if "LS fit: y =" not in str(ann.text)
+            ]
 
-    use_custom_data = len(xs) > 0 and len(ys) > 0
+    # Function to add best fit line with annotation
+    def add_fit_line(
+        data_xs: ArrayLike,
+        data_ys: ArrayLike,
+        color: str,
+        xref: str = "x",
+        yref: str = "y",
+    ) -> None:
+        # Calculate line parameters
+        slope, intercept = np.polyfit(data_xs, data_ys, 1)
+        x_min, x_max = min(data_xs), max(data_xs)
+        y0, y1 = slope * x_min + intercept, slope * x_max + intercept
 
-    if backend == MATPLOTLIB:
-        ax = fig if isinstance(fig, plt.Axes) else fig.gca()
-
-        if not use_custom_data:
-            artist = ax.get_children()[trace_idx]
-            if isinstance(artist, plt.Line2D):
-                xs, ys = artist.get_xdata(), artist.get_ydata()
-            else:
-                xs, ys = artist.get_offsets().T
-
-        slope, intercept = np.polyfit(xs, ys, 1)
-        (x_min, x_max), _ = get_fig_xy_range(fig, trace_idx=trace_idx)
-        x0, x1 = x_min, x_max
-        y0, y1 = slope * x0 + intercept, slope * x1 + intercept
-
-        if annotate_params:
-            defaults = dict(loc="lower right", color=line_color)
-            if isinstance(annotate_params, dict):
-                defaults |= annotate_params
-            sign = "+" if intercept >= 0 else "-"
-            annotate(
-                f"LS fit: y = {slope:.2g}x {sign} {abs(intercept):.2g}",
-                fig=fig,
-                **defaults,
-            )
-
-        defaults = dict(alpha=0.7, linestyle="--", zorder=1)
-        ax.axline((x0, y0), (x1, y1), **(defaults | (line_kwargs or {})) | kwargs)
-
-        return fig
-
-    if backend == PLOTLY:
-        # if is_faceted, add line to all subplots
-        traces = fig.data if is_faceted else [fig.data[trace_idx]]
-        annotation_texts = []
-
-        for trace in traces:
-            subplot = trace.xaxis[1:] if trace.xaxis else ""  # 'x2' -> '2', 'x' -> ''
-            xref = f"x{subplot}" if subplot else "x"
-            yref = f"y{subplot}" if subplot else "y"
-
-            _xs, _ys = (xs, ys) if use_custom_data else (trace.x, trace.y)
-
-            slope, intercept = np.polyfit(_xs, _ys, 1)
-
-            x_min, x_max = min(_xs), max(_xs)
-            x0, x1 = x_min, x_max
-            y0, y1 = slope * x0 + intercept, slope * x1 + intercept
-
-            line_kwargs = (
-                (line_kwargs or {})
-                | dict(color=line_color, width=2, dash="dash")
-                | kwargs.pop("line", {})
-            )
-            invalid_kwargs = ("color",)  # for fig.add_shape
-
+        # Add line based on backend
+        if backend == MATPLOTLIB:
+            ax = fig if isinstance(fig, plt.Axes) else fig.gca()
+            mpl_line_defaults = dict(alpha=0.7, linestyle="--", zorder=1, color=color)
+            if line_kwargs:
+                mpl_line_defaults.update(line_kwargs)
+            if kwargs:
+                mpl_line_defaults.update(kwargs)
+            ax.axline((x_min, y0), (x_max, y1), **mpl_line_defaults)
+        else:  # Plotly
+            plotly_line_defaults = dict(color=color, width=2, dash="dash")
+            if line_kwargs:
+                plotly_line_defaults.update(line_kwargs)
             fig.add_shape(
                 type="line",
-                x0=x0,
+                x0=x_min,
                 y0=y0,
-                x1=x1,
+                x1=x_max,
                 y1=y1,
                 xref=xref,
                 yref=yref,
-                line=line_kwargs,
-                **{k: v for k, v in kwargs.items() if k not in invalid_kwargs},
+                line=plotly_line_defaults,
+                **kwargs,
             )
 
-            if annotate_params:
-                sign = "+" if intercept >= 0 else "-"
-                annotation_texts.append(
-                    f"LS fit: y = {slope:.2g}x {sign} {abs(intercept):.2g}"
-                )
+        # Add annotation if requested
+        if not annotate_params or annotation_mode == "none":
+            return
 
-        if annotate_params:
-            defaults = dict(
+        sign = "+" if intercept >= 0 else "-"
+        text = f"LS fit: y = {slope:.2g}x {sign} {abs(intercept):.2g}"
+
+        # Calculate annotation position
+        nonlocal annotation_count  # Use outer variable to track annotation count
+        y_offset = 0.05 * annotation_count
+        annotation_count += 1  # Increment for the next annotation
+
+        if backend == MATPLOTLIB:
+            mpl_anno_defaults = dict(loc="lower right", color=color)
+            if isinstance(annotate_params, dict):
+                mpl_anno_defaults.update(annotate_params)
+            annotate(text, fig=fig, **mpl_anno_defaults)
+        else:  # Plotly
+            plotly_anno_defaults = dict(
                 x=0.98,
-                y=0.02,
+                y=0.02 + y_offset,  # Use cumulative offset
                 xanchor="right",
                 yanchor="bottom",
                 showarrow=False,
-                font=dict(color=line_color),
+                font=dict(color=color),
             )
-            if isinstance(annotate_params, dict):
-                defaults |= annotate_params
 
-            # Use a single string for non-faceted plots, list for faceted plots
-            annotation_text = (
-                annotation_texts[0] if len(annotation_texts) == 1 else annotation_texts
-            )
-            annotate(annotation_text, fig=fig, **defaults)
+            # For faceted plots, set proper references
+            if xref != "x" or yref != "y":
+                plotly_anno_defaults["xref"] = f"{xref} domain"
+                plotly_anno_defaults["yref"] = f"{yref} domain"
+
+            if isinstance(annotate_params, dict):
+                plotly_anno_defaults.update(annotate_params)
+                # Update y-position after applying custom parameters
+                if "y" not in annotate_params:
+                    plotly_anno_defaults["y"] = 0.02 + y_offset
+
+                # Ensure font color is properly set
+                if "color" in annotate_params:
+                    if "font" not in plotly_anno_defaults:
+                        plotly_anno_defaults["font"] = dict()
+                    plotly_anno_defaults["font"]["color"] = annotate_params["color"]  # type: ignore[index]
+
+            annotate(text, fig=fig, **plotly_anno_defaults)
+
+    # CASE 1: Custom data provided directly
+    if len(xs) > 0 and len(ys) > 0:
+        add_fit_line(xs, ys, line_color)
+        return fig
+
+    # CASE 2: Matplotlib - extract data from the selected trace
+    if backend == MATPLOTLIB:
+        ax = fig if isinstance(fig, plt.Axes) else fig.gca()
+        trace_idx = 0 if not isinstance(traces, int) else traces
+        artist = ax.get_children()[trace_idx]
+
+        if isinstance(artist, plt.Line2D):
+            xs, ys = artist.get_xdata(), artist.get_ydata()
+        else:
+            xs, ys = artist.get_offsets().T
+
+        add_fit_line(xs, ys, line_color)
+        return fig
+
+    # Get valid traces for plotly
+    valid_traces = _get_valid_traces(fig, traces, None)
+
+    # Check if this is a faceted plot
+    is_faceted = any(
+        hasattr(trace, "xaxis") and trace.xaxis != "x" for trace in fig.data
+    )
+
+    # CASE 3A: Faceted plotly plot
+    if is_faceted:
+        # Group traces by subplot
+        subplot_groups: dict[str, list[int]] = {}
+        for idx in valid_traces:
+            trace = fig.data[idx]
+            subplot = trace.xaxis if hasattr(trace, "xaxis") and trace.xaxis else "x"
+            if subplot not in subplot_groups:
+                subplot_groups[subplot] = []
+            subplot_groups[subplot].append(idx)
+
+        # Process each subplot
+        for subplot, traces_in_subplot in subplot_groups.items():
+            trace = fig.data[traces_in_subplot[0]]
+            subplot_idx_str = subplot[1:] if len(subplot) > 1 else ""
+            xref, yref = subplot, f"y{subplot_idx_str}" if subplot_idx_str else "y"
+            color = _get_trace_color(trace, "navy")
+            add_fit_line(trace.x, trace.y, color, xref, yref)
 
         return fig
 
-    raise ValueError(f"Unsupported {backend=}. Must be one of {BACKENDS}")
+    # CASE 3B: Combined annotation mode for plotly
+    if annotation_mode == "combined":
+        all_xs = np.concatenate([fig.data[idx].x for idx in valid_traces])
+        all_ys = np.concatenate([fig.data[idx].y for idx in valid_traces])
+        color = (
+            _get_trace_color(fig.data[valid_traces[0]], line_color)
+            if valid_traces
+            else line_color
+        )
+        add_fit_line(all_xs, all_ys, color)
+        return fig
+
+    # CASE 3C: Per-trace annotation mode for plotly
+    processed_traces: set[int] = set()
+    for trace_idx in valid_traces:
+        if trace_idx in processed_traces:
+            continue
+        processed_traces.add(trace_idx)
+
+        trace = fig.data[trace_idx]
+        if len(trace.x) < 2 or len(trace.y) < 2:
+            continue
+
+        color = _get_trace_color(trace, line_color)
+        add_fit_line(trace.x, trace.y, color, "x", "y")
+
+    return fig
 
 
 def enhance_parity_plot(
@@ -382,8 +533,9 @@ def enhance_parity_plot(
     *,
     identity_line: bool | dict[str, Any] = True,
     best_fit_line: bool | dict[str, Any] | None = None,
-    stats: bool | dict[str, Any] = True,
-    trace_idx: int = 0,
+    stats: bool | dict[str, Any] | None = True,
+    traces: TraceSelector = lambda _: True,
+    annotation_mode: AnnotationMode = "combined",
 ) -> AxOrFig:
     """Add parity plot powerups to either a plotly or matplotlib figure, including
     identity line (y=x), best-fit line, and pred vs ref statistics (MAE, R², ...).
@@ -398,52 +550,138 @@ def enhance_parity_plot(
         best_fit_line (bool | dict[str, Any] | None, optional): Whether to add a
             best-fit line. Pass a dict to customize line properties. If None (default),
             will be enabled if R² > 0.3.
-        stats (bool | dict[str, Any], optional): Whether to display a text box with MAE
-            and R². Pass a dict to customize text box properties. Defaults to True.
-        trace_idx (int, optional): Index of the trace to use for measuring x/y values
-            for fitting if xs and ys are not provided. Defaults to 0.
+        stats (bool | dict[str, Any] | None, optional): Whether to display text box(es)
+            with metrics (MAE, R², etc). Pass a dict to customize text box properties,
+            or None to disable. Defaults to True.
+        traces (TraceSelector, optional): Specifies which trace(s) to use. Can be int,
+            slice, sequence of ints, or a function that takes a trace and returns bool.
+            By default, applies to all traces. Only used when xs and ys not provided.
+        annotation_mode (AnnotationMode, optional): How to display metric annotations.
+            Defaults to "combined". Options:
+            - "per_trace": Each selected trace gets its own annotation
+            - "combined": All selected traces are combined into a single annotation
+            - "none": Only add identity line and best-fit line, don't show annotations
 
     Returns:
         plt.Axes | plt.Figure | go.Figure: The enhanced figure.
 
     Raises:
         ValueError: If xs and ys are not provided and fig is not a plotly figure where
-            the data can be directly accessed. matplotlib does not have a consistent way
-            to access the data from an Axes instance, depends on the type of plot.
+            the data can be directly accessed.
     """
-    err_msg = (
-        "this powerup can only get x/y data from the figure directly for plotly "
-        "figures. for matplotlib, pass pass xs and ys explicitly"
-    )
-    if len(xs) == 0:
-        if isinstance(fig, go.Figure):
-            xs = fig.data[trace_idx].x
-        else:
-            raise ValueError(err_msg)
-    if len(ys) == 0:
-        if isinstance(fig, go.Figure):
-            ys = fig.data[trace_idx].y
-        else:
-            raise ValueError(err_msg)
+    # Add identity line if requested
+    if identity_line and fig is not None:
+        identity_kwargs = identity_line if isinstance(identity_line, dict) else {}
+        add_identity_line(fig, traces=traces, **identity_kwargs)
 
-    if identity_line:
-        add_identity_line(
-            fig, **(identity_line if isinstance(identity_line, dict) else {})
+    # Early return if no stats or best-fit line needed and manual data not provided
+    if not stats and best_fit_line is not True and len(xs) == 0 and len(ys) == 0:
+        return fig
+
+    # Case 1: Data provided directly
+    if len(xs) > 0 and len(ys) > 0:
+        # If best_fit_line is None, determine whether to add it based on R²
+        if best_fit_line is None:
+            r2 = r2_score(xs, ys)
+            best_fit_line = r2 > 0.3
+
+        # Add best fit line if requested
+        if best_fit_line and fig is not None:
+            direct_best_fit_kwargs = (
+                {} if isinstance(best_fit_line, bool) else best_fit_line
+            )
+            add_best_fit_line(fig, xs=xs, ys=ys, **direct_best_fit_kwargs)
+
+        # Add stats annotation if requested
+        if stats and annotation_mode != "none" and fig is not None:
+            direct_stats_kwargs = {} if isinstance(stats, bool) else stats
+            annotate_metrics(xs, ys, fig=fig, **direct_stats_kwargs)
+
+        return fig
+
+    # Case 2: Need to extract data from figure
+    if not isinstance(fig, go.Figure):
+        raise TypeError(
+            "this powerup can only get x/y data from the figure directly for plotly "
+            "figures. for matplotlib, pass xs and ys explicitly."
         )
 
-    # if None, set best_fit_line if predictive power seems to warrant it
-    if best_fit_line is None:
-        r2 = r2_score(xs, ys)
-        best_fit_line = r2 > 0.3
+    # Get valid traces
+    valid_traces = _get_valid_traces(fig, traces, None)
 
-    if best_fit_line:
-        best_fit_kwargs = best_fit_line if isinstance(best_fit_line, dict) else {}
-        # default trace_idx=0 to suppress add_best_fit_line ambiguous trace_idx warning
-        best_fit_kwargs.setdefault("trace_idx", trace_idx)
-        add_best_fit_line(fig, xs=xs, ys=ys, **best_fit_kwargs)
+    # Handle different annotation modes
+    if annotation_mode == "combined":
+        # Combine data from all selected traces
+        all_xs = np.concatenate([fig.data[idx].x for idx in valid_traces])
+        all_ys = np.concatenate([fig.data[idx].y for idx in valid_traces])
 
-    if stats:
-        stats_kwargs = stats if isinstance(stats, dict) else {}
-        annotate_metrics(xs, ys, fig=fig, **stats_kwargs)
+        # Add overall best-fit line if requested
+        if best_fit_line is None:
+            r2 = r2_score(all_xs, all_ys)
+            best_fit_line = r2 > 0.3
+
+        if best_fit_line:
+            combined_best_fit_kwargs = (
+                {} if isinstance(best_fit_line, bool) else best_fit_line
+            )
+            add_best_fit_line(fig, xs=all_xs, ys=all_ys, **combined_best_fit_kwargs)
+
+        # Add combined stats annotation if requested
+        if stats and annotation_mode != "none":
+            combined_stats_kwargs = {} if isinstance(stats, bool) else stats
+            annotate_metrics(all_xs, all_ys, fig=fig, **combined_stats_kwargs)
+
+        return fig
+
+    if annotation_mode == "per_trace":
+        all_traced_processed: set[int] = (
+            set()
+        )  # Keep track of processed traces to avoid duplicates
+
+        for trace_idx in valid_traces:
+            if trace_idx in all_traced_processed:
+                continue
+            all_traced_processed.add(trace_idx)
+
+            # Get data for this trace
+            trace = fig.data[trace_idx]
+            trace_xs = np.array(trace.x)
+            trace_ys = np.array(trace.y)
+
+            # Skip if insufficient data
+            if len(trace_xs) < 2 or len(trace_ys) < 2:
+                continue
+
+            # Get color from trace
+            trace_color = _get_trace_color(trace, "navy")
+
+            # Add best fit line if requested
+            if best_fit_line is not False:
+                # Prepare line style
+                if isinstance(best_fit_line, dict):
+                    per_trace_line_style = dict(color=trace_color, width=2, dash="dash")
+                    per_trace_line_style.update(best_fit_line)
+                    add_best_fit_line(
+                        fig, xs=trace_xs, ys=trace_ys, line_kwargs=per_trace_line_style
+                    )
+                else:
+                    add_best_fit_line(
+                        fig,
+                        xs=trace_xs,
+                        ys=trace_ys,
+                        line_kwargs={"color": trace_color},
+                    )
+
+            # Add stats annotation if requested
+            if stats:
+                per_trace_stats_kwargs = {} if isinstance(stats, bool) else stats
+                annotate_metrics(trace_xs, trace_ys, fig=fig, **per_trace_stats_kwargs)
+
+        return fig
+
+    if annotation_mode != "none":
+        raise ValueError(
+            f"Unknown {annotation_mode=}. Must be one of {get_args(AnnotationMode)}"
+        )
 
     return fig

--- a/pymatviz/powerups/both.py
+++ b/pymatviz/powerups/both.py
@@ -400,7 +400,6 @@ def add_best_fit_line(
                 xref=xref,
                 yref=yref,
                 line=plotly_line_defaults,
-                **kwargs,
             )
 
         # Add annotation if requested

--- a/pymatviz/ptable/ptable_plotly.py
+++ b/pymatviz/ptable/ptable_plotly.py
@@ -1135,7 +1135,8 @@ def ptable_heatmap_splits_plotly(
                     # If colorscale is list of colors, convert to proper format
                     n_colors = len(cscale)
                     cscale = [
-                        [i / (n_colors - 1), color] for i, color in enumerate(cscale)
+                        [idx / (n_colors - 1), color]
+                        for idx, color in enumerate(cscale)
                     ]  # type: ignore[assignment]
                 elif not isinstance(cscale, list | tuple):
                     raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ ignore = [
 pydocstyle.convention = "google"
 isort.lines-after-imports = 2
 isort.split-on-trailing-comma = false
+pep8-naming.ignore-names = ["E_kin", "E_pot", "E_tot", "kT"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/tests/classify/test_confusion_matrix.py
+++ b/tests/classify/test_confusion_matrix.py
@@ -434,7 +434,7 @@ def test_confusion_matrix_callable_annotations(sample_conf_mat: np.ndarray) -> N
         assert "Row:" in anno
         assert "Col:" in anno
 
-    # Verify values for a specific cell (e.g., TN = 50)
+    # Verify values for a specific cell (e.g. TN = 50)
     tn_anno = next(
         anno.text
         for anno in fig.layout.annotations

--- a/tests/coordination/test_coordination_plotly.py
+++ b/tests/coordination/test_coordination_plotly.py
@@ -42,7 +42,7 @@ def test_coordination_hist_single_structure(structures: Sequence[Structure]) -> 
 
 def test_coordination_hist_multiple_structures(structures: Sequence[Structure]) -> None:
     """Test coordination_hist with multiple structures."""
-    struct_dict = {f"Structure_{i}": struct for i, struct in enumerate(structures)}
+    struct_dict = {f"Structure_{idx}": struct for idx, struct in enumerate(structures)}
     fig = coordination_hist(struct_dict)
     expected_traces = sum(
         len({site.specie.symbol for site in struct}) for struct in structures
@@ -258,7 +258,7 @@ def test_coordination_hist_hover_text_formatting(
 
 def test_coordination_hist_subplot_layout(structures: Sequence[Structure]) -> None:
     """Test subplot layout in coordination_hist."""
-    struct_dict = {f"s{i}": struct for i, struct in enumerate(structures[:3])}
+    struct_dict = {f"s{idx}": struct for idx, struct in enumerate(structures[:3])}
 
     # Test by_structure layout
     fig = coordination_hist(struct_dict, split_mode=CnSplitMode.by_structure)

--- a/tests/structure_viz/test_structure_viz_helpers.py
+++ b/tests/structure_viz/test_structure_viz_helpers.py
@@ -75,7 +75,7 @@ def test_get_structures(structures: list[Structure]) -> None:
     assert all(isinstance(s, Structure) for s in result.values())
 
     # Test with dict of structures
-    structs_dict = {f"struct{i}": struct for i, struct in enumerate(structures)}
+    structs_dict = {f"struct{idx}": struct for idx, struct in enumerate(structures)}
     result = get_structures(structs_dict)
     assert isinstance(result, dict)
     assert len(result) == len(structures)

--- a/tests/test_brillouin.py
+++ b/tests/test_brillouin.py
@@ -206,7 +206,7 @@ def test_brillouin_zone_3d_subplot_grid(structures: list[Structure]) -> None:
     assert len(fig._grid_ref[0]) == 2  # number of columns
 
     # Test with dict of structures
-    struct_dict = {f"struct_{i}": struct for i, struct in enumerate(structures)}
+    struct_dict = {f"struct_{idx}": struct for idx, struct in enumerate(structures)}
     fig = brillouin_zone_3d(struct_dict, n_cols=1)
     assert isinstance(fig, go.Figure)
     assert len(fig.layout.annotations) == len(struct_dict)

--- a/tests/test_rainclouds.py
+++ b/tests/test_rainclouds.py
@@ -169,7 +169,8 @@ def test_rainclouds_invalid_input(
 
 def test_rainclouds_long_labels(sample_data: dict[str, np.ndarray]) -> None:
     long_labels = {
-        f"Very long label {i}": data for i, (_, data) in enumerate(sample_data.items())
+        f"Very long label {idx}": data
+        for idx, (_, data) in enumerate(sample_data.items())
     }
     fig = pmv.rainclouds(long_labels)
     assert fig.layout.yaxis.tickangle == -90

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -321,13 +321,16 @@ def test_density_scatter_plotly_facet_best_fit_line() -> None:
         df=DF_TIPS, x="total_bill", y="tip", facet_col="smoker", best_fit_line=True
     )
 
-    # Check there are at least 4 shapes (2 identity lines, 2 best fit lines)
-    assert len(fig.layout.shapes) == 4
-    # Check the best fit lines are present with color navy
-    best_fit_lines = [
-        shape for shape in fig.layout.shapes if shape.line.color == "navy"
+    # Check there are shapes (identity and best fit lines)
+    assert len(fig.layout.shapes) == 3
+
+    # Check there are annotations for the best fit lines
+    best_fit_annotations = [
+        anno for anno in fig.layout.annotations if "LS fit: y =" in str(anno.text)
     ]
-    assert len(best_fit_lines) == 2  # One for each facet
+    # Should have one annotation per facet
+    assert len(best_fit_annotations) == 2
+    assert best_fit_annotations[0].font.color == "navy"
 
 
 def test_density_scatter_plotly_facet_custom_bins() -> None:
@@ -462,10 +465,10 @@ def test_colorbar_density_range_and_formatting() -> None:
     y_vals = []
 
     # Create clusters with different densities at specific locations
-    for i, n_pts in enumerate(points_per_cluster):
+    for idx, n_pts in enumerate(points_per_cluster):
         # Create a tight cluster of points at position (i, i)
-        cluster_x = np_rng.normal(i, 0.05, size=n_pts)
-        cluster_y = np_rng.normal(i, 0.05, size=n_pts)
+        cluster_x = np_rng.normal(idx, 0.05, size=n_pts)
+        cluster_y = np_rng.normal(idx, 0.05, size=n_pts)
 
         x_vals.extend(cluster_x)
         y_vals.extend(cluster_y)

--- a/tests/test_xrd.py
+++ b/tests/test_xrd.py
@@ -229,9 +229,9 @@ def test_xrd_pattern_stack_and_kwargs(
         assert actual_rows == expected_rows
         assert actual_cols == expected_cols
 
-        for i, trace in enumerate(fig.data):
-            expected_xaxis = f"x{i + 1 if i > 0 else ''}"
-            expected_yaxis = f"y{i + 1 if i > 0 else ''}"
+        for idx, trace in enumerate(fig.data):
+            expected_xaxis = f"x{idx + 1 if idx > 0 else ''}"
+            expected_yaxis = f"y{idx + 1 if idx > 0 else ''}"
             assert trace.xaxis == expected_xaxis, f"{trace.xaxis=}"
             assert trace.yaxis == expected_yaxis, f"{trace.yaxis=}"
 


### PR DESCRIPTION
in `pymatviz/powerups/both.py` replaced `trace_idx` with `traces` parameter for more flexible selection of multiple traces
- Introduced helper functions for validating and retrieving trace data.
- `enhance_parity_plot`, `add_best_fit_line` and `add_identity_line` now support new trace selection logic
- Improved annotation positioning for multiple traces in `enhance_parity_plot`.
- Updated tests to reflect changes in parameter names and added new tests for color matching and annotation positioning.