### PR TITLE
`structure_(2|3)d_plotly` add `cell_boundary_tol: float | dict[str, float]`

### DIFF
--- a/assets/scripts/phonons/phonon_dos.py
+++ b/assets/scripts/phonons/phonon_dos.py
@@ -10,7 +10,7 @@ from pymatgen.phonon.dos import PhononDos
 
 import pymatviz as pmv
 from pymatviz.phonons.helpers import PhononDBDoc
-from pymatviz.utils.testing import TEST_FILES
+from pymatviz.utils.testing import TEST_FILES, load_phonopy_nacl
 
 
 try:
@@ -41,17 +41,15 @@ for mp_id, formula in (
 
 # %% plotting a phonopy TotalDos also works
 try:
-    import phonopy
+    import phonopy  # noqa: F401
 except ImportError:
     raise SystemExit(0) from None  # install phonopy to run this script
 
-phonopy_nacl = phonopy.load(
-    f"{TEST_FILES}/phonons/NaCl/phonopy_disp.yaml.xz",
-    force_sets_filename=f"{TEST_FILES}/phonons/NaCl/force_sets.dat",
-)
 
+phonopy_nacl = load_phonopy_nacl()
 phonopy_nacl.run_mesh([10, 10, 10])
 phonopy_nacl.run_total_dos()
+
 plt = phonopy_nacl.plot_total_dos()
 plt.title("NaCl DOS plotted by phonopy")
 

--- a/assets/scripts/structure_viz/structure_3d_plotly.py
+++ b/assets/scripts/structure_viz/structure_3d_plotly.py
@@ -161,3 +161,28 @@ fig.update_layout(
 
 fig.show()
 # pmv.io.save_and_compress_svg(fig, "structures-2x2-grid-comprehensive-options")
+
+
+# %% Simple cubic structure to show effect of cell_boundary_tol
+LiF_cubic = Structure(
+    lattice=Lattice.cubic(3.0),
+    species=["Li", "F"],
+    coords=[(0, 0, 0), (0.5, 0.5, 0.5)],
+)
+
+# Show same structure with different cell_boundary_tol values
+cell_boundary_tols = {"Strict boundaries (tol=0)": 0, "Loose (tol=0.5)": 0.5}
+fig = pmv.structure_3d_plotly(
+    dict.fromkeys(cell_boundary_tols, LiF_cubic),
+    cell_boundary_tol=cell_boundary_tols,
+    show_image_sites=True,
+    show_sites=True,
+    site_labels="symbol",
+)
+
+title = "Effect of cell_boundary_tol on Image Site Rendering"
+subtitle = "Higher tolerance values include more atoms outside the unit cell"
+fig.layout.title = dict(text=f"{title}<br><sub>{subtitle}</sub>", x=0.5, font_size=16)
+fig.layout.update(height=600, width=800, margin_t=50)
+
+fig.show()

--- a/examples/notebook_display.py
+++ b/examples/notebook_display.py
@@ -61,13 +61,8 @@ dos = doc.phonon_dos
 bands
 
 
-# %%
-# Phonon DOS auto-renders
+# %% Phonon DOS auto-renders
 dos
-
-
-# %% Combined phonon bands and DOS
-bands, dos
 
 
 # %% Multiple structures
@@ -96,8 +91,7 @@ structures["Hexagonal"]
 structures["Tetragonal"]
 
 
-# %%
-# Manual control (optional) - New unified function
+# %% Manual control (optional) - New unified function
 nacl = Structure(Lattice.cubic(4.0), ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
 pmv.notebook_mode(on=False)  # Disable auto-rendering
 nacl  # Now displays as text
@@ -118,8 +112,7 @@ nacl_xrd = xrd_calc.get_pattern(nacl)
 nacl_xrd  # Auto-renders as XRD pattern plot
 
 
-# %%
-# Additional examples with the unified API
+# %% Additional examples with the unified API
 pmv.notebook_mode(on=False)  # Disable auto-rendering
 nacl  # Now displays as text
 

--- a/examples/notebook_display.py
+++ b/examples/notebook_display.py
@@ -18,7 +18,7 @@ from pymatgen.core import Lattice, Structure
 
 import pymatviz as pmv
 from pymatviz.phonons import PhononDBDoc
-from pymatviz.utils.testing import TEST_FILES
+from pymatviz.utils.testing import TEST_FILES, load_phonopy_nacl
 
 
 # %% Crystal structures auto-render as 3D plots
@@ -63,6 +63,20 @@ bands
 
 # %% Phonon DOS auto-renders
 dos
+
+
+# %% Phonopy DOS objects also auto-render
+try:
+    phonopy_nacl = load_phonopy_nacl()
+    phonopy_nacl.run_mesh([10, 10, 10])
+    phonopy_nacl.run_total_dos()
+    phonopy_dos = phonopy_nacl.total_dos
+
+except ImportError:
+    print("phonopy not available - skipping phonopy DOS example")
+    phonopy_dos = None
+
+phonopy_dos  # Auto-renders as interactive DOS plot (if phonopy is available)
 
 
 # %% Multiple structures

--- a/examples/ricci_carrier_transport/convert_dtype+add_structs.py
+++ b/examples/ricci_carrier_transport/convert_dtype+add_structs.py
@@ -31,8 +31,7 @@ with MPRester() as mpr:
     )
 
 
-# %%
-# get a map from task ID to its structure
+# %% get a map from task ID to its structure
 struct_df = pd.DataFrame(structs).explode(task_ids_key).set_index(task_ids_key)
 
 df_carrier[struct_df.columns] = struct_df

--- a/pymatviz/notebook.py
+++ b/pymatviz/notebook.py
@@ -81,6 +81,9 @@ _phonon_bands_ipython_display_, _phonon_bands_repr_mimebundle_ = (
 _phonon_dos_ipython_display_, _phonon_dos_repr_mimebundle_ = _create_display_methods(
     "phonon_dos"
 )
+_phonopy_dos_ipython_display_, _phonopy_dos_repr_mimebundle_ = _create_display_methods(
+    "phonon_dos"
+)
 
 
 def notebook_mode(*, on: bool) -> None:
@@ -101,6 +104,7 @@ def notebook_mode(*, on: bool) -> None:
     - ASE Atoms -> structure_3d_plotly
     - PhononBandStructureSymmLine -> phonon_bands
     - PhononDos -> phonon_dos
+    - phonopy TotalDos -> phonon_dos
     - DiffractionPattern -> xrd_pattern
     """
     class_configs = [  # Define (import_func, class_obj, display_methods)
@@ -133,6 +137,11 @@ def notebook_mode(*, on: bool) -> None:
             lambda: __import__("pymatgen.phonon.dos", fromlist=["PhononDos"]).PhononDos,
             _phonon_dos_ipython_display_,
             _phonon_dos_repr_mimebundle_,
+        ),
+        (
+            lambda: __import__("phonopy.phonon.dos", fromlist=["TotalDos"]).TotalDos,
+            _phonopy_dos_ipython_display_,
+            _phonopy_dos_repr_mimebundle_,
         ),
     ]
 

--- a/pymatviz/notebook.py
+++ b/pymatviz/notebook.py
@@ -8,8 +8,10 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import plotly.graph_objects as go
 
-def _hide_plotly_toolbar(fig: Any) -> None:
+
+def _hide_plotly_toolbar(fig: go.Figure) -> None:
     """Configure plotly figure to hide toolbar by default for cleaner display."""
     modebar_remove = (
         "pan select lasso zoomIn zoomOut autoScale resetScale3d".split()  # noqa: SIM905
@@ -19,7 +21,7 @@ def _hide_plotly_toolbar(fig: Any) -> None:
 
 def _create_display_methods(
     plot_func_name: str,
-) -> tuple[Callable[..., Any], Callable[..., Any]]:
+) -> tuple[Callable[..., None], Callable[..., dict[str, str]]]:
     """Create IPython display and MIME bundle methods for a given plot function."""
 
     def ipython_display(self: Any) -> None:
@@ -43,8 +45,8 @@ def _create_display_methods(
 
     def repr_mimebundle(
         self: Any,
-        include: set[str] | None = None,  # noqa: ARG001
-        exclude: set[str] | None = None,  # noqa: ARG001
+        include: tuple[str, ...] = (),  # noqa: ARG001
+        exclude: tuple[str, ...] = (),  # noqa: ARG001
     ) -> dict[str, str]:
         """Generic MIME bundle method."""
         try:
@@ -101,8 +103,7 @@ def notebook_mode(*, on: bool) -> None:
     - PhononDos -> phonon_dos
     - DiffractionPattern -> xrd_pattern
     """
-    # Define class configurations: (import_func, class_obj, display_methods)
-    class_configs = [
+    class_configs = [  # Define (import_func, class_obj, display_methods)
         (
             lambda: __import__("pymatgen.core", fromlist=["Structure"]).Structure,
             _structure_ipython_display_,
@@ -143,8 +144,8 @@ def notebook_mode(*, on: bool) -> None:
                 cls._repr_mimebundle_ = repr_mimebundle
             else:
                 if hasattr(cls, "_ipython_display_"):
-                    delattr(cls, "_ipython_display_")
+                    del cls._ipython_display_
                 if hasattr(cls, "_repr_mimebundle_"):
-                    delattr(cls, "_repr_mimebundle_")
+                    del cls._repr_mimebundle_
         except ImportError:
             pass  # Module not available

--- a/pymatviz/structure_viz/helpers.py
+++ b/pymatviz/structure_viz/helpers.py
@@ -129,7 +129,10 @@ def _angles_to_rotation_matrix(
 
 
 def get_image_sites(
-    site: PeriodicSite, lattice: Lattice, tol: float = 0.03, min_dist_dedup: float = 0.1
+    site: PeriodicSite,
+    lattice: Lattice,
+    cell_boundary_tol: float = 0.0,
+    min_dist_dedup: float = 0.1,
 ) -> np.ndarray:
     """Get images for a given site in a lattice.
 
@@ -139,7 +142,10 @@ def get_image_sites(
     Args:
         site (PeriodicSite): The site to get images for.
         lattice (Lattice): The lattice to get images for.
-        tol (float): The tolerance for being near the cell edge. Defaults to 0.03.
+        cell_boundary_tol (float): Distance (in fractional coordinates) beyond the unit
+            cell boundaries to include image atoms. Defaults to 0 for strict cell
+            boundaries (only atoms with 0 <= coord <= 1). Higher values include atoms
+            further outside the cell.
         min_dist_dedup (float): The min distance in Angstroms to any other site to avoid
             finding image atoms that are duplicates of original basis sites. Defaults to
             0.1.
@@ -157,8 +163,11 @@ def get_image_sites(
         new_cart = lattice.get_cartesian_coords(new_frac)
 
         # Check if the new fractional coordinates are within cell bounds
-        tol = max(tol, 0.13)  # Ensure we capture atoms at 0.125 -> 1.125, etc.
-        is_within_extended_cell = all(-tol <= coord <= 1 + tol for coord in new_frac)
+        # Use cell_boundary_tol to control how far outside the cell atoms can be
+        is_within_extended_cell = all(
+            0 - cell_boundary_tol <= coord <= 1 + cell_boundary_tol
+            for coord in new_frac
+        )
 
         # filter sites that are too close to the original to avoid duplicates
         if is_within_extended_cell:
@@ -1015,10 +1024,18 @@ def _standardize_struct(
 
 
 def _prep_augmented_structure_for_bonding(
-    struct_i: Structure, show_image_sites_flag: bool | dict[str, Any]
+    struct_i: Structure,
+    show_image_sites_flag: bool | dict[str, Any],
+    cell_boundary_tol: float = 0.0,
 ) -> Structure:
     """Prepare an augmented structure including primary and optionally image sites for
     bonding.
+
+    Args:
+        struct_i (Structure): System to prepare.
+        show_image_sites_flag: Whether to include image sites.
+        cell_boundary_tol (float): Distance beyond unit cell boundaries within which
+            image atoms are included.
     """
     all_sites_for_bonding = [
         PeriodicSite(
@@ -1034,7 +1051,11 @@ def _prep_augmented_structure_for_bonding(
     if show_image_sites_flag:  # True or a dict implies true for this purpose
         processed_image_coords: set[Xyz] = set()
         for site_in_cell in struct_i:
-            image_cart_coords_arrays = get_image_sites(site_in_cell, struct_i.lattice)
+            image_cart_coords_arrays = get_image_sites(
+                site_in_cell,
+                struct_i.lattice,
+                cell_boundary_tol=cell_boundary_tol,
+            )
             for image_cart_coords_arr in image_cart_coords_arrays:
                 coord_tuple_key = tuple(np.round(image_cart_coords_arr, 5))
                 if coord_tuple_key not in processed_image_coords:

--- a/pymatviz/utils/testing.py
+++ b/pymatviz/utils/testing.py
@@ -2,7 +2,42 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pymatviz.utils import ROOT
 
 
+if TYPE_CHECKING:
+    from phonopy import Phonopy
+
+
 TEST_FILES: str = f"{ROOT}/tests/files"
+
+
+def load_phonopy_nacl() -> Phonopy:
+    """Load phonopy NaCl object from test files.
+
+    Returns a Phonopy class instance of NaCl 2x2x2 without symmetrizing fc2.
+    This function can be used in both tests and examples to get a consistent
+    phonopy object for demonstrations.
+
+    Returns:
+        Phonopy: Loaded phonopy object with force constants.
+
+    Raises:
+        ImportError: If phonopy is not installed.
+
+    Example:
+        >>> phonopy_nacl = load_phonopy_nacl()
+        >>> phonopy_nacl.run_mesh([10, 10, 10])
+        >>> phonopy_nacl.run_total_dos()
+        >>> dos = phonopy_nacl.total_dos
+    """
+    import phonopy
+
+    return phonopy.load(
+        f"{TEST_FILES}/phonons/NaCl/phonopy_disp.yaml.xz",
+        force_sets_filename=f"{TEST_FILES}/phonons/NaCl/force_sets.dat",
+        symmetrize_fc=False,
+        produce_fc=True,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from pymatgen.io.ase import AseAtomsAdaptor
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine as PhononBands
 from pymatgen.phonon.dos import PhononDos
 
-from pymatviz.utils.testing import TEST_FILES
+from pymatviz.utils.testing import TEST_FILES, load_phonopy_nacl
 
 
 if TYPE_CHECKING:
@@ -185,14 +185,7 @@ def _extract_anno_from_fig(fig: go.Figure | plt.Figure) -> str:
 @pytest.fixture(scope="session")
 def phonopy_nacl() -> Phonopy:
     """Return Phonopy class instance of NaCl 2x2x2 without symmetrizing fc2."""
-    import phonopy
-
-    return phonopy.load(
-        f"{TEST_FILES}/phonons/NaCl/phonopy_disp.yaml.xz",
-        force_sets_filename=f"{TEST_FILES}/phonons/NaCl/force_sets.dat",
-        symmetrize_fc=False,
-        produce_fc=True,
-    )
+    return load_phonopy_nacl()
 
 
 @pytest.fixture

--- a/tests/structure_viz/test_structure_viz_helpers.py
+++ b/tests/structure_viz/test_structure_viz_helpers.py
@@ -118,7 +118,7 @@ def test_get_image_sites(structures: list[Structure]) -> None:
         assert image_atoms.shape[1] == 3  # Each image atom should have 3 coordinates
 
     # Test with custom tolerance
-    image_atoms = get_image_sites(site, lattice, tol=0.1)
+    image_atoms = get_image_sites(site, lattice, cell_boundary_tol=0.1)
     assert isinstance(image_atoms, np.ndarray)
     assert image_atoms.ndim in (1, 2)
     if image_atoms.size > 0:
@@ -132,7 +132,7 @@ def test_get_image_sites(structures: list[Structure]) -> None:
         (Lattice.cubic(1), [0, 0.5, 0], 3),
         (Lattice.hexagonal(3, 5), [0, 0, 0], 7),
         (Lattice.rhombohedral(3, 5), [0, 0, 0], 7),
-        (Lattice.rhombohedral(3, 5), [0.1, 0, 0], 7),
+        (Lattice.rhombohedral(3, 5), [0.1, 0, 0], 3),
         (Lattice.rhombohedral(3, 5), [0.5, 0, 0], 3),
     ],
 )
@@ -142,6 +142,67 @@ def test_get_image_sites_lattices(
     site = PeriodicSite("Si", site_coords, lattice)
     image_atoms = get_image_sites(site, lattice)
     assert len(image_atoms) == expected_images
+
+
+@pytest.mark.parametrize(
+    ("cell_boundary_tol", "site_coords", "expected_min_images", "expected_max_images"),
+    [
+        # Corner site - maximum image sites
+        (0.0, [0, 0, 0], 7, 7),  # Strict boundaries
+        (0.1, [0, 0, 0], 7, 15),  # Small buffer
+        (0.2, [0, 0, 0], 7, 20),  # Medium buffer
+        # Edge site - fewer images
+        (0.0, [0.5, 0, 0], 3, 3),  # Strict boundaries
+        (0.1, [0.5, 0, 0], 3, 8),  # Small buffer
+        # Center site - minimal images
+        (0.0, [0.5, 0.5, 0.5], 0, 0),  # Strict boundaries
+        (0.2, [0.5, 0.5, 0.5], 0, 6),  # Medium buffer
+    ],
+)
+def test_get_image_sites_cell_boundary_tol(
+    cell_boundary_tol: float,
+    site_coords: list[float],
+    expected_min_images: int,
+    expected_max_images: int,
+) -> None:
+    """Test cell_boundary_tol parameter controls image site inclusion correctly."""
+    lattice = Lattice.cubic(3.0)
+    site = PeriodicSite("Si", site_coords, lattice)
+
+    image_atoms = get_image_sites(site, lattice, cell_boundary_tol=cell_boundary_tol)
+
+    # Check expected number of image sites
+    n_images = len(image_atoms)
+    assert expected_min_images <= n_images <= expected_max_images, (
+        f"Expected {expected_min_images}-{expected_max_images} images for "
+        f"tol={cell_boundary_tol}, coords={site_coords}, got {n_images}"
+    )
+
+    # Verify all image sites are within tolerance bounds
+    if n_images > 0:
+        image_frac_coords = [
+            lattice.get_fractional_coords(img_cart) for img_cart in image_atoms
+        ]
+
+        for img_frac in image_frac_coords:
+            for coord in img_frac:
+                assert -cell_boundary_tol <= coord <= 1 + cell_boundary_tol, (
+                    f"Image site coordinate {coord} outside tolerance bounds"
+                )
+
+
+@pytest.mark.parametrize(("tol1", "tol2"), [(0.0, 0.1), (0.1, 0.2)])
+def test_get_image_sites_tolerance_ordering(tol1: float, tol2: float) -> None:
+    """Test that higher tolerances include at least as many sites as lower ones."""
+    lattice = Lattice.cubic(2.5)
+    site = PeriodicSite("Si", [0, 0, 0], lattice)  # Corner site for maximum effect
+
+    images_low_tol = get_image_sites(site, lattice, cell_boundary_tol=tol1)
+    images_high_tol = get_image_sites(site, lattice, cell_boundary_tol=tol2)
+
+    assert len(images_high_tol) >= len(images_low_tol), (
+        f"Higher tolerance {tol2} should include at least as many sites as {tol1}"
+    )
 
 
 @pytest.mark.parametrize("is_3d", [True, False])

--- a/tests/utils/test_testing.py
+++ b/tests/utils/test_testing.py
@@ -1,0 +1,27 @@
+"""Test testing utility functions."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.importorskip("phonopy")
+def test_load_phonopy_nacl() -> None:
+    """Test load_phonopy_nacl utility function."""
+    from pymatviz.utils.testing import load_phonopy_nacl
+
+    # Load phonopy object
+    phonopy_nacl = load_phonopy_nacl()
+
+    # Check that we got a proper Phonopy object
+    assert hasattr(phonopy_nacl, "unitcell")
+    assert hasattr(phonopy_nacl, "supercell")
+    assert hasattr(phonopy_nacl, "force_constants")
+
+    # Check that it's NaCl structure
+    symbols = phonopy_nacl.unitcell.symbols
+    assert "Na" in symbols
+    assert "Cl" in symbols
+
+    # Check that force constants are available
+    assert phonopy_nacl.force_constants is not None


### PR DESCRIPTION

- add `cell_boundary_tol: float | dict[str, f
loat]` to `structure_(2|3)d_plotly` and `get_im
age_sites`  

  - controls inclusion of image atoms beyond 
unit cell boundaries
  - new test functions to cover new keyword
  - new example in `assets/scripts/structure_viz/structure_3d_plotly.py` to show effect of different `cell_boundary_tol` values
  
- `notebook.py` add display methods for phonopy TotalDos

  - add `load_phonopy_nacl` utility function in `pymatviz.utils.testing` to load NaCl phonopy objects consistently across tests and examples
  - update `phonon_dos.py` and `notebook_display.py` to utilize the new utility function for loading phonopy objects
  - add test for the new utility function in `tests/utils/test_testing.py`
  - test_notebook.py add tests to cover phonopy TotalDos auto-rendering

