### PR TITLE
Fix plotly validators

### DIFF
--- a/pymatviz/cluster/composition/plot.py
+++ b/pymatviz/cluster/composition/plot.py
@@ -17,6 +17,7 @@ from pymatgen.core import Composition
 from pymatviz.cluster.composition.embed import matminer_featurize, one_hot_encode
 from pymatviz.cluster.composition.project import project_vectors
 
+
 symbolValidator = ValidatorCache.get_validator("scatter.marker", "symbol")
 symbol3dValidator = ValidatorCache.get_validator("scatter3d.marker", "symbol")
 

--- a/pymatviz/cluster/composition/plot.py
+++ b/pymatviz/cluster/composition/plot.py
@@ -18,8 +18,8 @@ from pymatviz.cluster.composition.embed import matminer_featurize, one_hot_encod
 from pymatviz.cluster.composition.project import project_vectors
 
 
-symbolValidator = ValidatorCache.get_validator("scatter.marker", "symbol")
-symbol3dValidator = ValidatorCache.get_validator("scatter3d.marker", "symbol")
+symbol_validator = ValidatorCache.get_validator("scatter.marker", "symbol")
+symbol_3d_validator = ValidatorCache.get_validator("scatter3d.marker", "symbol")
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -626,11 +626,11 @@ def cluster_compositions(
         # Get valid symbols for the current plot type
         if n_components == 3:
             # For 3D plots, we need to use a more limited set of markers
-            all_symbols = symbol3dValidator.values  # noqa: PD011
+            all_symbols = symbol_3d_validator.values  # noqa: PD011
             valid_symbols = list(filter(symbol_filter, all_symbols))
         else:
             # For 2D plots, we can use the full set of markers
-            all_symbols = symbolValidator.values  # noqa: PD011
+            all_symbols = symbol_validator.values  # noqa: PD011
             valid_symbols = list(filter(symbol_filter, all_symbols))
 
         # Check if we have more unique systems than available symbols

--- a/pymatviz/cluster/composition/plot.py
+++ b/pymatviz/cluster/composition/plot.py
@@ -11,13 +11,14 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-from plotly.validators.scatter.marker import SymbolValidator
-from plotly.validators.scatter3d.marker import SymbolValidator as Symbol3dValidator
+from plotly.validator_cache import ValidatorCache
 from pymatgen.core import Composition
 
 from pymatviz.cluster.composition.embed import matminer_featurize, one_hot_encode
 from pymatviz.cluster.composition.project import project_vectors
 
+symbolValidator = ValidatorCache.get_validator("scatter.marker", "symbol")
+symbol3dValidator = ValidatorCache.get_validator("scatter3d.marker", "symbol")
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -624,11 +625,11 @@ def cluster_compositions(
         # Get valid symbols for the current plot type
         if n_components == 3:
             # For 3D plots, we need to use a more limited set of markers
-            all_symbols = Symbol3dValidator("symbol", "scatter3d.marker").values  # noqa: PD011
+            all_symbols = symbol3dValidator.values  # noqa: PD011
             valid_symbols = list(filter(symbol_filter, all_symbols))
         else:
             # For 2D plots, we can use the full set of markers
-            all_symbols = SymbolValidator("symbol", "scatter.marker").values  # noqa: PD011
+            all_symbols = symbolValidator.values  # noqa: PD011
             valid_symbols = list(filter(symbol_filter, all_symbols))
 
         # Check if we have more unique systems than available symbols

--- a/pymatviz/ptable/plotly.py
+++ b/pymatviz/ptable/plotly.py
@@ -893,8 +893,10 @@ def ptable_heatmap_splits_plotly(
         ValueError: If n_splits not in {2, 3, 4} or orientation="grid" with n_splits!=4
     """
     import plotly.colors
-    from plotly.validators.scatter.marker import ColorscaleValidator
+    from plotly.validator_cache import ValidatorCache
     from pymatgen.core import Element
+
+    colorscaleValidator = ValidatorCache.get_validator("scatter.marker", "colorscale")
 
     # Get split names if data is a DataFrame
     split_labels: list[str] = []
@@ -973,7 +975,7 @@ def ptable_heatmap_splits_plotly(
         colorbars = [colorbar or {}]  # type: ignore[list-item]
 
     # Validate colorscales
-    validator = ColorscaleValidator()
+    validator = colorscaleValidator
     for idx, cscale in enumerate(colorscales):
         if callable(cscale):
             continue

--- a/pymatviz/ptable/plotly.py
+++ b/pymatviz/ptable/plotly.py
@@ -896,7 +896,7 @@ def ptable_heatmap_splits_plotly(
     from plotly.validator_cache import ValidatorCache
     from pymatgen.core import Element
 
-    colorscaleValidator = ValidatorCache.get_validator("scatter.marker", "colorscale")
+    colorscale_validator = ValidatorCache.get_validator("scatter.marker", "colorscale")
 
     # Get split names if data is a DataFrame
     split_labels: list[str] = []
@@ -975,7 +975,7 @@ def ptable_heatmap_splits_plotly(
         colorbars = [colorbar or {}]  # type: ignore[list-item]
 
     # Validate colorscales
-    validator = colorscaleValidator
+    validator = colorscale_validator
     for idx, cscale in enumerate(colorscales):
         if callable(cscale):
             continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "moyopy[interface]>=0.4.1",
     "nbformat>=5.10",
     "pandas[output-formatting,xml]>=2.2",
-    "plotly>=6,!=6.2",
+    "plotly>=6",
     "pymatgen>=2025.2.18",
     "pyyaml>=6",
     "scikit-learn>=1.5",

--- a/tests/cluster/composition/test_plot.py
+++ b/tests/cluster/composition/test_plot.py
@@ -1819,6 +1819,7 @@ def test_too_many_chem_systems() -> None:
 
     # First check how many valid symbols we have
     from plotly.validator_cache import ValidatorCache
+
     symbolValidator = ValidatorCache().get_validator("scatter.marker", "symbol")
 
     all_symbols = symbolValidator.values  # noqa: PD011

--- a/tests/cluster/composition/test_plot.py
+++ b/tests/cluster/composition/test_plot.py
@@ -1818,9 +1818,10 @@ def test_too_many_chem_systems() -> None:
     df_chem_sys = pd.DataFrame({"composition": compositions})
 
     # First check how many valid symbols we have
-    from plotly.validators.scatter.marker import SymbolValidator
+    from plotly.validator_cache import ValidatorCache
+    symbolValidator = ValidatorCache().get_validator("scatter.marker", "symbol")
 
-    all_symbols = SymbolValidator("symbol", "scatter.marker").values  # noqa: PD011
+    all_symbols = symbolValidator.values  # noqa: PD011
     valid_symbols = [
         s
         for s in all_symbols

--- a/tests/cluster/composition/test_plot.py
+++ b/tests/cluster/composition/test_plot.py
@@ -1820,9 +1820,9 @@ def test_too_many_chem_systems() -> None:
     # First check how many valid symbols we have
     from plotly.validator_cache import ValidatorCache
 
-    symbolValidator = ValidatorCache().get_validator("scatter.marker", "symbol")
+    symbol_validator = ValidatorCache().get_validator("scatter.marker", "symbol")
 
-    all_symbols = symbolValidator.values  # noqa: PD011
+    all_symbols = symbol_validator.values  # noqa: PD011
     valid_symbols = [
         s
         for s in all_symbols


### PR DESCRIPTION
In `plotly==6.2`, the directories of validator modules were removed in favor of a system that generates validator instances on demand from `plotly.validator_cache.ValidatorCache`.  The validator cache was already used internally in plotly > 99% of the time, and now it is the only way to get a validator.

In this PR, the uses of directly imported validator classes is refactored to use the `ValidatorCache`.  This is backward-compatible with `plotly<6.2`, because the `ValidatorCache` was already in place for e.g. `plotly==6.1.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved efficiency by centralizing the handling of Plotly validators with a caching approach.
  * Updated dependency requirements to support all Plotly versions 6 and above, including version 6.2.

* **Tests**
  * Aligned test imports with the new validator caching method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->