### PR TITLE
`spacegroup_sunburst` and `chem_sys_sunburst` add keywords `max_slices: int` and `max_slices_mode: other | none`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ examples/**/*.pt
 examples/dataset_exploration/**/*.pdf
 gnome
 assets/scripts/pmv-used-by-list-*.yaml*
-.cursor
+*.archive
+*.joblib

--- a/assets/scripts/sunburst/chem_sys_sunburst.py
+++ b/assets/scripts/sunburst/chem_sys_sunburst.py
@@ -11,8 +11,7 @@ from pymatviz.enums import Key
 from pymatviz.utils import ROOT
 
 
-# %% Basic examples
-# Example 1: Different grouping modes for the same formulas
+# %% Basic examples: Different grouping modes for the same formulas
 formulas = [
     "Fe2O3",  # binary
     "Fe4O6",  # same as Fe2O3 when group_by="reduced_formula"
@@ -46,7 +45,7 @@ fig = pmv.chem_sys_sunburst(
 fig.show()
 
 
-# Example 2: Complex formulas with fractional occupancies
+# %% Example 2: Complex formulas with fractional occupancies
 complex_formulas = [
     "Pb(Zr0.52Ti0.48)O3",  # PZT with fractional occupancy
     "La0.7Sr0.3MnO3",  # LSMO with fractional composition
@@ -61,7 +60,7 @@ fig = pmv.chem_sys_sunburst(
 fig.show()
 
 
-# %% Load the Ward metallic glass dataset https://pubs.acs.org/doi/10.1021/acs.chemmater.6b04153
+# %% Load the Ward metallic glasses https://pubs.acs.org/doi/10.1021/acs.chemmater.6b04153
 data_path = "ward_metallic_glasses/ward-metallic-glasses.csv.xz"
 df_mg = pd.read_csv(
     f"{ROOT}/examples/dataset_exploration/{data_path}", na_values=()
@@ -71,10 +70,10 @@ fig = pmv.chem_sys_sunburst(
     df_mg[Key.composition],
     group_by="chem_sys",
     show_counts="value+percent",
-    title="Ward Metallic Glass Dataset - Grouped by chemical system",
+    title="Ward Metallic Glasses - Grouped by chemical system",
     color_discrete_sequence=px.colors.qualitative.Set2,
 )
-title = "Ward Metallic Glass Dataset - Grouped by chemical system"
+title = "Ward Metallic Glasses - Grouped by chemical system"
 fig.layout.title = dict(text=f"<b>{title}</b>", x=0.5, y=0.96, font_size=18)
 fig.layout.update(height=500)
 fig.show()
@@ -85,12 +84,46 @@ for key, df_group in df_mg.groupby("gfa_type"):
     fig = pmv.chem_sys_sunburst(
         df_group[Key.composition],
         show_counts="value+percent",
-        title=f"Ward Metallic Glass Dataset - {key} Compositions",
+        title=f"Ward Metallic Glasses - {key} Compositions",
         color_discrete_sequence=px.colors.qualitative.Set2,
     )
-    title = f"Ward Metallic Glass Dataset - {key} Compositions"
+    title = f"Ward Metallic Glasses - {key} Compositions"
     fig.layout.title = dict(text=f"<b>{title}</b>", x=0.5, y=0.96, font_size=18)
     fig.layout.update(height=500)
     fig.show()
-    pmv.io.save_and_compress_svg(fig, "chem-sys-sunburst-ward-bmg")
+    # pmv.io.save_and_compress_svg(fig, "chem-sys-sunburst-ward-bmg")
     break
+
+
+# %% Show only top 3 systems per arity with "Other" slices
+max_slices = 15
+fig = pmv.chem_sys_sunburst(
+    df_mg[Key.composition],
+    group_by="chem_sys",
+    show_counts="value+percent",
+    max_slices=max_slices,
+    max_slices_mode="other",  # combine remaining systems into "Other" slices
+    color_discrete_sequence=px.colors.qualitative.Set2,
+)
+title = f"Ward Metallic Glasses - Top {max_slices} Systems per Arity (with Other)"
+fig.layout.title = dict(text=f"<b>{title}</b>", x=0.5, y=0.96, font_size=18)
+fig.layout.update(height=500)
+fig.show()
+# pmv.io.save_and_compress_svg(fig, "chem-sys-sunburst-ward-bmg-top3-other")
+
+
+# %% Show only top 3 systems per arity, dropping the rest
+max_slices = 12
+fig = pmv.chem_sys_sunburst(
+    df_mg[Key.composition],
+    group_by="chem_sys",
+    show_counts="value+percent",
+    max_slices=max_slices,
+    max_slices_mode="drop",  # discard remaining systems
+    color_discrete_sequence=px.colors.qualitative.Set2,
+)
+title = f"Ward Metallic Glasses<br>Top {max_slices} Systems per Arity (dropped)"
+fig.layout.title = dict(text=f"<b>{title}</b>", x=0.5, y=0.9, font_size=18)
+fig.layout.update(height=500)
+fig.show()
+# pmv.io.save_and_compress_svg(fig, "chem-sys-sunburst-ward-bmg-top3-drop")

--- a/assets/scripts/sunburst/spacegroup_sunburst.py
+++ b/assets/scripts/sunburst/spacegroup_sunburst.py
@@ -31,3 +31,35 @@ title = "Matbench Phonons Spacegroup Symbols Sunburst"
 fig.layout.title = dict(text=f"<b>{title}</b>", x=0.5, y=0.96, font_size=18)
 fig.show()
 # pmv.io.save_and_compress_svg(fig, "spg-symbol-sunburst")
+
+
+# %% Demonstrate max_slices with "other" mode
+# Show only top 3 space groups per crystal system, combine the rest into "Other"
+max_slices = 6
+fig = pmv.spacegroup_sunburst(
+    df_phonons[Key.spg_num],
+    show_counts="value+percent",
+    max_slices=max_slices,
+    max_slices_mode="other",
+)
+title = f"Matbench Phonons Space Groups - Top {max_slices} Crystal Systems (Other Mode)"
+fig.layout.title = dict(text=f"<b>{title}</b>", x=0.5, y=0.96, font_size=18)
+fig.layout.update(height=600)
+fig.show()
+# pmv.io.save_and_compress_svg(fig, "spg-num-sunburst-max-slices-other")
+
+
+# %% Demonstrate max_slices with "drop" mode
+# Show only top 2 space groups per crystal system, discard the rest
+max_slices = 5
+fig = pmv.spacegroup_sunburst(
+    df_phonons[Key.spg_num],
+    show_counts="value+percent",
+    max_slices=max_slices,
+    max_slices_mode="drop",
+)
+title = f"Matbench Phonons Space Groups - Top {max_slices} Crystal Systems (Drop Mode)"
+fig.layout.title = dict(text=f"<b>{title}</b>", x=0.5, y=0.96, font_size=18)
+fig.layout.update(height=600)
+fig.show()
+# pmv.io.save_and_compress_svg(fig, "spg-num-sunburst-max-slices-drop")

--- a/assets/scripts/treemap/chem_sys_treemap.py
+++ b/assets/scripts/treemap/chem_sys_treemap.py
@@ -35,10 +35,8 @@ for group_by in ("formula", "reduced_formula", "chem_sys"):
 
 
 # %% Load the Ward metallic glass dataset https://pubs.acs.org/doi/10.1021/acs.chemmater.6b04153
-data_path = "ward_metallic_glasses/ward-metallic-glasses.csv.xz"
-df_mg = pd.read_csv(
-    f"{ROOT}/examples/dataset_exploration/{data_path}", na_values=()
-).query("comment.isna()")
+csv_path = f"{ROOT}/examples/dataset_exploration/ward_metallic_glasses/ward-metallic-glasses.csv.xz"  # noqa: E501
+df_mg = pd.read_csv(csv_path, na_values=()).query("comment.isna()")
 
 fig = pmv.chem_sys_treemap(
     df_mg[Key.composition],

--- a/readme.md
+++ b/readme.md
@@ -312,7 +312,7 @@ See [`citation.cff`](citation.cff) or cite the [Zenodo record](https://zenodo.or
 
 ## Papers using `pymatviz`
 
-Sorted by number of citations. Last updated 2025-03-15. Auto-generated from Google Scholar. Manual additions via PR welcome.
+Sorted by number of citations. Last updated 2025-03-15. Auto-generated [from Google Scholar](https://scholar.google.com/scholar?q=pymatviz). Manual additions via PR welcome.
 
 1. C Zeni, R Pinsler, D Zügner et al. (2023). [Mattergen: a generative model for inorganic materials design](https://arxiv.org/abs/2312.03687) (cited by 119)
 1. J Riebesell, REA Goodall, P Benner et al. (2023). [Matbench Discovery--A framework to evaluate machine learning crystal stability predictions](https://arxiv.org/abs/2308.14920) (cited by 41)


### PR DESCRIPTION
to limit the number of slices displayed in sunburst plots

- `.gitignore` exclude `.archive` and `.joblib` files
- `readme.md` include hyperlink for Google Scholar citations
- new tests for slice limits in sunburst plots

**example**

```py
import pymatviz as pmv

max_slices = 6
fig = pmv.spacegroup_sunburst(
    df_phonons[Key.spg_num],
    show_counts="value+percent",
    max_slices=max_slices,
    max_slices_mode="other",
)
title = f"Matbench Phonons Space Groups - Top {max_slices} Crystal Systems (Other Mode)"
fig.layout.title = dict(text=f"<b>{title}</b>", x=0.5, y=0.96, font_size=18)
fig.show()
```

![spg-num-sunburst-max-slices-other](https://github.com/user-attachments/assets/15b7d448-d550-426d-ad9a-1cbe0e50bbf8)
