### PR TITLE
`cluster_compositions` add `annotate_points` keyword

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.11.8
     hooks:
       - id: ruff
         args: [--fix]
@@ -67,7 +67,7 @@ repos:
         exclude: ^(site/src/figs/.+\.svelte|data/wbm/20.+\..+|site/src/(routes|figs).+\.(yaml|json)|changelog.md)$
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.24.0
+    rev: v9.26.0
     hooks:
       - id: eslint
         types: [file]
@@ -82,12 +82,12 @@ repos:
           - "@stylistic/eslint-plugin"
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.398
+    rev: v1.1.400
     hooks:
       - id: pyright
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.32.1
+    rev: 0.33.0
     hooks:
       - id: check-jsonschema
         files: ^pymatviz/keys\.yml$

--- a/contributing.md
+++ b/contributing.md
@@ -34,4 +34,4 @@ git commit -m "commit message" # this will trigger the pre-commit hooks
 1. Open a Pull Request against the `main` branch of `janosh/pymatviz`.
 1. Your PR must pass all automated checks (tests, linting, code coverage) that run in our GitHub Actions workflows before it can be merged.
 
-By contributing, you agree that your contributions will be licensed under the same [MIT License](LICENSE) that covers the project. Thanks for contributing to `pymatviz`!
+By contributing, you agree that your contributions will be licensed under the same [MIT License](license) that covers the project. Thanks for contributing to `pymatviz`!

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,37 @@
+# Contributing to pymatviz
+
+Community contributions are very welcome! Whether it's reporting a bug, proposing a feature, or submitting code, your input is valuable.
+
+## Reporting Issues & Requesting Features
+
+- Use the [GitHub Issues](https://github.com/janosh/pymatviz/issues) to report bugs or suggest new features.
+- For bug reports, please include:
+  - A clear description of the issue and the package version you are using.
+  - Steps to reproduce the bug (including a minimal code example).
+  - What you expected vs. what actually happened.
+  - Any relevant error messages or tracebacks.
+
+## Contributing Code via Pull Requests
+
+We strive for a quick turnaround on pull requests (PRs) for bug fixes and new features.
+
+To ensure code quality and consistency, please install and set up `pre-commit` hooks before making commits:
+
+```sh
+pip install pre-commit
+pre-commit install
+git commit -m "commit message" # this will trigger the pre-commit hooks
+```
+
+### Workflow
+
+1. Fork the repository.
+1. Create a new branch for your changes (`git checkout -b your-feature-name`).
+1. Make code changes.
+1. Add tests for any new functionality and fixes.
+1. Update docs if necessary.
+1. Push your branch to your fork (`git push origin your-feature-name`).
+1. Open a Pull Request against the `main` branch of `janosh/pymatviz`.
+1. Your PR must pass all automated checks (tests, linting, code coverage) that run in our GitHub Actions workflows before it can be merged.
+
+By contributing, you agree that your contributions will be licensed under the same [MIT License](LICENSE) that covers the project. Thanks for contributing to `pymatviz`!


### PR DESCRIPTION
```py
cluster_compositions(
    annotate_points: Callable[[pd.Series], str | dict[str, Any] | None] | None = None
)
```

![matbench-dielectric-magpie-pca-2d](https://github.com/user-attachments/assets/b9e7e3b8-240a-4e50-8d14-6c7e5493eb5a)




```py
def annotate_top_points(row: pd.Series) -> dict[str, Any] | None:
    """Annotate top 5 points concisely with composition and property value."""
    # row.name is the original DataFrame index
    if row.name not in top_indices:
        return None
    # Use raw composition string for brevity
    comp_str = row["composition"]
    if len(comp_str) > 20:  # if comp too long, use row ID/ material ID
        comp_str = f"ID: {row.name}"
    else:
        comp_str = htmlify(comp_str).replace(" ", "")
    prop_val = f"{target_symbol}={row[target_label]:.2f}"
    text = f"{comp_str}<br>{prop_val}"
    return dict(text=text, font_size=11, bgcolor="rgba(240, 240, 240, 0.5)")

fig = pmv.cluster_compositions(
    df=df_plot,
    composition_col="composition",
    prop_name=target_label,
    embedding_method="embeddings",
    projection=projection,
    n_components=n_components,
    annotate_points=annotate_top_points,
)
```