### PR TITLE
Bump `matterviz`

### DIFF
--- a/examples/widgets/jupyter_demo.ipynb
+++ b/examples/widgets/jupyter_demo.ipynb
@@ -318,7 +318,7 @@
     "    display_mode=\"structure+scatter\",\n",
     "    show_force_vectors=False,\n",
     "    auto_rotate=0.5,\n",
-    "    style=\"height: 600px\",\n",
+    "    style=\"height: 600px;\",\n",
     ")\n",
     "\n",
     "torch_sim_widget"

--- a/examples/widgets/jupyter_demo.ipynb
+++ b/examples/widgets/jupyter_demo.ipynb
@@ -9,12 +9,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cc62f02a98e848e9ba00e994e4db41cd",
+       "model_id": "0f9e1712166343bb965cff886b638384",
        "version_major": 2,
        "version_minor": 1
       },
       "text/plain": [
-       "StructureWidget(structure={'@module': 'pymatgen.core.structure', '@class': 'Structure', 'charge': 0, 'lattice'…"
+       "StructureWidget(structure={'@module': 'pymatgen.core.structure', '@class': 'Structure', 'charge': 0.0, 'lattic…"
       ]
      },
      "execution_count": null,
@@ -94,12 +94,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2ae088494a2245b5a92c17903d2b21e5",
+       "model_id": "80d67f22c3d941659fbcba4b3c171aba",
        "version_major": 2,
        "version_minor": 1
       },
       "text/plain": [
-       "TrajectoryWidget(structure_props={'fullscreen_toggle': False}, trajectory={'frames': [{'structure': {'@module'…"
+       "TrajectoryWidget(layout='horizontal', trajectory={'frames': [{'structure': {'@module': 'pymatgen.core.structur…"
       ]
      },
      "execution_count": null,
@@ -179,22 +179,13 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/janosh/.venv/py313/lib/python3.13/site-packages/IPython/core/formatters.py:429: FormatterWarning: text/html formatter returned invalid type <class 'pymatviz.widgets.structure.StructureWidget'> (expected <class 'str'>) for object: <phonopy.structure.atoms.PhonopyAtoms object at 0x12f5f0830>\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "<phonopy.structure.atoms.PhonopyAtoms at 0x12f5f0830>"
+       "<phonopy.structure.atoms.PhonopyAtoms object at 0x14a5facf0>"
       ]
      },
-     "execution_count": null,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -217,12 +208,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c445545422b04d4283d848e94526ea0b",
+       "model_id": "3348d6fc00ec427abaeb3dc43c82c57d",
        "version_major": 2,
        "version_minor": 1
       },
       "text/plain": [
-       "TrajectoryWidget(auto_rotate=0.5, data_url='tmp/torch-sim-gold-cluster-55-atoms.h5', structure_props={'fullscr…"
+       "TrajectoryWidget(data_url='tmp/torch-sim-gold-cluster-55-atoms.h5', show_force_vectors=False)"
       ]
      },
      "execution_count": null,
@@ -265,7 +256,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fea87d2c778a41898f597794cdec7375",
+       "model_id": "e79497d7ae7e43a4925063a4237c8003",
        "version_major": 2,
        "version_minor": 1
       },
@@ -292,6 +283,7 @@
     "    force_vector_color=\"#ff4444\",\n",
     "    show_bonds=True,\n",
     "    bonding_strategy=\"nearest_neighbor\",\n",
+    "    style=\"height: 600px;\",\n",
     ")\n",
     "display(ase_traj_widget)"
    ]
@@ -305,12 +297,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "860b5d7d60f742f8be5c0115ebcea296",
+       "model_id": "33687d3c791a4c07a4da3282f2ececc5",
        "version_major": 2,
        "version_minor": 1
       },
       "text/plain": [
-       "TrajectoryWidget(auto_rotate=0.5, data_url='https://raw.githack.com/janosh/matterviz/33aa595dc/src/site/trajec…"
+       "TrajectoryWidget(data_url='https://raw.githack.com/janosh/matterviz/33aa595dc/src/site/trajectories/torch-sim-…"
       ]
      },
      "execution_count": null,
@@ -326,7 +318,7 @@
     "    display_mode=\"structure+scatter\",\n",
     "    show_force_vectors=False,\n",
     "    auto_rotate=0.5,\n",
-    "    style=\"min-height: 800px\",\n",
+    "    style=\"height: 600px\",\n",
     ")\n",
     "\n",
     "torch_sim_widget"
@@ -341,12 +333,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2303fc52f0c341779b04a9871065d262",
+       "model_id": "b408e382c31348f7b2ec56e26cb74cec",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "GridBox(children=(CompositionWidget(composition={'Fe': 2.0, 'O': 3.0}, height=100, width=100), CompositionWidg…"
+       "GridBox(children=(CompositionWidget(composition={'Fe': 2.0, 'O': 3.0}, style='width: 100px; height: 100px;'), …"
       ]
      },
      "execution_count": null,
@@ -367,7 +359,9 @@
     "size = 100\n",
     "children = [\n",
     "    pmv.CompositionWidget(\n",
-    "        composition=comp, mode=mode, width=(1 + (mode == \"bar\")) * size, height=size\n",
+    "        composition=comp,\n",
+    "        mode=mode,\n",
+    "        style=f\"width: {(1 + (mode == 'bar')) * size}px; height: {size}px;\",\n",
     "    )\n",
     "    for comp, mode in itertools.product(comps, modes)\n",
     "]\n",

--- a/examples/widgets/marimo_demo.py
+++ b/examples/widgets/marimo_demo.py
@@ -166,7 +166,7 @@ def _(githack_traj_dir_url, pmv):
         display_mode="structure+scatter",
         show_force_vectors=False,
         auto_rotate=0.5,
-        style="height: 600px",
+        style="height: 600px;",
     )
     _torch_sim_widget
 

--- a/examples/widgets/marimo_demo.py
+++ b/examples/widgets/marimo_demo.py
@@ -153,6 +153,7 @@ def _(Final, pmv):
         force_vector_color="#ff4444",
         show_bonds=True,
         bonding_strategy="nearest_neighbor",
+        style="height: 600px;",
     )
     ase_traj_widget
     return (githack_traj_dir_url,)
@@ -165,7 +166,7 @@ def _(githack_traj_dir_url, pmv):
         display_mode="structure+scatter",
         show_force_vectors=False,
         auto_rotate=0.5,
-        style="min-height: 800px",
+        style="height: 600px",
     )
     _torch_sim_widget
 
@@ -213,8 +214,7 @@ def _(dynamic_trajectory, pmv):
         display_mode="structure+scatter",
         show_controls=True,
         auto_rotate=0.3,
-        width=600,
-        height=400,
+        style="height: 600px;",
     )
     dynamic_trajectory_widget
     return dynamic_trajectory_widget
@@ -239,8 +239,7 @@ def _(Composition, mo, pmv):
                 pmv.CompositionWidget(
                     composition=comp,
                     mode=mode,
-                    width=(1 + (mode == "bar")) * size,
-                    height=size,
+                    style=f"width: {(1 + (mode == 'bar')) * size}px; height: {size}px;",
                 )
                 for mode in modes
             ]

--- a/examples/widgets/vscode_interactive_demo.py
+++ b/examples/widgets/vscode_interactive_demo.py
@@ -147,7 +147,7 @@ torch_sim_widget = pmv.TrajectoryWidget(
     display_mode="structure+scatter",
     show_force_vectors=False,
     auto_rotate=0.5,
-    style="height: 600px",
+    style="height: 600px;",
 )
 
 display(torch_sim_widget)

--- a/examples/widgets/vscode_interactive_demo.py
+++ b/examples/widgets/vscode_interactive_demo.py
@@ -136,6 +136,7 @@ ase_traj_widget = pmv.TrajectoryWidget(
     force_vector_color="#ff4444",
     show_bonds=True,
     bonding_strategy="nearest_neighbor",
+    style="height: 600px;",
 )
 display(ase_traj_widget)
 
@@ -146,7 +147,7 @@ torch_sim_widget = pmv.TrajectoryWidget(
     display_mode="structure+scatter",
     show_force_vectors=False,
     auto_rotate=0.5,
-    style="min-height: 800px",
+    style="height: 600px",
 )
 
 display(torch_sim_widget)
@@ -163,7 +164,9 @@ modes = ("pie", "bar", "bubble")
 size = 100
 children = [
     pmv.CompositionWidget(
-        composition=comp, mode=mode, width=(1 + (mode == "bar")) * size, height=size
+        composition=comp,
+        mode=mode,
+        style=f"width: {(1 + (mode == 'bar')) * size}px; height: {size}px;",
     )
     for comp, mode in itertools.product(comps, modes)
 ]

--- a/pymatviz/widgets/composition.py
+++ b/pymatviz/widgets/composition.py
@@ -30,23 +30,25 @@ class CompositionWidget(MatterVizWidget):
         With custom visualization options:
         >>> widget = CompositionWidget(
         ...     composition=comp,
-        ...     show_values=True,
-        ...     precision=3,
+        ...     mode="bar",
+        ...     show_percentages=True,
         ...     color_scheme="Jmol",
+        ...     style="width: 400px; margin: 20px auto;",
         ... )
     """
 
     composition = tl.Dict(allow_none=True).tag(sync=True)
-    mode: Literal["pie", "bar", "bubble"] = tl.Unicode("pie").tag(sync=True)
-    pymatgen_kwargs = tl.Dict(allow_none=True).tag(sync=True)
 
-    # Display options
+    # Visualization options
+    mode: Literal["pie", "bar", "bubble"] = tl.Unicode("pie").tag(sync=True)
     show_percentages = tl.Bool(default_value=False).tag(sync=True)
     color_scheme: MattervizElementColorSchemes = tl.Unicode("Jmol").tag(sync=True)
 
-    # Dimensions
-    width = tl.Int(allow_none=True).tag(sync=True)
-    height = tl.Int(allow_none=True).tag(sync=True)
+    # Widget styling
+    style = tl.Unicode(allow_none=True).tag(sync=True)  # Custom CSS styles
+
+    # PyMatGen composition kwargs
+    pymatgen_kwargs = tl.Dict(allow_none=True).tag(sync=True)
 
     def __init__(
         self, composition: CompositionLike | None = None, **kwargs: Any
@@ -57,11 +59,10 @@ class CompositionWidget(MatterVizWidget):
             composition: Composition data (pymatgen Composition object or dict)
             **kwargs: Additional widget properties
         """
-        comp_kwargs = dict(strict=True, allow_negative=True) | kwargs.pop(
-            "pymatgen_kwargs", {}
-        )
         if composition is None:
             comp_dict = None
         else:
+            comp_kwargs = dict(strict=True, allow_negative=True)
+            comp_kwargs |= kwargs.pop("pymatgen_kwargs", {})
             comp_dict = Composition(composition, **comp_kwargs).as_dict()
         super().__init__(composition=comp_dict, **kwargs)

--- a/pymatviz/widgets/structure.py
+++ b/pymatviz/widgets/structure.py
@@ -25,53 +25,52 @@ class StructureWidget(MatterVizWidget):
         ...     atom_radius=0.8,
         ...     show_bonds=True,
         ...     color_scheme="Jmol",
+        ...     style="border-radius: 10px; width: 100%; height: 600px;",
         ... )
     """
 
     structure = tl.Dict(allow_none=True).tag(sync=True)
     data_url = tl.Unicode(allow_none=True).tag(sync=True)
 
-    # Atom properties
-    atom_radius = tl.Float(1.0).tag(sync=True)
+    # Atom visualization
+    atom_radius = tl.Float(allow_none=True, default_value=None).tag(sync=True)
     show_atoms = tl.Bool(default_value=True).tag(sync=True)
-    show_bonds = tl.Bool(default_value=False).tag(sync=True)
-    show_site_labels = tl.Bool(default_value=False).tag(sync=True)
+    show_bonds = tl.Bool(allow_none=True, default_value=None).tag(sync=True)
+    show_site_labels = tl.Bool(allow_none=True, default_value=None).tag(sync=True)
     show_image_atoms = tl.Bool(default_value=True).tag(sync=True)
-    show_force_vectors = tl.Bool(default_value=False).tag(sync=True)
-    same_size_atoms = tl.Bool(default_value=False).tag(sync=True)
-    auto_rotate = tl.Float(0.0).tag(sync=True)
+    show_force_vectors = tl.Bool(allow_none=True, default_value=None).tag(sync=True)
+    same_size_atoms = tl.Bool(allow_none=True, default_value=None).tag(sync=True)
 
     # Force vectors
-    force_vector_scale = tl.Float(1.0).tag(sync=True)
-    force_vector_color = tl.Unicode("#ff6b6b").tag(sync=True)
+    force_vector_scale = tl.Float(allow_none=True, default_value=None).tag(sync=True)
+    force_vector_color = tl.Unicode(allow_none=True, default_value=None).tag(sync=True)
 
     # Bonds
-    bond_thickness = tl.Float(0.1).tag(sync=True)
-    bond_color = tl.Unicode("#666666").tag(sync=True)
+    bond_thickness = tl.Float(allow_none=True, default_value=None).tag(sync=True)
+    bond_color = tl.Unicode(allow_none=True, default_value=None).tag(sync=True)
     bonding_strategy = tl.Unicode("nearest_neighbor").tag(sync=True)
 
     # Cell
-    cell_edge_opacity = tl.Float(0.8).tag(sync=True)
-    cell_surface_opacity = tl.Float(0.1).tag(sync=True)
-    cell_edge_color = tl.Unicode("#333333").tag(sync=True)
-    cell_surface_color = tl.Unicode("#333333").tag(sync=True)
-    cell_line_width = tl.Float(2.0).tag(sync=True)
-    show_vectors = tl.Bool(default_value=True).tag(sync=True)
+    cell_edge_opacity = tl.Float(0.1).tag(sync=True)
+    cell_surface_opacity = tl.Float(0.05).tag(sync=True)
+    cell_edge_color = tl.Unicode(allow_none=True, default_value=None).tag(sync=True)
+    cell_surface_color = tl.Unicode(allow_none=True, default_value=None).tag(sync=True)
+    cell_line_width = tl.Float(1.5).tag(sync=True)
+    show_vectors = tl.Bool(allow_none=True, default_value=None).tag(sync=True)
 
-    # Styling
+    # Appearance
     color_scheme = tl.Unicode("Vesta").tag(sync=True)
     background_color = tl.Unicode(allow_none=True).tag(sync=True)
-    background_opacity = tl.Float(0.1).tag(sync=True)
+    background_opacity = tl.Float(allow_none=True, default_value=None).tag(sync=True)
 
-    # Dimensions
-    width = tl.Int(allow_none=True).tag(sync=True)
-    height = tl.Int(allow_none=True).tag(sync=True)
+    # Styling
+    style = tl.Unicode(allow_none=True).tag(sync=True)  # Custom CSS styles
 
-    # UI
+    # UI controls
     show_controls = tl.Bool(default_value=True).tag(sync=True)
     show_info = tl.Bool(default_value=True).tag(sync=True)
-    show_fullscreen_button = tl.Bool(default_value=False).tag(sync=True)
-    png_dpi = tl.Int(150).tag(sync=True)
+    show_fullscreen_button = tl.Bool(allow_none=True, default_value=None).tag(sync=True)
+    png_dpi = tl.Int(allow_none=True, default_value=None).tag(sync=True)
 
     def __init__(
         self, structure: dict[str, Any] | Any | None = None, **kwargs: Any

--- a/pymatviz/widgets/web/anywidget.ts
+++ b/pymatviz/widgets/web/anywidget.ts
@@ -12,55 +12,57 @@ import {
   setup_theme_watchers,
 } from './theme-detection'
 
-function inject_app_css(theme_type?: ThemeType): void {
+function inject_app_css(theme_type?: ThemeType, target_element?: HTMLElement): void {
   const style_id = `matterviz-widget-styles`
+  const detected_theme = theme_type || detect_parent_theme(target_element)
 
-  document.getElementById(style_id)?.remove() // Remove existing styles
+  // Determine if we're in Shadow DOM (used by marimo cells) and get the appropriate root node
+  const root_node = target_element?.getRootNode() || document
+  const is_shadow_dom = root_node !== document && root_node instanceof ShadowRoot
+  const target_root = is_shadow_dom ? root_node : document
 
-  const style = document.createElement(`style`)
-  style.id = style_id
+  // Remove existing styles
+  const existing_style = is_shadow_dom
+    ? target_root.querySelector(`#${style_id}`)
+    : document.getElementById(style_id)
+  existing_style?.remove()
 
-  // Use provided theme or detect parent theme
-  const detected_theme = theme_type || detect_parent_theme()
-
-  style.textContent = `
-    ${get_theme_css(detected_theme)}
-
-    /* something adds an annoying white background, remove it */
-    .cell-output-ipywidget-background {
-      background: transparent !important;
-      background-color: transparent !important;
-    }
-
-    /* Dark mode input styling for Jupyter notebooks and interactive windows in VSCode  */
+  // Create style content
+  const style_content = `
+    ${get_theme_css(detected_theme, is_shadow_dom)}
+    .cell-output-ipywidget-background { background: transparent !important; }
     :is(.vscode-dark, .dark-theme, [data-jp-theme-light="false"]) :is(input, textarea, select) {
-      background-color: #2d2d2d;
-      color: #ffffff;
-      border: 1px solid #555555;
-      border-radius: 4px;
-      padding: 6px 8px;
+      background-color: #2d2d2d; color: #ffffff; border: 1px solid #555555; border-radius: 4px; padding: 6px 8px;
     }
     :is(.vscode-dark, .dark-theme, [data-jp-theme-light="false"]) :is(input, textarea, select):focus {
-      outline: none;
-      border-color: #007acc;
-      box-shadow: 0 0 0 2px rgba(0, 122, 204, 0.2);
+      outline: none; border-color: #007acc; box-shadow: 0 0 0 2px rgba(0, 122, 204, 0.2);
     }
-    :is(.vscode-dark, .dark-theme, [data-jp-theme-light="false"]) :is(input, textarea)::placeholder {
-      color: #888888;
-    }
-
-    /* scope global styles to matterviz widgets to prevent site styles leaking into notebook styles */
-    /* this is brittle, will break should component CSS classes in matterviz change, try to find better solution */
-    div:is(.structure, .trajectory, .composition) {
-      ${app_css}
-    }
+    :is(.vscode-dark, .dark-theme, [data-jp-theme-light="false"]) :is(input, textarea)::placeholder { color: #888888; }
+    ${
+    is_shadow_dom
+      ? app_css
+      : `div:is(.structure, .trajectory, .composition) { ${app_css} }`
+  }
   `
-  document.head.appendChild(style)
+
+  // Apply styles
+  if (is_shadow_dom && `adoptedStyleSheets` in target_root) {
+    const sheet = new CSSStyleSheet()
+    sheet.replaceSync(style_content)
+    target_root.adoptedStyleSheets = [...target_root.adoptedStyleSheets, sheet]
+    return
+  }
+
+  // Fallback: create style element
+  const style = document.createElement(`style`)
+  style.id = style_id
+  style.textContent = style_content
+  if (is_shadow_dom) target_root.appendChild(style)
+  else document.head.appendChild(style)
 }
 
 const instances = new Map<HTMLElement, ReturnType<typeof mount>>()
 
-// Detect widget type and render
 const get_prop = (model: AnyModel, key: string) => {
   try {
     return model.get(key) ?? undefined
@@ -69,13 +71,14 @@ const get_prop = (model: AnyModel, key: string) => {
   }
 }
 
+// Detect widget type and render
 const render: Render = (props) => {
   const { model, el } = props
-  inject_app_css()
-  setup_theme_watchers()
+  inject_app_css(undefined, el)
+  setup_theme_watchers(el)
 
   // Register theme change callback to update CSS when theme changes
-  on_theme_change(inject_app_css)
+  on_theme_change((theme_type) => inject_app_css(theme_type, el))
 
   // Clean up existing instance
   const existing = instances.get(el)
@@ -135,14 +138,12 @@ const render_structure: Render = ({ model, el }) => {
       cell_line_width: get_prop(model, `cell_line_width`),
       show_vectors: get_prop(model, `show_vectors`),
     },
-
     // Display options
     show_site_labels: get_prop(model, `show_site_labels`),
     show_image_atoms: get_prop(model, `show_image_atoms`),
     color_scheme: get_prop(model, `color_scheme`),
     background_color: get_prop(model, `background_color`),
     background_opacity: get_prop(model, `background_opacity`),
-
     // Widget configuration
     show_controls: get_prop(model, `show_controls`),
     enable_info_panel: get_prop(model, `show_info`),
@@ -158,18 +159,15 @@ const render_structure: Render = ({ model, el }) => {
 
 const render_trajectory: Render = ({ model, el }) => {
   const props = {
-    // Core trajectory data
     trajectory: get_prop(model, `trajectory`),
     data_url: get_prop(model, `data_url`),
     current_step_idx: get_prop(model, `current_step_idx`),
-
     // Layout and display
     layout: get_prop(model, `layout`),
     display_mode: get_prop(model, `display_mode`),
     show_controls: get_prop(model, `show_controls`),
     show_fullscreen_button: get_prop(model, `show_fullscreen_button`),
     auto_play: get_prop(model, `auto_play`),
-
     // Widget configuration
     allow_file_drop: false, // Disable file drop in notebook context
     structure_props: {

--- a/pymatviz/widgets/web/deno.jsonc
+++ b/pymatviz/widgets/web/deno.jsonc
@@ -47,10 +47,10 @@
     "lib": ["dom", "esnext"]
   },
   "imports": {
-    "@sveltejs/vite-plugin-svelte": "npm:@sveltejs/vite-plugin-svelte@^6.0.0",
+    "@sveltejs/vite-plugin-svelte": "npm:@sveltejs/vite-plugin-svelte@^6.1.0",
     "anywidget": "npm:anywidget@^0.9.18",
-    "svelte": "npm:svelte@^5.36.13",
-    "matterviz": "npm:matterviz@^0.1.5"
+    "svelte": "npm:svelte@^5.37.0",
+    "matterviz": "npm:matterviz@^0.1.6"
   },
   "nodeModulesDir": "auto"
 }

--- a/pymatviz/widgets/web/theme-detection.ts
+++ b/pymatviz/widgets/web/theme-detection.ts
@@ -3,60 +3,81 @@
 import { luminance } from 'matterviz/colors'
 import 'matterviz/theme'
 import { COLOR_THEMES, type ThemeType } from 'matterviz/theme'
-// sets globalThis.MATTERVIZ_THEMES and globalThis.MATTERVIZ_CSS_MAP used below in on_theme_change
 import 'matterviz/theme/themes'
 
+// Extend globalThis with our custom properties
+declare global {
+  var jupyterlab: {
+    application?: { shell?: { dataset?: { theme?: string } } }
+  } | undefined
+  var MATTERVIZ_THEMES: Record<string, Record<string, string>> | undefined
+  var MATTERVIZ_CSS_MAP: Record<string, string> | undefined
+}
+
 let current_theme: ThemeType = `light`
-const theme_observers: Set<() => void> = new Set()
+const theme_observers: Set<(theme_type: ThemeType) => void> = new Set()
 let mutation_observer: MutationObserver | null = null
 let media_query_listener: MediaQueryList | null = null
+let media_query_handler: (() => void) | null = null
 
-export function detect_parent_theme(): ThemeType {
+export function detect_parent_theme(target_element?: HTMLElement): ThemeType {
   try {
-    // 1. Check for Marimo theme CSS class
-    if (document.body.classList.contains(`dark-theme`)) return `dark`
-    if (document.body.classList.contains(`light-theme`)) return `light`
-
-    // 2. Check for VSCode theme CSS class (recommended here https://github.com/microsoft/vscode/issues/176698#issuecomment-1468638041)
-    if (document.body.classList.contains(`vscode-dark`)) return `dark`
-    if (document.body.classList.contains(`vscode-light`)) return `light`
-
-    // 2. Use standard CSS media queries (official web API)
-    if (globalThis.matchMedia) {
-      const prefers_dark = globalThis.matchMedia(`(prefers-color-scheme: dark)`)
-      const prefers_light = globalThis.matchMedia(`(prefers-color-scheme: light)`)
-
-      if (prefers_dark.matches) return `dark`
-      if (prefers_light.matches) return `light`
+    // Check Shadow DOM context
+    if (target_element) {
+      const root_node = target_element.getRootNode()
+      if (root_node !== document && root_node instanceof ShadowRoot) {
+        const theme = check_element_hierarchy(root_node.host)
+        if (theme) return theme
+      }
     }
 
-    // 3. Check for Jupyter Lab official theme API
-    if (globalThis.jupyterlab?.application?.shell?.dataset?.theme) {
-      const jupyter_theme = globalThis.jupyterlab.application.shell.dataset
-        .theme as string
+    // Check document theme indicators
+    const theme_classes = [
+      `dark-theme`,
+      `light-theme`,
+      `vscode-dark`,
+      `vscode-light`,
+      `dark`,
+      `light`,
+    ]
+    for (const cls of theme_classes) {
+      if (document.body.classList.contains(cls)) {
+        return cls.includes(`dark`) ? `dark` : `light`
+      }
+    }
+
+    // System preference
+    if (globalThis.matchMedia) {
+      if (globalThis.matchMedia(`(prefers-color-scheme: dark)`).matches) return `dark`
+      if (globalThis.matchMedia(`(prefers-color-scheme: light)`).matches) return `light`
+    }
+
+    // Jupyter Lab theme API
+    const jupyter_theme = globalThis.jupyterlab?.application?.shell?.dataset?.theme
+    if (jupyter_theme) {
       return jupyter_theme.includes(`dark`) ? `dark` : `light`
     }
 
-    // 4. Check for Jupyter theme via official CSS custom properties
-    const jupyter_theme = getComputedStyle(document.documentElement)
-      .getPropertyValue(`--jp-layout-color0`)
-    if (jupyter_theme) {
-      // Jupyter uses --jp-layout-color0 as background - official property
-      const is_dark = is_dark_color(jupyter_theme)
+    // Jupyter CSS custom properties
+    const jp_bg = getComputedStyle(document.documentElement).getPropertyValue(
+      `--jp-layout-color0`,
+    )
+    if (jp_bg) {
+      const is_dark = is_dark_color(jp_bg)
       if (is_dark !== null) return is_dark ? `dark` : `light`
     }
 
-    // 5. Fallback: analyze computed background colors of key elements
-    const { body, documentElement } = document
-    const body_bg = getComputedStyle(body).backgroundColor
-    const root_bg = getComputedStyle(documentElement).backgroundColor
+    // Analyze background colors
+    const backgrounds = [
+      getComputedStyle(document.body).backgroundColor,
+      getComputedStyle(document.documentElement).backgroundColor,
+    ]
 
-    for (const bg of [body_bg, root_bg]) {
+    for (const bg of backgrounds) {
       const is_dark = is_dark_color(bg)
       if (is_dark !== null) return is_dark ? `dark` : `light`
     }
 
-    // 6. Final fallback to light theme
     return `light`
   } catch (error) {
     console.warn(`Theme detection failed, defaulting to light:`, error)
@@ -64,34 +85,72 @@ export function detect_parent_theme(): ThemeType {
   }
 }
 
-// Robust color analysis helper
+function check_element_hierarchy(element: Element): ThemeType | null {
+  let current_element: Element | null = element
+
+  while (current_element) {
+    // Check classes
+    const class_list = current_element.classList
+    if (
+      class_list.contains(`dark-theme`) || class_list.contains(`vscode-dark`) ||
+      class_list.contains(`dark`)
+    ) return `dark`
+    if (
+      class_list.contains(`light-theme`) || class_list.contains(`vscode-light`) ||
+      class_list.contains(`light`)
+    ) return `light`
+
+    // Check data attributes
+    const data_theme = current_element.getAttribute(`data-theme`)
+    if (data_theme === `dark`) return `dark`
+    if (data_theme === `light`) return `light`
+
+    // Check computed styles
+    const computed_style = getComputedStyle(current_element)
+    const bg_color = computed_style.backgroundColor
+    const text_color = computed_style.color
+
+    if (bg_color && bg_color !== `rgba(0, 0, 0, 0)` && bg_color !== `transparent`) {
+      const is_dark = is_dark_color(bg_color)
+      if (is_dark !== null) return is_dark ? `dark` : `light`
+    }
+
+    if (text_color && text_color !== `rgba(0, 0, 0, 0)` && text_color !== `transparent`) {
+      const text_is_dark = is_dark_color(text_color)
+      if (text_is_dark !== null) return text_is_dark ? `light` : `dark`
+    }
+
+    current_element = current_element.parentElement
+  }
+
+  return null
+}
+
 function is_dark_color(color: string): boolean | null {
   if (!color || [`transparent`, `initial`, `inherit`].includes(color)) return null
-
-  // Use standard luminance calculation (WCAG guidelines)
   return luminance(color) < 0.5
 }
 
-function notify_theme_change(): void {
-  const new_theme = detect_parent_theme()
+function notify_theme_change(target_element?: HTMLElement): void {
+  const new_theme = detect_parent_theme(target_element)
   if (new_theme !== current_theme) {
     current_theme = new_theme
-    theme_observers.forEach((callback) => callback())
+    theme_observers.forEach((callback) => callback(new_theme))
   }
 }
 
-export function setup_theme_watchers(): void {
+export function setup_theme_watchers(target_element?: HTMLElement): void {
   if (mutation_observer || media_query_listener) return // Avoid duplicates
 
   try {
-    // Watch for class/attribute changes
+    // Watch for DOM changes
     mutation_observer = new MutationObserver((mutations) => {
       if (
         mutations.some((mut) =>
           mut.type === `attributes` &&
           (mut.attributeName === `class` || mut.attributeName === `data-theme`)
         )
-      ) setTimeout(notify_theme_change, 10) // Debounce
+      ) setTimeout(() => notify_theme_change(target_element), 10) // Debounce
     })
 
     const observe_opts = { attributes: true, attributeFilter: [`class`, `data-theme`] }
@@ -101,10 +160,11 @@ export function setup_theme_watchers(): void {
     // Watch system preference changes
     if (globalThis.matchMedia) {
       media_query_listener = globalThis.matchMedia(`(prefers-color-scheme: dark)`)
-      media_query_listener.addEventListener(`change`, notify_theme_change)
+      media_query_handler = () => notify_theme_change(target_element)
+      media_query_listener.addEventListener(`change`, media_query_handler)
     }
 
-    current_theme = detect_parent_theme() // Set initial theme
+    current_theme = detect_parent_theme(target_element) // Set initial theme
   } catch (error) {
     console.warn(`Failed to setup theme watchers:`, error)
   }
@@ -114,21 +174,23 @@ export function cleanup_theme_watchers(): void {
   mutation_observer?.disconnect()
   mutation_observer = null
 
-  media_query_listener?.removeEventListener(`change`, notify_theme_change)
+  if (media_query_listener && media_query_handler) {
+    media_query_listener.removeEventListener(`change`, media_query_handler)
+  }
   media_query_listener = null
-
+  media_query_handler = null
   theme_observers.clear()
 }
 
-export function on_theme_change(callback: () => void): () => void {
+export function on_theme_change(callback: (theme_type: ThemeType) => void): () => void {
   theme_observers.add(callback)
   return () => theme_observers.delete(callback)
 }
 
-export function get_theme_css(theme_type: ThemeType): string {
+export function get_theme_css(theme_type: ThemeType, is_shadow_dom = false): string {
   const theme_name = COLOR_THEMES[theme_type]
 
-  // Get theme from global (themes.js sets these)
+  // Get theme data (matterviz/themes.js sets this)
   const theme = globalThis.MATTERVIZ_THEMES?.[theme_name]
   const css_map = globalThis.MATTERVIZ_CSS_MAP
 
@@ -142,5 +204,7 @@ export function get_theme_css(theme_type: ThemeType): string {
     .filter(Boolean)
     .join(`\n\t`)
 
-  return `:root {\n\t${css_vars}\n}`
+  // Use :host for Shadow DOM, :root for regular DOM
+  const selector = is_shadow_dom ? `:host` : `:root`
+  return `${selector} {\n\t${css_vars}\n}`
 }

--- a/tests/widgets/test_composition_widget.py
+++ b/tests/widgets/test_composition_widget.py
@@ -61,8 +61,7 @@ def test_widget_invalid_composition_handling(
     [
         ("show_percentages", [False, True]),
         ("color_scheme", ["Jmol", "CPK", "VESTA"]),
-        ("width", [400, 600, 800]),
-        ("height", [400, 500, 600]),
+        ("style", [None, "width: 400px; height: 600px", "width: 600px; height: 800px"]),
         ("mode", ["pie", "bar", "bubble"]),
     ],
 )
@@ -99,8 +98,7 @@ def test_widget_complete_lifecycle() -> None:
         show_percentages=True,
         color_scheme="CPK",
         mode="bar",
-        width=800,
-        height=600,
+        style="width: 800px; height: 600px",
     )
 
     # Test initial state
@@ -108,8 +106,7 @@ def test_widget_complete_lifecycle() -> None:
     assert widget.show_percentages is True
     assert widget.color_scheme == "CPK"
     assert widget.mode == "bar"
-    assert widget.width == 800
-    assert widget.height == 600
+    assert widget.style == "width: 800px; height: 600px"
 
     # Test state persistence
     state = {
@@ -117,8 +114,7 @@ def test_widget_complete_lifecycle() -> None:
         "show_percentages": widget.show_percentages,
         "color_scheme": widget.color_scheme,
         "mode": widget.mode,
-        "width": widget.width,
-        "height": widget.height,
+        "style": widget.style,
     }
 
     # Create new widget from state

--- a/tests/widgets/test_structure_widget.py
+++ b/tests/widgets/test_structure_widget.py
@@ -68,8 +68,7 @@ def test_widget_invalid_structure_handling(
         ("atom_radius", [1.0, 1.5, 2.0]),
         ("show_bonds", [True, False]),
         ("color_scheme", ["Jmol", "CPK", "VESTA"]),
-        ("width", [None, 400, 600, 800]),
-        ("height", [None, 400, 500, 600]),
+        ("style", [None, "width: 400px; height: 600px", "width: 600px; height: 800px"]),
         ("show_controls", [True, False]),
         ("show_info", [True, False]),
     ],
@@ -131,8 +130,7 @@ def test_widget_complete_lifecycle(structures: tuple[Structure, Structure]) -> N
         atom_radius=1.5,
         show_bonds=True,
         color_scheme="Jmol",
-        width=800,
-        height=600,
+        style="width: 800px; height: 600px",
         show_controls=False,
     )
 
@@ -141,8 +139,7 @@ def test_widget_complete_lifecycle(structures: tuple[Structure, Structure]) -> N
     assert widget.atom_radius == 1.5
     assert widget.show_bonds is True
     assert widget.color_scheme == "Jmol"
-    assert widget.width == 800
-    assert widget.height == 600
+    assert widget.style == "width: 800px; height: 600px"
     assert widget.show_controls is False
 
     # Test state persistence
@@ -151,8 +148,7 @@ def test_widget_complete_lifecycle(structures: tuple[Structure, Structure]) -> N
         "atom_radius": widget.atom_radius,
         "show_bonds": widget.show_bonds,
         "color_scheme": widget.color_scheme,
-        "width": widget.width,
-        "height": widget.height,
+        "style": widget.style,
         "show_controls": widget.show_controls,
     }
 

--- a/tests/widgets/test_trajectory_widget.py
+++ b/tests/widgets/test_trajectory_widget.py
@@ -208,8 +208,7 @@ def test_widget_complete_lifecycle(
     # Create widget with custom settings
     widget = TrajectoryWidget(
         trajectory=multi_frame_trajectory,
-        width=800,
-        height=600,
+        style="width: 800px; height: 600px",
         show_controls=False,
         layout="horizontal",
         display_mode="structure",
@@ -218,8 +217,7 @@ def test_widget_complete_lifecycle(
     # Test initial state
     assert widget.trajectory == multi_frame_trajectory
     assert widget.current_step_idx == 0
-    assert widget.width == 800
-    assert widget.height == 600
+    assert widget.style == "width: 800px; height: 600px"
     assert widget.show_controls is False
     assert widget.layout == "horizontal"
     assert widget.display_mode == "structure"
@@ -237,8 +235,7 @@ def test_widget_complete_lifecycle(
     state = {
         "trajectory": widget.trajectory,
         "current_step_idx": widget.current_step_idx,
-        "width": widget.width,
-        "height": widget.height,
+        "style": widget.style,
         "show_controls": widget.show_controls,
         "layout": widget.layout,
         "display_mode": widget.display_mode,


### PR DESCRIPTION
- bump matterviz@^0.1.6, refactor anywidget.ts for better type safety and less overriding of Svelte prop defaults by Python defaults
  
  - remove height and width from widget args, use style arg instead
  - set TrajectoryWidget height to 600px for better appearance

- fix matterviz/app.css injection having no effect in marimo due to notebook cells being rendered in shadow dom, also fix marimo theme detection
  
  - Refactor `inject_app_css` to accept an optional `target_element` parameter for better Shadow DOM support.
  - Update `detect_parent_theme` to utilize the `target_element` for theme detection in Shadow DOM contexts.
  - Improve theme change notification and setup functions to handle the new parameter.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable CSS styling options to widgets, allowing users to set widget height, width, and style via a style string.
  * Introduced new display options such as auto-play, property labels, and units for trajectory widgets.
  * Enhanced theme detection and style scoping to support Shadow DOM environments for improved integration with various platforms.

* **Improvements**
  * Many widget properties are now optional, providing greater flexibility in customization.
  * Unified and simplified widget sizing by using CSS style strings instead of separate width and height parameters.
  * Updated default visual styling for widgets, including opacity and line width adjustments.
  * Refined widget property access with error handling for more robust rendering.

* **Bug Fixes**
  * Improved robustness and error handling in widget property access and rendering.

* **Documentation**
  * Updated example usage in widget docstrings to reflect new styling and display options.

* **Chores**
  * Updated third-party dependencies to the latest versions for improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->