### PR TITLE
Update ty suppressions and typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.12
     hooks:
       - id: ruff-check
         args: [--fix]
@@ -18,7 +18,7 @@ repos:
         language: python
         types: [python]
         pass_filenames: false
-        additional_dependencies: [ty==0.0.18]
+        additional_dependencies: [ty]
       - id: check-readme-src-links
         name: Check README source links
         entry: python .github/scripts/check_readme_src_links.py

--- a/assets/scripts/brillouin/brillouin_zone_3d.py
+++ b/assets/scripts/brillouin/brillouin_zone_3d.py
@@ -70,9 +70,9 @@ fig.show()
 
 # %% 2x4 grid
 fig = pmv.brillouin_zone_3d(
-    structures,  # type: ignore[arg-type]
+    structures,
     n_cols=4,
-    subplot_title=simple_subplot_title,  # type: ignore[arg-type]
+    subplot_title=simple_subplot_title,  # ty: ignore[invalid-argument-type]
     surface_kwargs=dict(opacity=0.4),
 )
 fig.show()
@@ -82,9 +82,9 @@ fig.show()
 # %% 3x3 grid with structure and BZ volumes
 fig = pmv.brillouin_zone_3d(
     # only pass 6 structures to avoid crowding
-    {k: v for idx, (k, v) in enumerate(structures.items()) if idx < 6},  # type: ignore[arg-type]
+    {k: v for idx, (k, v) in enumerate(structures.items()) if idx < 6},
     n_cols=3,
-    subplot_title=volume_subplot_title,  # type: ignore[arg-type]
+    subplot_title=volume_subplot_title,  # ty: ignore[invalid-argument-type]
     surface_kwargs=dict(opacity=0.4),
 )
 fig.layout.title = dict(
@@ -97,9 +97,9 @@ fig.show()
 
 # %% 4x2 grid with spacegroup information
 fig = pmv.brillouin_zone_3d(
-    structures,  # type: ignore[arg-type]
+    structures,
     n_cols=2,
-    subplot_title=spacegroup_subplot_title,  # type: ignore[arg-type]
+    subplot_title=spacegroup_subplot_title,
     surface_kwargs=dict(opacity=0.4),
 )
 fig.layout.title = dict(

--- a/assets/scripts/cluster/composition/cluster_compositions_matbench.py
+++ b/assets/scripts/cluster/composition/cluster_compositions_matbench.py
@@ -119,7 +119,7 @@ def process_dataset(
         if embed_method == "one-hot":
             embeddings = pcc.one_hot_encode(compositions)
         elif embed_method in (Embed.magpie, Embed.matscholar_el):
-            embeddings = pcc.matminer_featurize(compositions, preset=embed_method.value)  # type: ignore[arg-type]
+            embeddings = pcc.matminer_featurize(compositions, preset=embed_method.value)  # ty: ignore[invalid-argument-type]
         else:
             raise ValueError(f"Unknown {embed_method=}")
 

--- a/assets/scripts/phonons/phonon_bands.py
+++ b/assets/scripts/phonons/phonon_bands.py
@@ -75,5 +75,5 @@ bands = {
 }
 phonopy_nacl.run_band_structure(paths=list(bands.values()))
 
-fig = pmv.phonon_bands({"NaCl (phonopy)": phonopy_nacl.band_structure})  # type: ignore[arg-type]
+fig = pmv.phonon_bands({"NaCl (phonopy)": phonopy_nacl.band_structure})
 fig.show()

--- a/assets/scripts/ptable/ptable_heatmap_splits_plotly.py
+++ b/assets/scripts/ptable/ptable_heatmap_splits_plotly.py
@@ -9,7 +9,7 @@ from pymatgen.core import Element
 
 import pymatviz as pmv
 import pymatviz.colors as pmv_colors
-from pymatviz.typing import RgbColorType
+from pymatviz.typing import PTABLE_SPLIT_ORIENTATIONS, RgbColorType
 
 
 np_rng = np.random.default_rng(seed=0)
@@ -17,7 +17,7 @@ np_rng = np.random.default_rng(seed=0)
 
 # %% Examples of ptable_heatmap_splits_plotly with different numbers of splits
 for idx, (n_splits, orientation) in enumerate(
-    itertools.product(range(2, 5), ("diagonal", "horizontal", "vertical", "grid"))
+    itertools.product(range(2, 5), PTABLE_SPLIT_ORIENTATIONS)
 ):
     if orientation == "grid" and n_splits != 4:
         continue
@@ -26,7 +26,7 @@ for idx, (n_splits, orientation) in enumerate(
 
     # Example 1: Single colorscale with single colorbar
     data_dict = {
-        elem.symbol: np_rng.integers(10, 20, size=n_splits) for elem in Element
+        elem.symbol: np_rng.integers(10, 20, size=n_splits).tolist() for elem in Element
     }
     cbar_title = f"Periodic Table Heatmap with {n_splits}-fold split"
     fig = pmv.ptable_heatmap_splits_plotly(
@@ -138,7 +138,7 @@ fig.show()
 
 # %% Example 6: Mixed colorbar orientations
 # Create data with 4 splits
-data_dict = {el.symbol: np_rng.integers(0, 100, size=4) for el in Element}
+data_dict = {el.symbol: np_rng.integers(0, 100, size=4).tolist() for el in Element}
 
 # Use grid orientation with 4 different colorscales and mixed colorbar orientations
 fig = pmv.ptable_heatmap_splits_plotly(

--- a/assets/scripts/ptable/ptable_scatter_plotly.py
+++ b/assets/scripts/ptable/ptable_scatter_plotly.py
@@ -17,7 +17,7 @@ for elem in Element:
     phase = np_rng.uniform(0, 2 * np.pi)
     noise = np_rng.normal(0, 0.2, len(xs))
     ys = np.sin(freq * xs + phase) + noise
-    rand_sine_data[elem.symbol] = xs, ys  # type: ignore[assignment]
+    rand_sine_data[elem.symbol] = xs, ys
 
 
 rand_parity_data = {  # random parity data with y = x + noise
@@ -70,10 +70,10 @@ for mode, line_kwargs, marker_kwargs, symbol_kwargs, elem_data_dict, color_strat
     ),
 ]:
     fig = pmv.ptable_scatter_plotly(
-        elem_data_dict,  # type: ignore[arg-type]
-        mode=mode,  # type: ignore[arg-type]
+        elem_data_dict,
+        mode=mode,  # ty: ignore[invalid-argument-type]
         line_kwargs=line_kwargs,
-        color_elem_strategy=color_strategy,  # type: ignore[arg-type]
+        color_elem_strategy=color_strategy,  # ty: ignore[invalid-argument-type]
         scale=1.2,
         marker_kwargs=marker_kwargs,
         symbol_kwargs=symbol_kwargs,

--- a/assets/scripts/structure/structure_2d.py
+++ b/assets/scripts/structure/structure_2d.py
@@ -31,7 +31,7 @@ fig.show()
 
 # %% Example: Disordered site rendering (pie slices in 2D)
 fig = pmv.structure_2d(
-    disordered_demo_structures,  # type: ignore[arg-type]
+    disordered_demo_structures,
     elem_colors=ElemColorScheme.jmol,
     n_cols=2,
     show_cell={"edge": dict(color="darkgray", width=2)},

--- a/assets/scripts/structure/structure_3d.py
+++ b/assets/scripts/structure/structure_3d.py
@@ -50,7 +50,7 @@ fig.show()
 
 # %% Example: Disordered site rendering (multiple spheres in 3D)
 fig = pmv.structure_3d(
-    disordered_demo_structures,  # type: ignore[arg-type]
+    disordered_demo_structures,
     elem_colors=ElemColorScheme.jmol,
     n_cols=2,
     show_cell={"edge": dict(color="darkgray", width=2)},

--- a/assets/scripts/track_pymatviz_citations.py
+++ b/assets/scripts/track_pymatviz_citations.py
@@ -187,13 +187,15 @@ def fetch_scholar_papers(
             if isinstance(pub_info, dict) and "authors" in pub_info:
                 authors = [
                     author["name"]
-                    for author in pub_info.pop("authors")
+                    for author in pub_info.get("authors", [])
                     if isinstance(author, dict) and "name" in author
                 ]
 
             # Store all metadata from the result, overwrite only processed fields
-            paper: ScholarPaper = {  # type:ignore[typeddict-item]
+            paper: ScholarPaper = {
                 **result,  # Keep all original fields
+                "title": result["title"],
+                "link": result["link"],
                 "authors": authors
                 or result.get("authors", []),  # Use processed authors
                 "year": year,  # Use extracted year

--- a/examples/diatomics/plot_hetero_diatomic_curves.py
+++ b/examples/diatomics/plot_hetero_diatomic_curves.py
@@ -73,7 +73,7 @@ filtered_energies: dict[str, np.ndarray] = {}
 # First pass: collect min energies and filter data
 for elem2 in sorted_elements:
     distances, energies = map(np.asarray, diatomic_curves[elem2])
-    mask = distances >= 0.5  # type: ignore[unsupported-operator]
+    mask = distances >= 0.5
     filtered_distances[elem2] = distances[mask]
     filtered_energies[elem2] = energies[mask]
     min_energies[elem2] = min(energies[mask])

--- a/examples/mprester_ptable.ipynb
+++ b/examples/mprester_ptable.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_mp = pd.DataFrame(map(dict, mp_data)).set_index(\"material_id\")  # type: ignore[arg-type]\n",
+    "df_mp = pd.DataFrame(map(dict, mp_data)).set_index(\"material_id\")  # ty: ignore[invalid-argument-type]\n",
     "df_mp.head()"
    ]
   },
@@ -106,7 +106,7 @@
     "# %store df_mp\n",
     "\n",
     "# uncomment line to load cached MP data from disk\n",
-    "%store -r df_mp  # type: ignore[arg-type]"
+    "%store -r df_mp"
    ]
   },
   {
@@ -260,7 +260,7 @@
     "app.layout = main_layout\n",
     "\n",
     "\n",
-    "@app.callback(Output(graph.id, \"figure\"), Input(dropdown.id, \"value\"))  # type: ignore[attr-defined]\n",
+    "@app.callback(Output(graph.id, \"figure\"), Input(dropdown.id, \"value\"))\n",
     "def update_figure(dropdown_value: str) -> go.Figure:\n",
     "    \"\"\"Update figure based on dropdown value.\"\"\"\n",
     "    return arity_figs[dropdown_value]\n",

--- a/examples/widgets/vscode_interactive_demo.py
+++ b/examples/widgets/vscode_interactive_demo.py
@@ -704,7 +704,7 @@ for widgets, fmts in [
         for fmt in fmts:
             path = f"{EXPORT_DIR}/{name}.{fmt}"
             try:
-                widget.to_img(filename=path, fmt=fmt)  # type: ignore[arg-type]
+                widget.to_img(filename=path, fmt=fmt)  # ty: ignore[invalid-argument-type]
                 print(f"  saved {path}")
             except (
                 TimeoutError,

--- a/pymatviz/brillouin.py
+++ b/pymatviz/brillouin.py
@@ -14,7 +14,7 @@ from pymatviz.typing import AnyStructure
 
 
 def brillouin_zone_3d(
-    struct: AnyStructure | Sequence[AnyStructure] | dict[str, AnyStructure],
+    struct: AnyStructure | Sequence[AnyStructure] | dict[Hashable, AnyStructure],
     *,
     # Surface styling
     surface_kwargs: dict[str, Any] | None = None,

--- a/pymatviz/chem_env.py
+++ b/pymatviz/chem_env.py
@@ -82,7 +82,7 @@ def classify_local_env_with_order_params(
 
         # Get neighboring sites using CrystalNN
         crystal_nn = local_env.CrystalNN()
-        nn_info = crystal_nn.get_nn_info(structure=structure, n=site_idx)  # type: ignore[arg-type]
+        nn_info = crystal_nn.get_nn_info(structure=structure, n=site_idx)
 
         # Create sites list: central site + neighbors
         sites = [structure[site_idx]] + [info["site"] for info in nn_info]
@@ -90,7 +90,7 @@ def classify_local_env_with_order_params(
         # Calculate order parameters
         neighbor_indices = list(range(1, len(sites)))
         local_order_params = local_ops.get_order_parameters(
-            structure=structure,  # type: ignore[arg-type]
+            structure=structure,
             n=0,
             indices_neighs=neighbor_indices,
         )

--- a/pymatviz/classify/confusion_matrix.py
+++ b/pymatviz/classify/confusion_matrix.py
@@ -186,11 +186,14 @@ def confusion_matrix(
 
     # Handle metrics parameter
     if isinstance(metrics, list | tuple | set):
-        metrics_dict: dict[str, str | None] = dict.fromkeys(metrics)
+        metrics_dict: dict[Any, str | None] = dict.fromkeys(metrics)
     elif isinstance(metrics, dict):
         metrics_dict = metrics
     else:
         raise TypeError(f"Unknown {metrics=}")
+    for metric in metrics_dict:
+        if not isinstance(metric, str):
+            raise TypeError(f"Metric keys must be strings, got {type(metric).__name__}")
 
     # Add metrics annotation
     metrics_text = []
@@ -216,7 +219,7 @@ def confusion_matrix(
             ),
         }
 
-    for metric, fmt in metrics_dict.items():
+    for metric, fmt in cast("dict[str, str | None]", metrics_dict).items():
         if metric not in available_metrics:
             raise ValueError(
                 f"Unknown {metric=}. Available: {', '.join(available_metrics)}"
@@ -248,9 +251,10 @@ def confusion_matrix(
             font_size=22,
         ) | (metrics_kwargs or {})
         fig.add_annotation(**metrics_defaults)
-        if metrics_defaults.get("y", 0) >= 1:
+        y_pos = metrics_defaults.get("y", 0)
+        if isinstance(y_pos, (int, float)) and y_pos >= 1:
             fig.layout.margin.t = 60
-        if metrics_defaults.get("y", 0) <= 0:
+        if isinstance(y_pos, (int, float)) and y_pos <= 0:
             fig.layout.margin.b = 60
 
     # Update axes formatting

--- a/pymatviz/classify/curves.py
+++ b/pymatviz/classify/curves.py
@@ -69,7 +69,7 @@ def _standardize_input(
 
     if strict:
         for trace_dict in curves_dict.values():
-            curve_probs = np.asarray(trace_dict["probs_positive"])  # type: ignore[index]
+            curve_probs = np.asarray(trace_dict["probs_positive"])
             curve_probs_no_nan = curve_probs[~np.isnan(curve_probs)]
             min_prob, max_prob = curve_probs_no_nan.min(), curve_probs_no_nan.max()
             if not (0 <= min_prob <= max_prob <= 1):
@@ -77,7 +77,7 @@ def _standardize_input(
                     f"Probabilities must be in [0, 1], got range {(min_prob, max_prob)}"
                 )
 
-    return targets, curves_dict  # type: ignore[invalid-return-type]
+    return targets, curves_dict
 
 
 def roc_curve_plotly(

--- a/pymatviz/cluster/composition/plot.py
+++ b/pymatviz/cluster/composition/plot.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import math
 import warnings
-from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, get_args
 
 import numpy as np
@@ -21,7 +20,7 @@ from pymatviz.enums import LabelEnum
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Mapping, Sequence
 
     from sklearn.decomposition import KernelPCA
     from sklearn.manifold import TSNE, Isomap
@@ -375,7 +374,7 @@ def cluster_compositions(
     heatmap_colorscale: str = "Viridis",
     marker_size: int = 8,
     show_chem_sys: ShowChemSys | None = None,
-    color_discrete_map: dict[str, ColorType] | None = None,
+    color_discrete_map: Mapping[str, ColorType] | None = None,
     embedding_kwargs: dict[str, Any] | None = None,
     projection_kwargs: dict[str, Any] | None = None,
     sort: bool | int | Callable[[np.ndarray], np.ndarray] = True,
@@ -623,7 +622,9 @@ def cluster_compositions(
                         "a callable, or a valid column name in the DataFrame"
                     ) from exc
                 embeddings = matminer_featurize(
-                    compositions, preset=preset.value, **(embedding_kwargs or {})
+                    compositions,
+                    preset=preset.value,  # ty: ignore[invalid-argument-type]
+                    **(embedding_kwargs or {}),
                 )
 
         # Project embeddings
@@ -636,18 +637,20 @@ def cluster_compositions(
                 **projection_kwargs,
             )
             projector = None
-        elif projection in list(ProjectionMethod):
+        else:
             # Use built-in projection methods
+            try:
+                projection_method = ProjectionMethod(projection)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"{projection=} must be in {list(ProjectionMethod)}, "
+                    f"a callable, or column name in the DataFrame"
+                ) from exc
             projected, projector = project_vectors(
                 embeddings,
-                method=projection,  # type: ignore[arg-type]
+                method=projection_method,
                 n_components=n_components,
                 **projection_kwargs,
-            )
-        else:
-            raise ValueError(
-                f"{projection=} must be in {list(ProjectionMethod)}, "
-                f"a callable, or column name in the DataFrame"
             )
 
     # Extract chemical systems if needed
@@ -802,7 +805,7 @@ def cluster_compositions(
             sort_direction = sort
         elif callable(sort):
             # Custom sort function
-            sort_indices = sort(prop_values)
+            sort_indices = sort(np.asarray(prop_values))
             df_plot = df_plot.iloc[sort_indices]
             projected = projected[sort_indices]
             if embeddings is not None:

--- a/pymatviz/enums.py
+++ b/pymatviz/enums.py
@@ -14,7 +14,7 @@ from pymatviz.utils import PKG_DIR, html_tag
 if TYPE_CHECKING:
     from typing import Any, Self
 
-    from pymatviz.typing import RgbColorType
+    from pymatviz.typing import ColorType
 
 
 # Load YAML data at module level
@@ -22,9 +22,9 @@ with open(f"{PKG_DIR}/keys.yml", encoding="utf-8") as file:
     _key_data = yaml.safe_load(file)
 
 # Flatten nested structure and add group info
-_keys: Final[dict[str, dict[str, str]]] = {}
+_keys: dict[str, dict[str, str]] = {}
 for category, keys in _key_data.items():
-    _keys |= {key: {"category": category} | val for key, val in keys.items()}  # type: ignore[misc]
+    _keys |= {key: {"category": category} | val for key, val in keys.items()}
 
 
 # Map Unicode characters to their ASCII equivalents
@@ -895,7 +895,7 @@ class ElemColorScheme(LabelEnum):
     pastel = "pastel", "Pastel", "Pastel color scheme"
 
     @property
-    def color_map(self) -> dict[str, RgbColorType]:
+    def color_map(self) -> dict[str, ColorType]:
         """Return map from element symbol to color."""
         import pymatviz.colors as pmv_colors
 

--- a/pymatviz/histogram.py
+++ b/pymatviz/histogram.py
@@ -152,7 +152,7 @@ def histogram(
 
     fig = go.Figure(**fig_kwargs or {})
     for label, vals in data.items():
-        hist_vals, _ = np.histogram(vals, bins=bin_edges, density=density)  # type: ignore[call-overload]
+        hist_vals, _ = np.histogram(vals, bins=bin_edges, density=density)
         fig.add_bar(
             x=bin_edges[:-1],
             y=hist_vals,

--- a/pymatviz/powerups.py
+++ b/pymatviz/powerups.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from numbers import Real
 from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 
 import numpy as np
@@ -28,7 +29,7 @@ def annotate_metrics(
     xs: ArrayLike,
     ys: ArrayLike,
     fig: go.Figure | None = None,
-    metrics: dict[str, float] | Sequence[str] = ("MAE", "R2"),
+    metrics: Mapping[str, float] | Sequence[str] = ("MAE", "R2"),
     prefix: str = "",
     suffix: str = "",
     fmt: str = ".3",
@@ -43,9 +44,9 @@ def annotate_metrics(
         ys (array): y values.
         fig (go.Figure | None, optional): plotly Figure on which to add the annotation.
             Defaults to None.
-        metrics (dict[str, float] | Sequence[str], optional): Metrics to show. Can be a
-            subset of recognized keys MAE, R2, R2_adj, RMSE, MSE, MAPE or the names of
-            sklearn.metrics.regression functions or any dict of metric names and values.
+        metrics (Mapping[str, int | float] | Sequence[str], optional): Metrics to
+            show. Can be built-in metric names, sklearn metric names, or custom numeric
+            values.
             Defaults to ("MAE", "R2").
         prefix (str, optional): Title or other string to prepend to metrics.
             Defaults to "".
@@ -60,7 +61,7 @@ def annotate_metrics(
         metrics = [metrics]
     if not isinstance(fig, go.Figure):
         raise TypeError(f"{fig=} must be instance of go.Figure")
-    if not isinstance(metrics, (dict, list, tuple, set)):
+    if not isinstance(metrics, (Mapping, list, tuple, set)):
         raise TypeError(
             f"metrics must be dict|list|tuple|set, not {type(metrics).__name__}"
         )
@@ -73,10 +74,16 @@ def annotate_metrics(
         "R2": r2_score,
         "R2_adj": lambda x, y: 1 - (1 - r2_score(x, y)) * (len(x) - 1) / (len(x) - 2),
     }
-    for key in set(metrics) - set(funcs):
+    if isinstance(metrics, Mapping):
+        metric_keys = {
+            str(key) for key, val in metrics.items() if not isinstance(val, Real)
+        }
+    else:
+        metric_keys = {str(key) for key in metrics}
+    for key in metric_keys - set(funcs):
         if func := getattr(sklearn.metrics, key, None):
             funcs[key] = func
-    if bad_keys := set(metrics) - set(funcs):
+    if bad_keys := metric_keys - set(funcs):
         raise ValueError(f"Unrecognized metrics: {bad_keys}")
 
     def calculate_metrics(xs: ArrayLike, ys: ArrayLike) -> str:
@@ -89,10 +96,11 @@ def annotate_metrics(
         nan_mask = np.isnan(xs) | np.isnan(ys)
         xs, ys = xs[~nan_mask], ys[~nan_mask]
         text = prefix
-        if isinstance(metrics, dict):
+        if isinstance(metrics, Mapping):
             for key, val in metrics.items():
-                label = PRETTY_LABELS.get(key, key)  # type: ignore[arg-type]
-                text += f"{label} = {val:{fmt}}<br>"
+                label = PRETTY_LABELS.get(key, key)  # ty: ignore[no-matching-overload]
+                metric_value = float(val) if isinstance(val, Real) else val
+                text += f"{label} = {metric_value:{fmt}}<br>"
         else:
             for key in metrics:
                 value = funcs[key](xs, ys)
@@ -403,9 +411,16 @@ def add_best_fit_line(
 
             # Ensure font color is properly set
             if "color" in annotate_params:
-                if "font" not in plotly_anno_defaults:
-                    plotly_anno_defaults["font"] = dict()
-                plotly_anno_defaults["font"]["color"] = annotate_params["color"]  # type: ignore[index]
+                font = plotly_anno_defaults.get("font")
+                if not isinstance(font, dict):
+                    font_obj = cast("Any", font)
+                    font = (
+                        font_obj.to_plotly_json()
+                        if hasattr(font_obj, "to_plotly_json")
+                        else {}
+                    )
+                    plotly_anno_defaults["font"] = font
+                font["color"] = annotate_params["color"]
 
         annotate(text, fig=fig, **plotly_anno_defaults)
 

--- a/pymatviz/process_data.py
+++ b/pymatviz/process_data.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 def count_elements(
     values: ElemValues,
     count_mode: ElemCountMode = ElemCountMode.composition,
-    exclude_elements: Sequence[str] = (),
+    exclude_elements: str | Sequence[str] = (),
     fill_value: float | None = None,
 ) -> pd.Series:
     """Count element occurrence in list of formula strings or dict-like compositions.
@@ -61,7 +61,7 @@ def count_elements(
             - occurrence: Count the number of times each element occurs in a list of
                 formulas irrespective of compositions. E.g. [Fe2 O3, Fe O, Fe4 P4 O16]
                 counts to {Fe: 3, O: 3, P: 1}.
-        exclude_elements (Sequence[str]): Elements to exclude from the count.
+        exclude_elements (str | Sequence[str]): Element(s) to exclude from the count.
             Defaults to ().
         fill_value (float | None): Value to fill in for missing elements.
             Defaults to None for NaN.
@@ -127,15 +127,15 @@ def count_elements(
 
     if len(exclude_elements) > 0:
         if isinstance(exclude_elements, str):
-            exclude_elements = [exclude_elements]
-        if isinstance(exclude_elements, tuple):
-            exclude_elements = list(exclude_elements)
+            excluded_elements = [exclude_elements]
+        else:
+            excluded_elements = list(exclude_elements)
         try:
-            srs = srs.drop(exclude_elements)
+            srs = srs.drop(excluded_elements)
         except KeyError as exc:
-            bad_symbols = ", ".join(x for x in exclude_elements if x not in srs)
+            bad_symbols = ", ".join(x for x in excluded_elements if x not in srs)
             raise ValueError(
-                f"Unexpected symbol(s) {bad_symbols} in {exclude_elements=}"
+                f"Unexpected symbol(s) {bad_symbols} in {excluded_elements=}"
             ) from exc
 
     return srs
@@ -316,7 +316,7 @@ def normalize_structures(
     systems: AnyStructure
     | Sequence[AnyStructure]
     | pd.Series
-    | dict[str, AnyStructure],
+    | dict[Hashable, AnyStructure],
 ) -> dict[Hashable, Structure | IStructure | Molecule | IMolecule]:
     """Convert pymatgen Structures/IStructures, ASE Atoms, or PhonopyAtoms or
     sequences/dicts of them to a dictionary mapping hashable keys to pymatgen
@@ -375,7 +375,7 @@ def normalize_structures(
 
 def normalize_to_dict(
     inputs: T | Sequence[T] | dict[str, T],
-    cls: type[T] = SiteCollection,
+    cls: type[T] = SiteCollection,  # ty: ignore[invalid-parameter-default]
     key_gen: Callable[[T], str] = lambda obj: getattr(
         obj, "formula", type(obj).__name__
     ),
@@ -398,24 +398,27 @@ def normalize_to_dict(
         TypeError: If the input format is invalid.
     """
     if isinstance(inputs, cls):
-        return cast("dict[str, T]", {"": inputs})
+        return {key_gen(inputs): inputs}
 
-    if (
-        isinstance(inputs, list | tuple)
-        and all(isinstance(obj, cls) for obj in inputs)
-        and len(inputs) > 0
-    ):
+    if isinstance(inputs, Sequence) and not isinstance(inputs, (str, bytes)) and inputs:
         out_dict: dict[str, T] = {}
         for obj in inputs:
-            key = key_gen(obj)
+            if not isinstance(obj, cls):
+                raise TypeError(
+                    f"Invalid item in inputs, expected {cls.__name__}, "
+                    f"got {type(obj).__name__}"
+                )
+            base_key = key_gen(obj)
+            candidate = base_key
             idx = 1
-            while key in out_dict:
-                key += f" {idx}"
+            while candidate in out_dict:
+                candidate = f"{base_key} {idx}"
                 idx += 1
-            out_dict[key] = obj
+            out_dict[candidate] = obj
         return out_dict
+
     if isinstance(inputs, dict):
-        return inputs  # ty: ignore[invalid-return-type]
+        return cast("dict[str, T]", inputs)
     if isinstance(inputs, pd.Series):
         return inputs.to_dict()
 
@@ -467,24 +470,22 @@ def df_to_arrays(
         )
 
     flat_args = []
-    # tuple doesn't support item assignment
-    args = list(args)  # ty: ignore[invalid-assignment]
-
     for col_name in args:
         if isinstance(col_name, str | int):
             flat_args.append(col_name)
         else:
-            flat_args.extend(col_name)
+            flat_args.extend(col_name)  # ty: ignore[invalid-argument-type]
 
     df_no_nan = df.dropna(subset=flat_args)
-    for idx, col_name in enumerate(args):
+    out_args: list[str | ArrayLike | dict[str, ArrayLike]] = []
+    for col_name in args:
         if isinstance(col_name, str | int):
-            args[idx] = df_no_nan[col_name].to_numpy()  # ty: ignore[invalid-assignment]
+            out_args.append(df_no_nan[col_name].to_numpy())
         else:
-            col_data = df_no_nan[[*col_name]].to_numpy().T
-            args[idx] = dict(zip(col_name, col_data, strict=True))  # ty: ignore[invalid-assignment]
+            col_data = df_no_nan[[*col_name]].to_numpy().T  # ty: ignore[not-iterable]
+            out_args.append(dict(zip(col_name, col_data, strict=True)))  # ty: ignore[invalid-argument-type,no-matching-overload]
 
-    return args  # ty: ignore[invalid-return-type]
+    return out_args
 
 
 def bin_df_cols(
@@ -589,7 +590,7 @@ def normalize_spacegroups(
         from moyopy.interface import MoyoAdapter
 
         return pd.Series(
-            [MoyoDataset(MoyoAdapter.from_py_obj(struct)).number for struct in data]
+            [MoyoDataset(MoyoAdapter.from_py_obj(struct)).number for struct in data]  # ty: ignore[invalid-argument-type]
         )
 
     result = pd.Series(data)

--- a/pymatviz/ptable/figures.py
+++ b/pymatviz/ptable/figures.py
@@ -20,6 +20,7 @@ from pymatviz.typing import (
     VALID_COLOR_ELEM_STRATEGIES,
     ColorElemTypeStrategy,
     ElemValues,
+    PTableSplitOrientation,
 )
 from pymatviz.utils import df_ptable
 from pymatviz.utils.data import si_fmt
@@ -208,7 +209,7 @@ def ptable_heatmap_plotly(
     if label_map is None:
         # default to space string for None, np.nan and "nan". space is needed
         # for <br> in tile_text to work so all element symbols are vertically aligned
-        label_map = dict.fromkeys([np.nan, None, "nan", "nan%"], "-")  # type: ignore[list-item]
+        label_map = dict.fromkeys([np.nan, None, "nan", "nan%"], "-")  # ty: ignore[invalid-assignment]
 
     all_ints = all(isinstance(val, int) for val in values)
     counts_total = values.sum()
@@ -388,7 +389,10 @@ def ptable_heatmap_plotly(
         orig_max = np.ceil(max(non_nan_values))
         tick_values = np.logspace(orig_min, orig_max, num=10, endpoint=True)
         tick_values = [round(val, -int(np.floor(np.log10(val)))) for val in tick_values]
-        tick_values = list(colorbar.pop("tickvals", tick_values))
+        tick_values = [
+            float(val)
+            for val in cast("Sequence[Any]", colorbar.pop("tickvals", tick_values))
+        ]
         if any(val <= 0 for val in tick_values):
             raise ValueError(
                 f"tickvals must be positive for log scale, got {tick_values}"
@@ -397,7 +401,9 @@ def ptable_heatmap_plotly(
         custom_ticktext = colorbar.pop("ticktext", None)
 
         if custom_ticktext is not None:
-            ticktext = [str(t) for t in custom_ticktext]
+            if isinstance(custom_ticktext, str):
+                custom_ticktext = [custom_ticktext]
+            ticktext = [str(tick) for tick in custom_ticktext]  # ty: ignore[not-iterable]
         else:
             # Auto-increase precision to avoid duplicate labels
             # Extract precision and format type from format like ".2f" or ".10g"
@@ -774,7 +780,8 @@ def _add_colorbar_trace(
     """Add an invisible scatter trace with a colorbar to the figure."""
     # For callable colorscales, sample at endpoints to create a 2-point colorscale
     if callable(colorscale):
-        colorscale = [[0, colorscale("", cmin, 0)], [1, colorscale("", cmax, 0)]]  # type: ignore[assignment]
+        color_fn = cast("Callable[[str, float, int], str]", colorscale)
+        colorscale = [[0, color_fn("", cmin, 0)], [1, color_fn("", cmax, 0)]]  # ty: ignore[invalid-assignment]
 
     # Ensure tickformat is included in colorbar settings
     if "tickformat" not in colorbar:
@@ -855,7 +862,7 @@ def ptable_heatmap_splits_plotly(
     ),
     *,
     # Split
-    orientation: Literal["diagonal", "horizontal", "vertical", "grid"] = "diagonal",
+    orientation: PTableSplitOrientation = "diagonal",
     # Figure
     colorscale: ColorScale | Sequence[ColorScale] = "Viridis",
     colorbar: dict[str, Any] | Sequence[dict[str, Any]] | Literal[False] | None = None,
@@ -989,9 +996,9 @@ def ptable_heatmap_splits_plotly(
         split_labels = list(data.columns)
         # Propagate column names to colorbar titles if not explicitly set
         if isinstance(colorbar, dict):
-            colorbar = colorbar.copy()  # type: ignore[arg-type]
-            if "title" not in colorbar:  # type: ignore[arg-type]
-                colorbar["title"] = split_labels[0] if len(split_labels) == 1 else None  # type: ignore[arg-type]
+            colorbar = colorbar.copy()  # ty: ignore[invalid-assignment]
+            if "title" not in colorbar:  # ty: ignore[unsupported-operator]
+                colorbar["title"] = split_labels[0] if len(split_labels) == 1 else None  # ty: ignore[invalid-assignment]
         elif isinstance(colorbar, Sequence):
             colorbar = list(colorbar)  # Convert to list to allow modification
             for idx, (cbar, label) in enumerate(
@@ -1015,9 +1022,26 @@ def ptable_heatmap_splits_plotly(
     if not split_labels:  # if not DataFrame or empty columns
         split_labels = [f"Split {idx + 1}" for idx in range(n_splits)]
 
-    use_multiple_cbar = (
-        isinstance(colorscale, Sequence) and not isinstance(colorscale, str)
-    ) or isinstance(colorbar, Sequence)
+    def is_multi_colorscale(obj: object) -> bool:
+        """Distinguish multiple colorscales from a single list of color tokens."""
+        if not isinstance(obj, Sequence) or isinstance(obj, str):
+            return False
+        named_colorscales = set(plotly.colors.named_colorscales())
+        if all(isinstance(item, str) for item in obj):
+            return all(
+                item.lower().removesuffix("_r") in named_colorscales
+                for item in cast("Sequence[str]", obj)
+            )
+        return all(
+            callable(item)
+            or isinstance(item, Mapping)
+            or (isinstance(item, Sequence) and not isinstance(item, str))
+            for item in obj
+        )
+
+    use_multiple_cbar = is_multi_colorscale(colorscale) or isinstance(
+        colorbar, Sequence
+    )
 
     # Calculate ranges per split
     split_ranges = []
@@ -1041,17 +1065,17 @@ def ptable_heatmap_splits_plotly(
             if not isinstance(colorscale, Sequence) or isinstance(colorscale, str)
             else colorscale
         )
-        colorbars = (
-            [colorbar or {}] * len(colorscales)
-            if not isinstance(colorbar, Sequence)
-            else colorbar
-        )
 
         # Validate lengths
         if len(colorscales) != n_splits:
             raise ValueError(
                 f"Number of colorscales ({len(colorscales)}) must match {n_splits=}"
             )
+        colorbars = list(
+            [colorbar or {}] * n_splits
+            if not isinstance(colorbar, Sequence)
+            else colorbar
+        )
         if len(colorbars) != n_splits:
             raise ValueError(
                 f"Number of colorbars ({len(colorbars)}) must match {n_splits=}"
@@ -1061,15 +1085,18 @@ def ptable_heatmap_splits_plotly(
         colorscales = [colorscale] * n_splits
         colorbars = [colorbar or {}]
 
+    colorscales = cast("list[ColorScale]", list(colorscales))
+    colorbars = cast("list[dict[str, Any]]", colorbars)
+
     # Validate colorscales
     validator = colorscale_validator
     for idx, cscale in enumerate(colorscales):
         if callable(cscale):
             continue
         if isinstance(cscale, str):
-            colorscales[idx] = validator.validate_coerce(cscale)  # type: ignore[index]
+            colorscales[idx] = validator.validate_coerce(cscale)  # ty: ignore[invalid-assignment]
         else:
-            colorscales[idx] = validator.validate_coerce(list(cscale))  # type: ignore[index]
+            colorscales[idx] = validator.validate_coerce(list(cscale))  # ty: ignore[invalid-assignment]
 
     # Initialize figure with subplots
     has_f_block_data = any(
@@ -1098,7 +1125,7 @@ def ptable_heatmap_splits_plotly(
 
     def create_section_coords(
         n_splits: Literal[2, 3, 4],
-        orientation: Literal["diagonal", "horizontal", "vertical", "grid"],
+        orientation: PTableSplitOrientation,
     ) -> list[tuple[list[float], list[float]]]:
         """Generate x,y coordinates to split a unit square into n equal sections."""
         if orientation == "grid":
@@ -1183,11 +1210,13 @@ def ptable_heatmap_splits_plotly(
         # Get values and colors
         values = np.asarray(data.get(symbol, []), dtype=float)
 
-        if len(values) not in {2, 3, 4}:
-            raise ValueError(f"Number of splits {len(values)} must be 2, 3, or 4")
+        n_sections = len(values)
+        if n_sections not in {2, 3, 4}:
+            raise ValueError(f"Number of splits {n_sections} must be 2, 3, or 4")
+        n_sections = cast("Literal[2, 3, 4]", n_sections)
 
         # Create sections
-        sections = create_section_coords(len(values), orientation)  # type: ignore[arg-type]
+        sections = create_section_coords(n_sections, orientation)
         split_colors: list[str] = []  # Store colors for each split
         for idx, (xs, ys) in enumerate(sections):  # Loop over element tile splits
             if values[idx] == 0:
@@ -1518,7 +1547,7 @@ def ptable_heatmap_splits_plotly(
 
             # Get colorbar settings with consistent positioning
             cbar_settings = _get_colorbar_settings(
-                cbar,  # type: ignore[arg-type]
+                cbar,
                 split_idx=split_idx,
                 n_splits=n_splits if use_multiple_cbar else 1,
                 split_name=split_name if use_multiple_cbar else None,
@@ -1540,7 +1569,7 @@ def ptable_heatmap_splits_plotly(
                     else colorbars[0]
                 )
                 cbar_settings = _get_colorbar_settings(
-                    cbar,  # type: ignore[arg-type]
+                    cbar,
                     split_idx=split_idx,
                     n_splits=n_splits,
                     split_name=split_name,
@@ -1555,7 +1584,11 @@ def ptable_heatmap_splits_plotly(
 ElemData: TypeAlias = (
     tuple[Sequence[float], Sequence[float]]
     | tuple[Sequence[float], Sequence[float], Sequence[float | str]]
-    | dict[str, tuple[Sequence[float], Sequence[float]]]
+    | Mapping[str, tuple[Sequence[float], Sequence[float]]]
+)
+LineData: TypeAlias = (
+    tuple[Sequence[float], Sequence[float]]
+    | tuple[Sequence[float], Sequence[float], Sequence[float | str]]
 )
 
 
@@ -1699,10 +1732,11 @@ def ptable_scatter_plotly(
         all_y_vals: list[float] = []
         # _* to ignore optional color data
         for elem_data in data.values():
-            for x_vals, y_vals, *_ in (
-                # handle both single line and multiple lines per element cases
-                elem_data if isinstance(elem_data, dict) else {"": elem_data}
-            ).values():
+            line_data = cast(
+                "Mapping[str, LineData]",
+                elem_data if isinstance(elem_data, Mapping) else {"": elem_data},
+            )
+            for x_vals, y_vals, *_ in line_data.values():
                 all_x_vals.extend(x_vals)
                 all_y_vals.extend(y_vals)
 
@@ -1720,11 +1754,13 @@ def ptable_scatter_plotly(
     # Find global color range if any numeric color values exist
     cbar_min, cbar_max = float("inf"), float("-inf")
     for elem_values in data.values():
-        for elem_data in (
-            elem_values if isinstance(elem_values, dict) else {"": elem_values}
-        ).values():
+        line_data = cast(
+            "Mapping[str, LineData]",
+            elem_values if isinstance(elem_values, Mapping) else {"": elem_values},
+        )
+        for elem_data in line_data.values():
             if len(elem_data) > 2:  # Has color data
-                color_vals = elem_data[2]  # type: ignore[index]
+                color_vals = elem_data[2]  # ty: ignore[index-out-of-bounds]
                 if all(isinstance(val, int | float) for val in color_vals):
                     cbar_min = min(cbar_min, *color_vals)
                     cbar_max = max(cbar_max, *color_vals)
@@ -1738,14 +1774,14 @@ def ptable_scatter_plotly(
 
     # Track whether we're plotting multiple lines per element
     line_colors: dict[str, str] | None = None
-    has_multiple_lines = any(isinstance(val, dict) for val in data.values())
+    has_multiple_lines = any(isinstance(val, Mapping) for val in data.values())
 
     if has_multiple_lines:
         # Get all unique line names across elements for consistent colors
         line_names = {
             key
             for elem_data in data.values()
-            if isinstance(elem_data, dict)
+            if isinstance(elem_data, Mapping)
             for key in elem_data
         }
         # Create color map for line names
@@ -1789,7 +1825,10 @@ def ptable_scatter_plotly(
 
         symbol_data = data[symbol]
         # Add line plot if data exists for this element
-        elem_data = symbol_data if isinstance(symbol_data, dict) else {"": symbol_data}
+        elem_data = cast(
+            "Mapping[str, LineData]",
+            symbol_data if isinstance(symbol_data, Mapping) else {"": symbol_data},
+        )
         for line_name, elem_vals in elem_data.items():
             x_vals, y_vals, *rest = elem_vals
             color_vals = rest[0] if rest else None  # if 3-tuple, first entry is color

--- a/pymatviz/rainclouds.py
+++ b/pymatviz/rainclouds.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import warnings
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
@@ -14,7 +16,6 @@ from scipy import stats
 
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
     from typing import Literal
 
 
@@ -32,7 +33,11 @@ def rainclouds(
     scale: Literal["area", "count", "width"] = "area",
     rain_offset: float = -0.25,
     offset: float | None = None,
-    hover_data: Sequence[str] | dict[str, Sequence[str]] | None = None,
+    hover_data: (
+        Sequence[str]
+        | Mapping[str, Sequence[str] | Mapping[str, Sequence[object]]]
+        | None
+    ) = None,
     show_violin: bool = True,
     show_box: bool = True,
     show_points: bool = True,
@@ -69,10 +74,10 @@ def rainclouds(
         rain_offset (float, optional): Shift the strip plot position. Defaults to -0.25.
         offset (float | None, optional): Shift the violin plot position.
             Defaults to None.
-        hover_data (Sequence[str] | dict[str, Sequence[str]] | None, optional):
-            Additional data to be shown in hover tooltips. Can be a list of column names
-            or a dict with the same keys as data and different column names for each
-            trace.
+        hover_data: Extra hover data. Pass None to show only plotted values. For
+            DataFrame-backed data, pass column names like ["temperature", "pressure"],
+            or a mapping from trace label to column names or per-point arrays, e.g.
+            {"train": ["temperature"]} or {"train": {"source": ["DFT", "ML"]}}.
         show_violin (bool, optional): Whether to show the violin plot. Defaults to True.
         show_box (bool, optional): Whether to show the box plot. Defaults to True.
         show_points (bool, optional): Whether to show the strip plot points.
@@ -107,17 +112,28 @@ def rainclouds(
                 hover_data = [col]
             elif isinstance(hover_data, list) and col not in hover_data:
                 hover_data = [col, *hover_data]
-            elif isinstance(hover_data, dict) and label in hover_data:
-                existing = hover_data[label]  # ty: ignore[invalid-argument-type]
-                if isinstance(existing, list) and col not in existing:
+            elif isinstance(hover_data, Mapping):
+                hover_map = cast(
+                    "Mapping[str, Sequence[str] | Mapping[str, Sequence[object]]]",
+                    hover_data,
+                )
+                existing = hover_map.get(label)
+                if (
+                    isinstance(existing, Sequence)
+                    and not isinstance(existing, (str, bytes))
+                    and col not in existing
+                ):
                     # avoid mutating caller's dict by creating a new one
-                    hover_data = {**hover_data, label: [col, *existing]}  # ty: ignore[invalid-assignment]
+                    hover_data = {**hover_map, label: [col, *existing]}
         else:
             values = data_itm
 
         if show_violin:  # the cloud
             kde = stats.gaussian_kde(values, bw_method=bw)
-            x_range = np.linspace(min(values) - cut, max(values) + cut, 100)
+            numeric_values = np.asarray(values, dtype=float)
+            x_range = np.linspace(
+                numeric_values.min() - cut, numeric_values.max() + cut, 100
+            )
             y_range = kde(x_range)
 
             if scale == "area":
@@ -179,23 +195,43 @@ def rainclouds(
             hover_text = [f"{label}<br>{hover_key}: {val:.3g}" for val in values]
 
             if hover_data is not None:
-                if isinstance(hover_data, dict):
-                    cols_to_show: Sequence[str] = hover_data.get(label, [])  # type: ignore[assignment]
-                else:
-                    cols_to_show = hover_data
-
-                if isinstance(data_itm, tuple) and isinstance(
-                    cols_to_show, (list, tuple)
-                ):
-                    df_i, col = data_itm
-                    for col in cols_to_show:
-                        if col in df_i:  # type: ignore[operator]
-                            for val_idx, val in enumerate(df_i[col]):  # type: ignore[index]
-                                hover_text[val_idx] += f"<br>{col}: {val}"
-                elif isinstance(hover_data, dict):
-                    for col, col_data in hover_data.get(label, {}).items():  # type: ignore[union-attr]
-                        for val_idx, val in enumerate(col_data):
+                extra_hover = (
+                    cast(
+                        "Mapping[str, Sequence[str] | Mapping[str, Sequence[object]]]",
+                        hover_data,
+                    ).get(label)
+                    if isinstance(hover_data, Mapping)
+                    else None
+                )
+                if isinstance(extra_hover, Mapping):
+                    for col, col_data in extra_hover.items():
+                        if isinstance(col_data, (str, bytes)):
+                            continue
+                        col_values = list(cast("Sequence[object]", col_data))
+                        if len(col_values) != len(hover_text):
+                            warnings.warn(
+                                f"Skipping hover column {col!r}: "
+                                f"{len(col_values)=} != {len(hover_text)=}",
+                                stacklevel=2,
+                            )
+                            continue
+                        for val_idx, val in enumerate(col_values):
                             hover_text[val_idx] += f"<br>{col}: {val}"
+                elif (
+                    len(data_itm) == 2
+                    and isinstance(df_i := data_itm[0], pd.DataFrame)
+                    and isinstance(data_itm[1], str)
+                    and (
+                        cols_to_show := extra_hover
+                        if isinstance(hover_data, Mapping)
+                        else hover_data
+                    )
+                    and not isinstance(cols_to_show, str)
+                ):
+                    for hover_col in cols_to_show:
+                        if hover_col in df_i:
+                            for val_idx, val in enumerate(df_i[hover_col]):
+                                hover_text[val_idx] += f"<br>{hover_col}: {val}"
 
             common_scatter_kwargs = dict(
                 mode="markers",

--- a/pymatviz/scatter.py
+++ b/pymatviz/scatter.py
@@ -28,8 +28,8 @@ def _get_axis_labels(
     """Extract axis labels from data or column names."""
     if df is not None:
         # x, y are column names (str) when df is provided
-        xlabel: str = getattr(df[x], "name", x)  # type: ignore[arg-type]
-        ylabel: str = getattr(df[y], "name", y)  # type: ignore[arg-type]
+        xlabel: str = getattr(df[x], "name", x)
+        ylabel: str = getattr(df[y], "name", y)
     else:
         xlabel = getattr(x, "name", x if isinstance(x, str) else "Actual")
         ylabel = getattr(y, "name", y if isinstance(y, str) else "Predicted")
@@ -471,9 +471,7 @@ def density_hexbin(
     xlabel, ylabel = _get_axis_labels(x, y, df)
 
     # Use numpy's histogram2d for initial binning, then convert to hex coordinates
-    hist, x_edges, y_edges = np.histogram2d(  # type: ignore[no-matching-overload]
-        xs, ys, bins=gridsize, weights=weights
-    )
+    hist, x_edges, y_edges = np.histogram2d(xs, ys, bins=gridsize, weights=weights)
 
     # Create hexagonal grid from rectangular bins
     x_centers = (x_edges[:-1] + x_edges[1:]) / 2

--- a/pymatviz/structure/figures.py
+++ b/pymatviz/structure/figures.py
@@ -178,7 +178,7 @@ def structure_2d(
             )
 
             if is_struct_key_mapping:  # is map of structure keys to color schemes
-                struct_elem_colors = elem_colors.get(struct_key, ElemColorScheme.jmol)  # type: ignore[arg-type]
+                struct_elem_colors = elem_colors.get(struct_key, ElemColorScheme.jmol)  # ty: ignore[no-matching-overload]
 
         _elem_colors = helpers.get_elem_colors(struct_elem_colors)
 
@@ -359,7 +359,7 @@ def structure_2d(
             # Handle per-structure show_bonds settings if it's a dict
             struct_show_bonds: bool | NearNeighbors
             if isinstance(show_bonds, dict):
-                struct_show_bonds = show_bonds.get(struct_key, False)  # type: ignore[assignment]
+                struct_show_bonds = show_bonds.get(struct_key, False)  # ty: ignore[no-matching-overload]
             else:
                 struct_show_bonds = show_bonds
 
@@ -587,7 +587,7 @@ def structure_3d(
             )
 
             if is_struct_key_mapping:  # is map of structure keys to color schemes
-                struct_elem_colors = elem_colors.get(struct_key, ElemColorScheme.jmol)  # type: ignore[arg-type]
+                struct_elem_colors = elem_colors.get(struct_key, ElemColorScheme.jmol)  # ty: ignore[no-matching-overload]
 
         _elem_colors = helpers.get_elem_colors(struct_elem_colors)
 
@@ -730,7 +730,7 @@ def structure_3d(
             # Handle per-structure show_bonds settings if it's a dict
             struct_show_bonds: bool | NearNeighbors
             if isinstance(show_bonds, dict):
-                struct_show_bonds = show_bonds.get(struct_key, False)  # type: ignore[assignment]
+                struct_show_bonds = show_bonds.get(struct_key, False)  # ty: ignore[no-matching-overload]
             else:
                 struct_show_bonds = show_bonds
 

--- a/pymatviz/structure/helpers.py
+++ b/pymatviz/structure/helpers.py
@@ -102,7 +102,7 @@ def get_struct_prop(
     if is_ase_atoms(struct):
         prop_value = struct.info.get(prop_name)
     elif hasattr(struct, "properties"):
-        prop_value = struct.properties.get(prop_name)  # ty: ignore[unresolved-attribute]
+        prop_value = struct.properties.get(prop_name)
 
     if prop_value is not None:
         return prop_value
@@ -161,7 +161,7 @@ def get_site_symbol(site: PeriodicSite) -> str:
     if isinstance(species, Composition):
         el_amt_dict = species.get_el_amt_dict()
         if el_amt_dict:
-            return max(el_amt_dict, key=el_amt_dict.get)  # ty: ignore[no-matching-overload]
+            return max(el_amt_dict, key=el_amt_dict.get)
         if species.elements:
             return species.elements[0].symbol
         return "X"
@@ -314,7 +314,7 @@ def get_elem_colors(
     if isinstance(elem_colors, Mapping):
         return dict(elem_colors)
     if isinstance(elem_colors, ElemColorScheme):
-        return elem_colors.color_map  # type: ignore[return-value]
+        return elem_colors.color_map
     raise ValueError(
         f"colors must be a dict or one of ('{', '.join(ElemColorScheme)}')"
     )
@@ -396,7 +396,7 @@ def get_subplot_title(
             from moyopy import MoyoDataset
             from moyopy.interface import MoyoAdapter
 
-            spg_num = MoyoDataset(MoyoAdapter.from_py_obj(struct_i)).number  # ty: ignore[invalid-argument-type]
+            spg_num = MoyoDataset(MoyoAdapter.from_py_obj(struct_i)).number
             title_dict["text"] = f"{idx}. {struct_i.formula} (spg={spg_num})"
         else:  # For str or any other Hashable type, convert to string
             title_dict["text"] = str(struct_key)
@@ -481,9 +481,14 @@ def normalize_elem_color(raw_color_from_map: ColorType) -> str:
         and len(raw_color_from_map) == 3
         and all(isinstance(c, (float, int)) for c in raw_color_from_map)
     ):
+        red, green, blue = cast(
+            "tuple[int | float, int | float, int | float]", raw_color_from_map
+        )
         rgb = [
-            int(c * 255) if isinstance(c, float) and 0 <= c <= 1 else int(c)  # type: ignore[arg-type]
-            for c in raw_color_from_map
+            int(channel * 255)
+            if isinstance(channel, float) and 0 <= channel <= 1
+            else int(channel)
+            for channel in (red, green, blue)
         ]
         r, g, b = rgb
         return f"rgb({r},{g},{b})"
@@ -576,7 +581,7 @@ def draw_site(
 
     # Handle ordered sites (single species)
     majority_species = (
-        max(species, key=species.get) if isinstance(species, Composition) else species  # ty: ignore[no-matching-overload]
+        max(species, key=species.get) if isinstance(species, Composition) else species
     )
     if not isinstance(majority_species, Species):
         majority_species = Species(str(majority_species))
@@ -1520,7 +1525,7 @@ def draw_bonds(
 
     for site_idx, site1 in enumerate(structure):
         try:
-            connections = nn.get_nn_info(structure, n=site_idx)  # ty: ignore[invalid-argument-type]
+            connections = nn.get_nn_info(structure, n=site_idx)
         except ValueError as exc:
             if "No Voronoi neighbors found" in str(exc):
                 warnings.warn(

--- a/pymatviz/sunburst/chem_env.py
+++ b/pymatviz/sunburst/chem_env.py
@@ -127,7 +127,7 @@ def _chem_env_sunburst_chem_env(
 
         for structure in structs:
             try:
-                lgf.setup_structure(structure=structure)  # type: ignore[arg-type]
+                lgf.setup_structure(structure=structure)
                 structure_environments = lgf.compute_structure_environments()
                 lse = (
                     struct_envs.LightStructureEnvironments.from_structure_environments(
@@ -206,12 +206,12 @@ def _chem_env_sunburst_crystal_nn(
                 # Get coordination info for each site
                 for site_idx in range(len(structure)):
                     # Get coordination number
-                    nn_info = crystal_nn.get_nn_info(structure, site_idx)  # type: ignore[arg-type]
+                    nn_info = crystal_nn.get_nn_info(structure, site_idx)
                     cn_val = len(nn_info)
 
                     # Get best matching coordination environment using order parameters
                     ce_symbol = chem_env.classify_local_env_with_order_params(
-                        structure,  # type: ignore[arg-type]
+                        structure,
                         site_idx,
                         cn_val,
                     )

--- a/pymatviz/sunburst/spacegroup.py
+++ b/pymatviz/sunburst/spacegroup.py
@@ -57,8 +57,7 @@ def spacegroup_sunburst(
         from moyopy.interface import MoyoAdapter
 
         series = pd.Series(
-            MoyoDataset(MoyoAdapter.from_py_obj(struct)).number  # type: ignore[arg-type]
-            for struct in data
+            MoyoDataset(MoyoAdapter.from_py_obj(struct)).number for struct in data
         )
     else:
         series = pd.Series(data)

--- a/pymatviz/treemap/chem_env.py
+++ b/pymatviz/treemap/chem_env.py
@@ -183,7 +183,7 @@ def _chem_env_treemap_chem_env(
 
         for structure in structs:
             try:
-                lgf.setup_structure(structure=structure)  # type: ignore[arg-type]
+                lgf.setup_structure(structure=structure)
                 structure_environments = lgf.compute_structure_environments()
                 lse = (
                     struct_envs.LightStructureEnvironments.from_structure_environments(
@@ -264,12 +264,12 @@ def _chem_env_treemap_crystal_nn(
                 # Get coordination info for each site
                 for site_idx in range(len(structure)):
                     # Get coordination number
-                    nn_info = crystal_nn.get_nn_info(structure, site_idx)  # type: ignore[arg-type]
+                    nn_info = crystal_nn.get_nn_info(structure, site_idx)
                     cn_val = len(nn_info)
 
                     # Get best matching coordination environment using order parameters
                     ce_symbol = chem_env.classify_local_env_with_order_params(
-                        structure,  # type: ignore[arg-type]
+                        structure,
                         site_idx,
                         cn_val,
                     )

--- a/pymatviz/treemap/py_pkg.py
+++ b/pymatviz/treemap/py_pkg.py
@@ -884,7 +884,7 @@ def py_pkg_treemap(
                 metadata = importlib.metadata.metadata(package)
 
                 # Try Home-page first, then Project-URL entries
-                homepage = metadata.get("Home-page")  # type: ignore[attr-defined] https://github.com/astral-sh/ty/issues/1134
+                homepage = metadata.get("Home-page")  # ty: ignore[unresolved-attribute] https://github.com/astral-sh/ty/issues/1134
                 if homepage and "github.com" in homepage:
                     github_url_found = homepage
                 else:

--- a/pymatviz/typing.py
+++ b/pymatviz/typing.py
@@ -27,6 +27,13 @@ AnyDos: TypeAlias = Union[PhononDos, "TotalDos"]
 ColorElemTypeStrategy: TypeAlias = Literal["symbol", "background", "both", "off"]
 VALID_COLOR_ELEM_STRATEGIES = get_args(ColorElemTypeStrategy)
 
+PTableSplitOrientation: TypeAlias = Literal[
+    "diagonal", "horizontal", "vertical", "grid"
+]
+PTABLE_SPLIT_ORIENTATIONS: tuple[PTableSplitOrientation, ...] = get_args(
+    PTableSplitOrientation
+)
+
 CrystalSystem: TypeAlias = Literal[
     "triclinic",
     "monoclinic",

--- a/pymatviz/utils/plotting.py
+++ b/pymatviz/utils/plotting.py
@@ -179,7 +179,10 @@ def luminance(color: ColorType) -> float:
             raise ValueError(f"Unsupported color format: {color}")
     elif isinstance(color, tuple) and len(color) >= 3:
         # Extract RGB values (first 3 elements must be numeric for valid colors)
-        r, g, b = float(color[0]), float(color[1]), float(color[2])  # type: ignore[arg-type]
+        try:
+            r, g, b = [float(cast("Any", channel)) for channel in color[:3]]
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Unsupported color tuple: {color}") from exc
         # Check if any value is > 1, indicating 0-255 range
         if r > 1 or g > 1 or b > 1:
             r, g, b = r / 255, g / 255, b / 255

--- a/pymatviz/widgets/_normalize.py
+++ b/pymatviz/widgets/_normalize.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import math
 import re
-from typing import Any
+from typing import Any, cast
 
 
 def _normalize_ferrox_hkls(hkls_data: Any) -> Any:
@@ -295,7 +295,9 @@ def normalize_convex_hull_entries(obj: Any) -> list[dict[str, Any]] | None:
     if obj is None:
         return None
     if isinstance(obj, (list, tuple)):
-        entries = obj if isinstance(obj, list) else list(obj)
+        entries = cast(
+            "list[dict[str, Any]]", obj if isinstance(obj, list) else list(obj)
+        )
         return _normalize_entry_compositions(entries)
 
     try:

--- a/pymatviz/widgets/heatmap_matrix.py
+++ b/pymatviz/widgets/heatmap_matrix.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import traitlets as tl
 
@@ -10,8 +10,12 @@ from pymatviz.widgets._normalize import normalize_plot_json
 from pymatviz.widgets.matterviz import MatterVizWidget
 
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
 def _normalize_axis_items(
-    items: list[str | dict[str, Any]],
+    items: Sequence[str | dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Convert axis items to the ``{key, label}`` dicts expected by the JS component.
 
@@ -71,8 +75,8 @@ class HeatmapMatrixWidget(MatterVizWidget):
 
     def __init__(
         self,
-        x_items: list[str | dict[str, Any]] | None = None,
-        y_items: list[str | dict[str, Any]] | None = None,
+        x_items: str | Sequence[str | dict[str, Any]] | None = None,
+        y_items: str | Sequence[str | dict[str, Any]] | None = None,
         values: list[list[float]] | dict[str, dict[str, float]] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -86,10 +90,13 @@ class HeatmapMatrixWidget(MatterVizWidget):
             values: 2D list of values or nested dict keyed by item keys.
             **kwargs: Additional widget properties.
         """
+        x_axis_items = [x_items] if isinstance(x_items, str) else x_items or []
+        y_axis_items = [y_items] if isinstance(y_items, str) else y_items or []
+
         super().__init__(
             widget_type="heatmap_matrix",
-            x_items=_normalize_axis_items(x_items or []),
-            y_items=_normalize_axis_items(y_items or []),
+            x_items=_normalize_axis_items(x_axis_items),
+            y_items=_normalize_axis_items(y_axis_items),
             values=normalize_plot_json(values, "HeatmapMatrix.values"),
             **kwargs,
         )

--- a/pymatviz/widgets/matterviz.py
+++ b/pymatviz/widgets/matterviz.py
@@ -57,9 +57,12 @@ def _marimo_esm_url(esm_text: str) -> str | None:
 
     # Resolve ./@file/ to absolute URL via request context, fall back to relative
     try:
-        base = get_context().request.base_url
+        request = get_context().request
     except (RuntimeError, AttributeError, TypeError):
         return relative_url
+    if request is None:
+        return relative_url
+    base = request.base_url
     if not isinstance(base, dict):
         return relative_url
     scheme, netloc = base.get("scheme"), base.get("netloc")
@@ -120,9 +123,13 @@ def configure_assets(
         esm_content = fetch_widget_asset("matterviz.js", version)
         css_content = fetch_widget_asset("matterviz.css", version)
     else:
+        if esm_src is None:
+            raise ValueError(
+                "configure_assets() requires 'esm_src' when no version is provided."
+            )
         if css_src is None:
-            css_src = re.sub(r"\.m?js$", ".css", esm_src)  # type: ignore[arg-type]
-        esm_content = _read_asset_source(esm_src)  # type: ignore[arg-type]
+            css_src = re.sub(r"\.m?js$", ".css", esm_src)
+        esm_content = _read_asset_source(esm_src)
         css_content = _read_asset_source(css_src)
 
     cls._asset_cache["default"] = (esm_content, css_content)
@@ -387,7 +394,10 @@ class MatterVizWidget(AnyWidget):
         else:
             cls = type(self)
             cls._set_class_assets()
-            esm_content, css_content = cls._asset_cache["default"]  # type: ignore[misc]
+            default_assets = cls._asset_cache["default"]
+            if not isinstance(default_assets, tuple):
+                raise TypeError("Default widget assets were not initialized correctly.")
+            esm_content, css_content = default_assets
 
         img_bytes = render_widget_headless(
             widget_data=self.to_dict(),

--- a/pymatviz/widgets/mime.py
+++ b/pymatviz/widgets/mime.py
@@ -128,4 +128,4 @@ def register_matterviz_widgets() -> None:
     # Register _display_ for marimo auto-rendering
     for cls in _AUTO_DISPLAY:
         if not hasattr(cls, "_display_"):
-            cls._display_ = create_widget  # type: ignore[attr-defined]
+            cls._display_ = create_widget  # ty: ignore[invalid-assignment]

--- a/pymatviz/widgets/web/anywidget.ts
+++ b/pymatviz/widgets/web/anywidget.ts
@@ -97,9 +97,10 @@ const cleanup_element = (element: HTMLElement): void => {
 
 const get_prop = (model: AnyModel, key: string) => {
   try {
-    return model.get(key) ?? undefined
+    return model.get(key) ?? void 0
   } catch {
-    return
+    // Missing trait values are omitted from the frontend props object.
+    return void 0
   }
 }
 

--- a/pymatviz/widgets/web/package.json
+++ b/pymatviz/widgets/web/package.json
@@ -11,17 +11,17 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "@types/node": "^22.0.0",
-    "anywidget": "^0.9.21",
-    "matterviz": "^0.3.2",
-    "svelte": "^5.50.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.13",
-    "vite-plus": "^0.1.13"
+    "@types/node": "^25.6.0",
+    "anywidget": "^0.11.0",
+    "matterviz": "^0.3.4",
+    "svelte": "^5.55.5",
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.20",
+    "vite-plus": "^0.1.20"
   },
   "overrides": {
     "@sveltejs/vite-plugin-svelte": {
       "vite": "$vite"
     },
-    "svelte": "^5.50.0"
+    "svelte": "$svelte"
   }
 }

--- a/pymatviz/widgets/web/theme-detection.ts
+++ b/pymatviz/widgets/web/theme-detection.ts
@@ -191,7 +191,9 @@ export function cleanup_theme_watchers(): void {
 
 export function on_theme_change(callback: (theme_type: ThemeType) => void): () => void {
   theme_observers.add(callback)
-  return () => theme_observers.delete(callback)
+  return () => {
+    theme_observers.delete(callback)
+  }
 }
 
 export function get_theme_css(theme_type: ThemeType, is_shadow_dom = false): string {

--- a/pymatviz/widgets/web/vite.config.ts
+++ b/pymatviz/widgets/web/vite.config.ts
@@ -1,12 +1,11 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { readFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { gunzipSync } from 'node:zlib'
 import { defineConfig } from 'vite-plus'
 import { off, shared_fmt, shared_lint } from './vite.shared.ts'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dirname
 
 export default defineConfig({
   fmt: shared_fmt,

--- a/pymatviz/widgets/web/vite.shared.ts
+++ b/pymatviz/widgets/web/vite.shared.ts
@@ -60,6 +60,7 @@ export const shared_lint = {
       `@typescript-eslint/no-unsafe-member-access`,
       `@typescript-eslint/no-unsafe-argument`,
       `@typescript-eslint/only-throw-error`,
+      `@typescript-eslint/prefer-readonly-parameter-types`,
     ),
   },
 }

--- a/pymatviz/xrd.py
+++ b/pymatviz/xrd.py
@@ -148,7 +148,7 @@ def xrd_pattern(  # noqa: D417
         if is_ase_atoms(pattern_or_struct):
             from pymatgen.io.ase import AseAtomsAdaptor
 
-            pattern_or_struct = AseAtomsAdaptor().get_structure(pattern_or_struct)  # type: ignore[arg-type]
+            pattern_or_struct = AseAtomsAdaptor().get_structure(pattern_or_struct)
 
         if isinstance(pattern_or_struct, Structure):
             xrd_calculator = XRDCalculator(wavelength=wavelength)

--- a/readme.md
+++ b/readme.md
@@ -57,12 +57,12 @@ See the Jupyter notebooks under [`examples/`](examples) for how to use `pymatviz
 
 See [`pymatviz/ptable/figures.py`](pymatviz/ptable/figures.py). The module supports heatmaps, heatmap splits (multiple values per element), histograms, scatter plots and line plots. All visualizations are interactive through [Plotly](https://plotly.com) and support displaying additional data on hover.
 
-|                                        [`ptable_heatmap_plotly(atomic_masses)`](pymatviz/ptable/figures.py#L53)                                         | [`ptable_heatmap_plotly(compositions, log=True)`](pymatviz/ptable/figures.py#L53) [![fig-icon]](assets/scripts/ptable/ptable_heatmap_plotly.py) |
+|                                        [`ptable_heatmap_plotly(atomic_masses)`](pymatviz/ptable/figures.py#L54)                                         | [`ptable_heatmap_plotly(compositions, log=True)`](pymatviz/ptable/figures.py#L54) [![fig-icon]](assets/scripts/ptable/ptable_heatmap_plotly.py) |
 | :-----------------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------: |
 |                                                        ![ptable-heatmap-plotly-more-hover-data]                                                         |                                                          ![ptable-heatmap-plotly-log]                                                           |
-|               [`ptable_hists_plotly(data)`](pymatviz/ptable/figures.py#L435) [![fig-icon]](assets/scripts/ptable/ptable_hists_plotly.py)                | [`ptable_scatter_plotly(data, mode="markers")`](pymatviz/ptable/figures.py#L1562) [![fig-icon]](assets/scripts/ptable/ptable_scatter_plotly.py) |
+|               [`ptable_hists_plotly(data)`](pymatviz/ptable/figures.py#L441) [![fig-icon]](assets/scripts/ptable/ptable_hists_plotly.py)                | [`ptable_scatter_plotly(data, mode="markers")`](pymatviz/ptable/figures.py#L1595) [![fig-icon]](assets/scripts/ptable/ptable_scatter_plotly.py) |
 |                                                                 ![ptable-hists-plotly]                                                                  |                                                        ![ptable-scatter-plotly-markers]                                                         |
-| [`ptable_heatmap_splits_plotly(2_vals_per_elem)`](pymatviz/ptable/figures.py#L850) [![fig-icon]](assets/scripts/ptable/ptable_heatmap_splits_plotly.py) |                               [`ptable_heatmap_splits_plotly(3_vals_per_elem)`](pymatviz/ptable/figures.py#L850)                                |
+| [`ptable_heatmap_splits_plotly(2_vals_per_elem)`](pymatviz/ptable/figures.py#L857) [![fig-icon]](assets/scripts/ptable/ptable_heatmap_splits_plotly.py) |                               [`ptable_heatmap_splits_plotly(3_vals_per_elem)`](pymatviz/ptable/figures.py#L857)                                |
 |                                                            ![ptable-heatmap-splits-plotly-2]                                                            |                                                        ![ptable-heatmap-splits-plotly-3]                                                        |
 
 [ptable-heatmap-plotly-log]: assets/svg/ptable-heatmap-plotly-log.svg
@@ -93,7 +93,7 @@ See [`examples/mprester_ptable.ipynb`](examples/mprester_ptable.ipynb).
 
 ### Composition Clustering
 
-| [`cluster_compositions(compositions, properties, embedding_method, projection_method, n_components=2)`](pymatviz/cluster/composition/plot.py#L364) [![fig-icon]](assets/scripts/cluster/composition/cluster_compositions_matbench.py) | [`cluster_compositions(compositions, properties, embedding_method, projection_method, n_components=3)`](pymatviz/cluster/composition/plot.py#L364) |
+| [`cluster_compositions(compositions, properties, embedding_method, projection_method, n_components=2)`](pymatviz/cluster/composition/plot.py#L363) [![fig-icon]](assets/scripts/cluster/composition/cluster_compositions_matbench.py) | [`cluster_compositions(compositions, properties, embedding_method, projection_method, n_components=3)`](pymatviz/cluster/composition/plot.py#L363) |
 | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------: |
 |                                                                                                 ![matbench-perovskites-magpie-pca-2d]                                                                                                 |                                                       ![matbench-perovskites-magpie-tsne-3d]                                                       |
 
@@ -286,7 +286,7 @@ See [`pymatviz/treemap/chem_sys.py`](pymatviz/treemap/chem_sys.py).
 
 See [`pymatviz/rainclouds.py`](pymatviz/rainclouds.py).
 
-| [`rainclouds(two_key_dict)`](pymatviz/rainclouds.py#L21) [![fig-icon]](assets/scripts/rainclouds/rainclouds.py) | [`rainclouds(three_key_dict)`](pymatviz/rainclouds.py#L21) |
+| [`rainclouds(two_key_dict)`](pymatviz/rainclouds.py#L22) [![fig-icon]](assets/scripts/rainclouds/rainclouds.py) | [`rainclouds(three_key_dict)`](pymatviz/rainclouds.py#L22) |
 | :-------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------: |
 |                                              ![rainclouds-bimodal]                                              |                   ![rainclouds-trimodal]                   |
 

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -24,4 +24,9 @@ export default defineConfig({
     fs: { allow: [`../..`] }, // Needed to import from $root
     port: 3000,
   },
+
+  build: {
+    // Default cssTarget is chrome111 which doesn't support light-dark(),
+    cssTarget: `esnext`, // causing LightningCSS to polyfill it with broken space toggles
+  },
 })

--- a/tests/classify/test_confusion_matrix.py
+++ b/tests/classify/test_confusion_matrix.py
@@ -276,6 +276,13 @@ def test_confusion_matrix_error_cases() -> None:
             metrics={"invalid": None},
         )
 
+    with pytest.raises(TypeError, match="Metric keys must be strings, got int"):
+        confusion_matrix(
+            np.array([[1, 2], [3, 4]]),
+            x_labels=("A", "B"),
+            metrics={1: None},  # ty: ignore[invalid-argument-type]
+        )
+
 
 def test_confusion_matrix_custom_annotations(sample_conf_mat: np.ndarray) -> None:
     """Test custom cell annotations."""

--- a/tests/cluster/composition/test_embed.py
+++ b/tests/cluster/composition/test_embed.py
@@ -22,7 +22,7 @@ def test_one_hot_encode(
 ) -> None:
     """Test one-hot encoding of chemical formulas."""
     # Default elements list contains all elements in the periodic table
-    result = one_hot_encode(compositions)  # type: ignore[arg-type]
+    result = one_hot_encode(compositions)
 
     # Check shape
     assert result.shape == expected_shape
@@ -32,7 +32,7 @@ def test_one_hot_encode(
 
     # Test with a custom elements list
     elements = ["H", "C", "O", "Na", "Cl"]
-    result_custom = one_hot_encode(compositions, elements=elements)  # type: ignore[arg-type]
+    result_custom = one_hot_encode(compositions, elements=elements)
 
     # Check custom shape
     assert result_custom.shape == (len(compositions), len(elements))
@@ -72,10 +72,10 @@ def test_one_hot_encode_pandas_input() -> None:
 def test_one_hot_encode_invalid_input() -> None:
     """Test one-hot encoding with invalid input."""
     with pytest.raises(ValueError, match="Invalid composition="):
-        one_hot_encode([1, 2, 3])  # type: ignore[arg-type]
+        one_hot_encode([1, 2, 3])
 
     with pytest.raises(ValueError, match="Invalid composition="):
-        one_hot_encode([["H2O"]])  # type: ignore[arg-type]
+        one_hot_encode([["H2O"]])
 
 
 @pytest.mark.parametrize(
@@ -124,10 +124,10 @@ def test_matminer_featurize_invalid_input() -> None:
     """Test matminer featurization with invalid input."""
     pytest.importorskip("matminer")
     with pytest.raises(ValueError, match="Invalid composition="):
-        matminer_featurize([1, 2, 3])  # type: ignore[arg-type]
+        matminer_featurize([1, 2, 3])
 
     with pytest.raises(ValueError, match="Invalid composition="):
-        matminer_featurize([["H2O"]])  # type: ignore[arg-type]
+        matminer_featurize([["H2O"]])
 
 
 def test_matminer_featurize_invalid_feature_subset() -> None:

--- a/tests/cluster/composition/test_plot.py
+++ b/tests/cluster/composition/test_plot.py
@@ -637,7 +637,7 @@ def test_custom_embedding_projection(
     fig = pmv.cluster_compositions(
         df_in=sample_df,
         prop_name="property",
-        embedding_method=embedding_method,  # type: ignore[arg-type]
+        embedding_method=embedding_method,  # ty: ignore[invalid-argument-type]
         projection=projection,
         embedding_kwargs=embedding_kwargs,
         projection_kwargs=projection_kwargs,
@@ -757,7 +757,7 @@ def test_hover_text_alignment(
         prop_name=prop_name,
         embedding_method=embedding_method,
         projection="pca",
-        sort=sort_option,  # type: ignore[arg-type]
+        sort=sort_option,  # ty: ignore[invalid-argument-type]
         show_chem_sys=viz_mode,
     )
 
@@ -1759,7 +1759,7 @@ def test_invalid_show_projection_stats(df_comp: pd.DataFrame) -> None:
             df_in=df_comp,
             embedding_method="one-hot",
             projection="pca",
-            show_projection_stats="invalid",  # type: ignore[arg-type]
+            show_projection_stats="invalid",  # ty: ignore[invalid-argument-type]
         )
 
 
@@ -1937,7 +1937,7 @@ def test_custom_projection_function(
 ) -> None:
     """Test using a custom projection function."""
     # Add some tracking to verify it's called
-    custom_projection_func.called = False  # type: ignore[attr-defined]
+    custom_projection_func.called = False  # ty: ignore[unresolved-attribute]
 
     original_func = custom_projection_func
 
@@ -1945,8 +1945,8 @@ def test_custom_projection_function(
         embeddings: np.ndarray, n_components: int, **kwargs: Any
     ) -> np.ndarray:
         """Wrapper to track that the function was called."""
-        original_func.called = True  # type: ignore[attr-defined]
-        return original_func(embeddings, n_components, **kwargs)  # type: ignore[call-arg]
+        original_func.called = True  # ty: ignore[unresolved-attribute]
+        return original_func(embeddings, n_components, **kwargs)  # ty: ignore[missing-argument]
 
     # Use the custom projection function
     fig = pmv.cluster_compositions(
@@ -1961,7 +1961,7 @@ def test_custom_projection_function(
     assert len(fig.data[0].x) == len(df_prop)
 
     # Verify the custom projector was called
-    assert original_func.called  # type: ignore[attr-defined]
+    assert original_func.called  # ty: ignore[unresolved-attribute]
 
     # Verify metadata
     assert isinstance(fig, ClusterFigure)

--- a/tests/cluster/composition/test_project.py
+++ b/tests/cluster/composition/test_project.py
@@ -260,7 +260,7 @@ def test_project_vectors_random_state(sample_data: np.ndarray) -> None:
 def test_project_vectors_invalid_method(sample_data: np.ndarray) -> None:
     """Test error handling for invalid method."""
     with pytest.raises(ValueError, match="Unknown projection method="):
-        project_vectors(sample_data, method="invalid_method")  # type: ignore[arg-type]
+        project_vectors(sample_data, method="invalid_method")  # ty: ignore[invalid-argument-type]
 
 
 def test_project_vectors_invalid_components(sample_data: np.ndarray) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def structures() -> tuple[Structure, Structure]:
 
 @pytest.fixture
 def ase_atoms() -> tuple[ase.Atoms, ase.Atoms]:
-    return tuple(copy.copy(atoms) for atoms in SI_ATOMS)  # type: ignore[return-value]
+    return tuple(copy.copy(atoms) for atoms in SI_ATOMS)
 
 
 @pytest.fixture
@@ -159,7 +159,7 @@ def fe3co4_disordered() -> Structure:
     """
     from pymatviz.structure import fe3co4_disordered
 
-    return fe3co4_disordered  # type: ignore[return-value]
+    return fe3co4_disordered
 
 
 @pytest.fixture

--- a/tests/coordination/test_coordination_helpers.py
+++ b/tests/coordination/test_coordination_helpers.py
@@ -63,7 +63,7 @@ def test_normalize_get_neighbors_with_nn_class() -> None:
 def test_normalize_get_neighbors_invalid_input() -> None:
     """Test normalize_get_neighbors with invalid input."""
     with pytest.raises(TypeError, match="Invalid strategy="):
-        normalize_get_neighbors(strategy="invalid")  # type: ignore[invalid-argument-type]
+        normalize_get_neighbors(strategy="invalid")  # ty: ignore[invalid-argument-type]
 
 
 def test_calculate_average_cn() -> None:

--- a/tests/coordination/test_coordination_plotly.py
+++ b/tests/coordination/test_coordination_plotly.py
@@ -144,7 +144,7 @@ def test_coordination_hist_bar_kwargs(structures: Sequence[Structure]) -> None:
 def test_coordination_hist_invalid_input() -> None:
     """Test coordination_hist with invalid input."""
     with pytest.raises(TypeError):
-        coordination_hist("invalid input")  # type: ignore[arg-type]
+        coordination_hist("invalid input")
 
 
 def test_coordination_hist_empty() -> None:
@@ -240,14 +240,14 @@ def test_coordination_vs_cutoff_line_invalid_input() -> None:
             match="Input must be a pymatgen Structure, IStructure, Molecule, "
             "IMolecule, ASE Atoms, or PhonopyAtoms object",
         ):
-            coordination_vs_cutoff_line(inputs)  # type: ignore[arg-type]
+            coordination_vs_cutoff_line(inputs)
 
 
 def test_coordination_vs_cutoff_line_invalid_strategy() -> None:
     """Test coordination_vs_cutoff_line with invalid strategy."""
     structure = Structure(Lattice.cubic(5), ["Si"], [[0, 0, 0]])
     with pytest.raises(TypeError, match="Invalid strategy="):
-        coordination_vs_cutoff_line(structure, strategy="invalid")  # type: ignore[arg-type]
+        coordination_vs_cutoff_line(structure, strategy="invalid")
 
 
 def test_coordination_hist_hover_text_formatting(
@@ -324,13 +324,13 @@ def test_coordination_hist_color_schemes(structures: Sequence[Structure]) -> Non
 def test_coordination_hist_invalid_elem_colors(structures: Sequence[Structure]) -> None:
     """Test invalid color scheme handling."""
     with pytest.raises(TypeError, match=r"Invalid.*element_color_scheme"):
-        coordination_hist(structures[0], element_color_scheme="invalid")  # type: ignore[arg-type]
+        coordination_hist(structures[0], element_color_scheme="invalid")  # ty: ignore[invalid-argument-type]
 
 
 def test_coordination_hist_invalid_hover_data(structures: Sequence[Structure]) -> None:
     """Test invalid hover_data handling."""
     with pytest.raises(TypeError, match="Invalid hover_data"):
-        coordination_hist(structures[0], hover_data=123)  # type: ignore[arg-type]
+        coordination_hist(structures[0], hover_data=123)  # ty: ignore[invalid-argument-type]
 
 
 def test_coordination_hist_invalid_split_mode(structures: Sequence[Structure]) -> None:

--- a/tests/phonons/test_phonon_helpers.py
+++ b/tests/phonons/test_phonon_helpers.py
@@ -151,7 +151,7 @@ def test_phonon_bands_raises(
         match=f"Only {PhononBands.__name__}, phonopy BandStructure or dict supported, "
         "got str",
     ):
-        pmv.phonon_bands("invalid input")  # type: ignore[arg-type]
+        pmv.phonon_bands("invalid input")
 
     # issues warning when requesting some available and some unavailable branches
     pmv.phonon_bands(
@@ -164,7 +164,7 @@ def test_phonon_bands_raises(
     with pytest.raises(ValueError, match="Invalid path_mode='invalid'"):
         pmv.phonon_bands(
             phonon_bands_doses_mp_2758["bands"]["DFT"],
-            path_mode="invalid",  # type: ignore[arg-type]
+            path_mode="invalid",  # ty: ignore[invalid-argument-type]
         )
 
     with pytest.raises(ValueError, match="Empty band structure mapping"):
@@ -174,13 +174,13 @@ def test_phonon_bands_raises(
     with pytest.raises(TypeError, match="expect shaded_ys as dict, got str"):
         pmv.phonon_bands(
             phonon_bands_doses_mp_2758["bands"]["DFT"],
-            shaded_ys="invalid",  # type: ignore[arg-type]
+            shaded_ys="invalid",  # ty: ignore[invalid-argument-type]
         )
 
     with pytest.raises(ValueError, match="Invalid y_val='invalid', must be one of"):
         pmv.phonon_bands(
             phonon_bands_doses_mp_2758["bands"]["DFT"],
-            shaded_ys={(0, "invalid"): dict(fillcolor="red")},  # type: ignore[arg-type]
+            shaded_ys={(0, "invalid"): dict(fillcolor="red")},  # ty: ignore[invalid-argument-type]
         )
 
 

--- a/tests/phonons/test_phonon_plotly.py
+++ b/tests/phonons/test_phonon_plotly.py
@@ -68,7 +68,7 @@ def test_phonon_dos(
 def test_phonon_dos_raises(phonon_bands_doses_mp_2758: BandsDoses) -> None:
     """Test phonon_dos raises appropriate errors."""
     with pytest.raises(TypeError, match="supported, got str"):
-        pmv.phonon_dos("invalid input")  # type: ignore[arg-type]
+        pmv.phonon_dos("invalid input")
 
     with pytest.raises(ValueError, match="Empty DOS dict"):
         pmv.phonon_dos({})
@@ -77,7 +77,7 @@ def test_phonon_dos_raises(phonon_bands_doses_mp_2758: BandsDoses) -> None:
         "Invalid unit='invalid', must be one of ['THz', 'eV', 'meV', 'Ha', 'cm-1']"
     )
     with pytest.raises(ValueError, match=re.escape(expected_msg)):
-        pmv.phonon_dos(phonon_bands_doses_mp_2758["doses"], units="invalid")  # type: ignore[arg-type]
+        pmv.phonon_dos(phonon_bands_doses_mp_2758["doses"], units="invalid")  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(
@@ -190,7 +190,7 @@ def test_phonon_bands_path_mode_raises(phonon_bands_doses_mp_2758: BandsDoses) -
     with pytest.raises(ValueError, match="Invalid path_mode='invalid'"):
         pmv.phonon_bands(
             phonon_bands_doses_mp_2758["bands"]["DFT"],
-            path_mode="invalid",  # type: ignore[arg-type]
+            path_mode="invalid",  # ty: ignore[invalid-argument-type]
         )
 
 
@@ -240,7 +240,7 @@ def test_phonon_bands_and_dos_path_mode_raises(
         pmv.phonon_bands_and_dos(
             phonon_bands_doses_mp_2758["bands"],
             phonon_bands_doses_mp_2758["doses"],
-            path_mode="invalid",  # type: ignore[arg-type]
+            path_mode="invalid",  # ty: ignore[invalid-argument-type]
         )
 
 
@@ -252,7 +252,7 @@ def test_phonon_dos_with_phonopy(phonopy_nacl: Phonopy) -> None:
 
     # Test single TotalDos
     fig = pmv.phonon_dos(
-        phonopy_nacl.total_dos,  # type: ignore[arg-type]
+        phonopy_nacl.total_dos,
         stack=False,
         sigma=0.1,
         normalize="max",
@@ -264,7 +264,7 @@ def test_phonon_dos_with_phonopy(phonopy_nacl: Phonopy) -> None:
 
     # Test dictionary of TotalDos objects
     dos_dict = {"DFT": phonopy_nacl.total_dos, "ML": phonopy_nacl.total_dos}
-    fig = pmv.phonon_dos(dos_dict, stack=True, sigma=0.1, normalize="max", units="THz")  # type: ignore[arg-type]
+    fig = pmv.phonon_dos(dos_dict, stack=True, sigma=0.1, normalize="max", units="THz")
     assert isinstance(fig, go.Figure)
     assert {trace.name for trace in fig.data} == {"DFT", "ML"}
 
@@ -284,7 +284,7 @@ def test_phonon_bands_with_phonopy(phonopy_nacl: Phonopy) -> None:
     phonopy_nacl.run_band_structure(paths=list(bands.values()))
 
     # Test single band structure
-    fig = pmv.phonon_bands(phonopy_nacl.band_structure)  # type: ignore[arg-type]
+    fig = pmv.phonon_bands(phonopy_nacl.band_structure)
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == 6
 
@@ -293,7 +293,7 @@ def test_phonon_bands_with_phonopy(phonopy_nacl: Phonopy) -> None:
         "NaCl (phonopy)": phonopy_nacl.band_structure,
         "DFT": phonopy_nacl.band_structure,
     }
-    fig = pmv.phonon_bands(bands_dict)  # type: ignore[arg-type]
+    fig = pmv.phonon_bands(bands_dict)
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == 6 * len(bands_dict)
 
@@ -439,7 +439,7 @@ def test_phonon_dos_projection_raises(
         pmv.phonon_dos(mixed, project="element")
     # invalid project value
     with pytest.raises(ValueError, match="Invalid project='invalid'"):
-        pmv.phonon_dos(complete_phonon_dos, project="invalid")  # type: ignore[arg-type]
+        pmv.phonon_dos(complete_phonon_dos, project="invalid")  # ty: ignore[invalid-argument-type]
 
 
 def test_phonon_dos_projection_unit_conversion(

--- a/tests/ptable/plotly/test_ptable_heatmap_plotly.py
+++ b/tests/ptable/plotly/test_ptable_heatmap_plotly.py
@@ -70,7 +70,7 @@ def test_ptable_heatmap_plotly(glass_formulas: list[str]) -> None:
 
     with pytest.raises(TypeError, match="should be string, list of strings or list"):
         # test that bad colorscale raises ValueError
-        pmv.ptable_heatmap_plotly(glass_formulas, colorscale=lambda: "bad scale")  # type: ignore[arg-type]
+        pmv.ptable_heatmap_plotly(glass_formulas, colorscale=lambda: "bad scale")  # ty: ignore[invalid-argument-type]
 
     # test that unknown builtin colorscale raises ValueError
     with pytest.raises(PlotlyError, match="Colorscale foobar is not a built-in scale"):
@@ -210,7 +210,7 @@ def test_ptable_heatmap_plotly_cscale_range_raises() -> None:
     with pytest.raises(
         ValueError, match=re.escape(f"{cscale_range=} should have length 2")
     ):
-        pmv.ptable_heatmap_plotly(df_ptable[Key.density], cscale_range=cscale_range)  # type: ignore[arg-type]
+        pmv.ptable_heatmap_plotly(df_ptable[Key.density], cscale_range=cscale_range)  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(
@@ -228,7 +228,7 @@ def test_ptable_heatmap_plotly_label_map(
     if label_map is not False:
         if label_map is None:
             # use default map
-            label_map = dict.fromkeys([np.nan, None, "nan", "nan%"], " ")  # type: ignore[list-item]
+            label_map = dict.fromkeys([np.nan, None, "nan", "nan%"], " ")  # ty: ignore[invalid-assignment]
         # check for non-empty intersection between label_map values and annotations
         # we use `val in anno.text` cause the labels are wrapped in non-matching
         # HTML <span> tags
@@ -292,7 +292,11 @@ def test_ptable_heatmap_plotly_hover_props() -> None:
 
 def test_ptable_heatmap_plotly_custom_label_map() -> None:
     values = {"Fe": 2, "O": 3, "H": np.nan}
-    label_map = lambda label: {2: "High", 3: "Low"}.get(float(label), label)
+
+    def label_map(label: str) -> str:
+        """Map numeric labels to custom display strings."""
+        return {2.0: "High", 3.0: "Low"}.get(float(label), label)
+
     fig = pmv.ptable_heatmap_plotly(values, label_map=label_map)
     annos = [
         anno.text
@@ -306,7 +310,7 @@ def test_ptable_heatmap_plotly_error_cases() -> None:
     with pytest.raises(
         ValueError, match=re.escape("cscale_range=(0,) should have length 2")
     ):
-        pmv.ptable_heatmap_plotly({"Fe": 2, "O": 3}, cscale_range=(0,))  # type: ignore[arg-type]
+        pmv.ptable_heatmap_plotly({"Fe": 2, "O": 3}, cscale_range=(0,))  # ty: ignore[invalid-argument-type]
 
     hover_props = ("atomic_mass", bad_hover_prop := "invalid_prop")
     with pytest.raises(ValueError, match=f"Unsupported hover_props: {bad_hover_prop}"):
@@ -348,7 +352,7 @@ def test_ptable_heatmap_plotly_hover_tooltips() -> None:
 
     # Test fraction and percent modes
     for heat_mode in ["fraction", "percent"]:
-        fig = pmv.ptable_heatmap_plotly(float_values, heat_mode=heat_mode)  # type: ignore[arg-type]
+        fig = pmv.ptable_heatmap_plotly(float_values, heat_mode=heat_mode)  # ty: ignore[invalid-argument-type]
         hover_texts = fig.data[-1].text.flat
 
         for elem_symb, value in float_values.items():
@@ -603,7 +607,7 @@ def test_ptable_heatmap_plotly_value_formatting() -> None:
     for values, heat_mode, fmt, expected_labels in test_cases:
         fig = pmv.ptable_heatmap_plotly(
             values,
-            heat_mode=heat_mode,  # type: ignore[arg-type]
+            heat_mode=heat_mode,  # ty: ignore[invalid-argument-type]
             fmt=fmt,
             font_size=10,  # smaller font for stable span style
         )

--- a/tests/ptable/plotly/test_ptable_heatmap_splits_plotly.py
+++ b/tests/ptable/plotly/test_ptable_heatmap_splits_plotly.py
@@ -25,8 +25,8 @@ def test_ptable_heatmap_splits_plotly_basic() -> None:
     }
 
     # Test each orientation
-    for orientation in ["diagonal", "horizontal", "vertical"]:
-        fig = pmv.ptable_heatmap_splits_plotly(data, orientation=orientation)  # type: ignore[arg-type]
+    for orientation in ("diagonal", "horizontal", "vertical"):
+        fig = pmv.ptable_heatmap_splits_plotly(data, orientation=orientation)
         assert isinstance(fig, go.Figure)
         # Each split should have its own subplot
         assert len(fig.data) == sum(len(v) for v in data.values()) + 1
@@ -169,7 +169,7 @@ def test_ptable_heatmap_splits_plotly_annotations() -> None:
     data = {"Fe": [1, 2], "O": [3, 4], "H": [0.5, 1.5], "He": [1.5, 2.5]}
 
     # Test with dict annotations
-    annotations = {
+    annotations: dict[str, str | dict[str, Any]] = {
         "Fe": {"text": "Iron", "font": {"size": 14, "color": "red"}},
         "O": {"text": "Oxygen", "font": {"size": 14, "color": "blue"}},
     }

--- a/tests/ptable/plotly/test_ptable_hists_plotly.py
+++ b/tests/ptable/plotly/test_ptable_hists_plotly.py
@@ -101,7 +101,7 @@ def test_ptable_hists_plotly_annotations() -> None:
         ],
         "O": {"text": "Oxygen", **anno_kwargs},
     }
-    fig = pmv.ptable_hists_plotly(data, annotations=annotations)  # type: ignore[arg-type]
+    fig = pmv.ptable_hists_plotly(data, annotations=annotations)  # ty: ignore[invalid-argument-type]
     assert isinstance(fig, go.Figure)
 
     # Check multiple annotations are present
@@ -136,7 +136,7 @@ def test_ptable_hists_plotly_error_cases() -> None:
     with pytest.raises(
         ValueError, match="color_elem_strategy='invalid' must be one of"
     ):
-        pmv.ptable_hists_plotly(data, color_elem_strategy="invalid")  # type: ignore[arg-type]
+        pmv.ptable_hists_plotly(data, color_elem_strategy="invalid")  # ty: ignore[invalid-argument-type]
 
     # Test invalid scale
     with pytest.raises(ValueError, match="Invalid value of type ") as exc:

--- a/tests/ptable/plotly/test_ptable_scatter_plotly.py
+++ b/tests/ptable/plotly/test_ptable_scatter_plotly.py
@@ -158,7 +158,7 @@ def test_annotations(
     expected_count: int,
 ) -> None:
     """Test different types of annotations."""
-    fig = pmv.ptable_scatter_plotly(sample_data, annotations=annotations)  # type: ignore[arg-type]
+    fig = pmv.ptable_scatter_plotly(sample_data, annotations=annotations)  # ty: ignore[invalid-argument-type]
 
     if callable(annotations):
         # For callable annotations, check format
@@ -204,7 +204,7 @@ def test_ptable_scatter_plotly_invalid_input() -> None:
     # Invalid mode should raise ValueError
     err_msg = "Invalid value of type 'builtins.str' received for the 'mode' property"
     with pytest.raises(ValueError, match=re.escape(err_msg)):
-        pmv.ptable_scatter_plotly({"Fe": ([1], [1])}, mode="invalid")  # type: ignore[arg-type]
+        pmv.ptable_scatter_plotly({"Fe": ([1], [1])}, mode="invalid")  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(
@@ -479,7 +479,7 @@ def test_mixed_input_types() -> None:
             "tuple": ((1, 2), (3, 4)),  # Python tuples
         }
     }
-    fig = pmv.ptable_scatter_plotly(data, mode="lines")  # type: ignore[arg-type]
+    fig = pmv.ptable_scatter_plotly(data, mode="lines")
 
     # All should be plotted correctly
     assert len(fig.data) == 3

--- a/tests/rdf/test_rdf_helpers.py
+++ b/tests/rdf/test_rdf_helpers.py
@@ -396,8 +396,8 @@ def test_calculate_rdf_input_validation(
 
     # Test for expected error
     structure_param = params.pop("structure")
-    with pytest.raises(expected_err_cls, match=error_msg):  # type: ignore[arg-type]
-        calculate_rdf(structure_param, **params)  # type: ignore[arg-type]
+    with pytest.raises(expected_err_cls, match=error_msg):
+        calculate_rdf(structure_param, **params)  # ty: ignore[invalid-argument-type]
 
 
 def test_calculate_rdf_invalid_structure_type() -> None:
@@ -405,9 +405,9 @@ def test_calculate_rdf_invalid_structure_type() -> None:
     with pytest.raises(
         TypeError, match="Input must be a pymatgen Structure, IStructure, Molecule"
     ):
-        calculate_rdf("not a structure", cutoff=10, n_bins=10)  # type: ignore[arg-type]
+        calculate_rdf("not a structure", cutoff=10, n_bins=10)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(
         TypeError, match="Input must be a pymatgen Structure, IStructure, Molecule"
     ):
-        calculate_rdf(42, cutoff=10, n_bins=10)  # type: ignore[arg-type]
+        calculate_rdf(42, cutoff=10, n_bins=10)  # ty: ignore[invalid-argument-type]

--- a/tests/rdf/test_rdf_plotly.py
+++ b/tests/rdf/test_rdf_plotly.py
@@ -117,7 +117,7 @@ def test_element_pair_rdfs_invalid_elements(structures: list[Structure]) -> None
 def test_element_pair_rdfs_invalid_structure() -> None:
     err_msg = "Input must be a pymatgen Structure, IStructure, Molecule"
     with pytest.raises(TypeError, match=err_msg):
-        element_pair_rdfs("not a structure")  # type: ignore[arg-type]
+        element_pair_rdfs("not a structure")  # ty: ignore[invalid-argument-type]
 
 
 def test_element_pair_rdfs_conflicting_bins_and_bin_size(
@@ -137,7 +137,7 @@ def test_element_pair_rdfs_cutoff_and_bin_size(
 ) -> None:
     struct = structures[0]
     for value in values:
-        fig = element_pair_rdfs(struct, **{param: value})  # type: ignore[arg-type]
+        fig = element_pair_rdfs(struct, **{param: value})  # ty: ignore[invalid-argument-type]
 
         # Check that we have the correct number of traces (one for each element pair)
         n_elements = len({site.specie.symbol for site in struct})
@@ -312,7 +312,7 @@ def test_full_rdf_empty_structure() -> None:
 def test_full_rdf_invalid_structure() -> None:
     err_msg = "Input must be a pymatgen Structure, IStructure, Molecule"
     with pytest.raises(TypeError, match=err_msg):
-        full_rdf("not a structure")  # type: ignore[arg-type]
+        full_rdf("not a structure")  # ty: ignore[invalid-argument-type]
 
 
 def test_full_rdf_conflicting_bins_and_bin_size(structures: list[Structure]) -> None:
@@ -331,7 +331,7 @@ def test_full_rdf_cutoff_and_bin_size(
 ) -> None:
     structure = structures[0]
     for value in values:
-        fig = full_rdf(structure, **{param: value})  # type: ignore[arg-type]
+        fig = full_rdf(structure, **{param: value})  # ty: ignore[invalid-argument-type]
 
         assert len(fig.data) == 1
         trace = fig.data[0]

--- a/tests/structure/test_structure_helpers.py
+++ b/tests/structure/test_structure_helpers.py
@@ -135,7 +135,7 @@ def test_get_elem_colors(
 def test_get_elem_colors_invalid_input() -> None:
     err_msg = f"colors must be a dict or one of ('{', '.join(ElemColorScheme)}')"
     with pytest.raises(ValueError, match=re.escape(err_msg)):
-        get_elem_colors("invalid_input")  # type: ignore[arg-type]
+        get_elem_colors("invalid_input")  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(
@@ -344,7 +344,7 @@ def test_get_subplot_title(
     expected_text: str,
 ) -> None:
     structure = structures[0]
-    title = get_subplot_title(structure, struct_key, 1, subplot_title)  # type: ignore[arg-type]
+    title = get_subplot_title(structure, struct_key, 1, subplot_title)
     assert isinstance(title, dict)
     assert "text" in title
     assert expected_text in title["text"]
@@ -391,11 +391,11 @@ def test_draw_vector(
 ) -> None:
     """Test vector drawing with various settings."""
     fig = go.Figure()
-    start, vector = np.array(start), np.array(vector)  # type: ignore[assignment]
+    start, vector = np.array(start), np.array(vector)
 
     # Draw vector and check trace count
     initial_trace_count = len(fig.data)
-    draw_vector(fig, start, vector, is_3d=is_3d, arrow_kwargs=arrow_kwargs)  # type: ignore[arg-type]
+    draw_vector(fig, start, vector, is_3d=is_3d, arrow_kwargs=arrow_kwargs)
     assert len(fig.data) - initial_trace_count == expected_traces
 
     # Check trace properties based on dimensionality
@@ -563,7 +563,7 @@ def test_get_site_hover_text(
     """Test hover text generation for sites with various formats."""
     lattice = Lattice.cubic(1.0)
     site = PeriodicSite("Si", [0, 0, 0], lattice)
-    result = get_site_hover_text(site, hover_text, site.species)  # type: ignore[arg-type]
+    result = get_site_hover_text(site, hover_text, site.species)
     assert result == expected_output
 
 
@@ -574,7 +574,7 @@ def test_get_site_hover_text_float_formatting() -> None:
     site = PeriodicSite("Si", [1.23456789, 1e-17, 2.3456], lattice)
 
     # Test default format (.4)
-    result_default = get_site_hover_text(site, SiteCoords.cartesian, site.species)  # type: ignore[arg-type]
+    result_default = get_site_hover_text(site, SiteCoords.cartesian, site.species)
     assert "1.235" in result_default
     assert ("1e-17" in result_default) or (
         "0" in result_default
@@ -582,13 +582,13 @@ def test_get_site_hover_text_float_formatting() -> None:
     assert "2.346" in result_default
 
     # Test custom string format (.2f)
-    result_2f = get_site_hover_text(site, SiteCoords.cartesian, site.species, ".2f")  # type: ignore[arg-type]
+    result_2f = get_site_hover_text(site, SiteCoords.cartesian, site.species, ".2f")
     assert "1.23" in result_2f
     assert "0.00" in result_2f
     assert "2.35" in result_2f
 
     # Test with fractional coordinates
-    result_frac = get_site_hover_text(site, SiteCoords.fractional, site.species, ".6f")  # type: ignore[arg-type]
+    result_frac = get_site_hover_text(site, SiteCoords.fractional, site.species, ".6f")
     assert "1.234568" in result_frac
     assert "0.000000" in result_frac
     assert "2.345600" in result_frac
@@ -601,7 +601,7 @@ def test_get_site_hover_text_float_formatting() -> None:
     result_custom = get_site_hover_text(
         site,
         SiteCoords.cartesian,
-        site.species,  # type: ignore[arg-type]
+        site.species,
         custom_formatter,
     )
     assert "~1.2" in result_custom
@@ -612,7 +612,7 @@ def test_get_site_hover_text_float_formatting() -> None:
     result_both = get_site_hover_text(
         site,
         SiteCoords.cartesian_fractional,
-        site.species,  # type: ignore[arg-type]
+        site.species,
         ".3f",
     )
     assert "1.235" in result_both  # cartesian
@@ -625,7 +625,7 @@ def test_get_site_hover_text_invalid_template() -> None:
     lattice = Lattice.cubic(1.0)
     site = PeriodicSite("Si", [0, 0, 0], lattice)
     with pytest.raises(ValueError, match="Invalid hover_text="):
-        get_site_hover_text(site, "invalid_template", site.species)  # type: ignore[arg-type]
+        get_site_hover_text(site, "invalid_template", site.species)  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize("is_3d", [True, False])

--- a/tests/structure/test_structure_plotly.py
+++ b/tests/structure/test_structure_plotly.py
@@ -1620,7 +1620,7 @@ def test_color_processing_edge_cases() -> None:
     ]
 
     for input_color, expected in test_cases:
-        result = normalize_elem_color(input_color)  # type: ignore[arg-type]
+        result = normalize_elem_color(input_color)  # ty: ignore[invalid-argument-type]
         assert result == expected
 
 

--- a/tests/test_brillouin.py
+++ b/tests/test_brillouin.py
@@ -390,7 +390,7 @@ def test_brillouin_zone_3d_axes_vectors(structures: list[Structure]) -> None:
 def test_brillouin_zone_3d_edge_cases(structures: list[Structure]) -> None:
     """Test edge cases and error handling."""
     with pytest.raises(TypeError, match="Subplot title must be a string or dict"):
-        brillouin_zone_3d(structures, subplot_title=lambda *_args: 42)
+        brillouin_zone_3d(structures, subplot_title=lambda *_args: 42)  # ty: ignore[invalid-argument-type]
 
     # Test with invalid axes_vectors dict
     with pytest.raises(KeyError, match="axes_vectors must contain 'shaft' and 'cone'"):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -141,7 +141,7 @@ def test_df_to_html(
 def test_save_fig_type_error(tmp_path: Path) -> None:
     """save_fig raises TypeError for non-Figure input."""
     with pytest.raises(TypeError, match=r"Unsupported figure type.*expected plotly"):
-        pmv.save_fig("not a figure", f"{tmp_path}/dummy.html", env_disable=[])  # type: ignore[arg-type]
+        pmv.save_fig("not a figure", f"{tmp_path}/dummy.html", env_disable=[])
 
 
 def test_save_fig_prec_rounds_floats(tmp_path: Path) -> None:
@@ -199,7 +199,7 @@ def test_save_fig_pdf_template_and_hidden_traces(
 def test_save_and_compress_svg_type_error() -> None:
     """save_and_compress_svg raises TypeError for non-Figure."""
     with pytest.raises(TypeError, match="fig must be a plotly Figure"):
-        pmv.io.save_and_compress_svg("not a figure", "test")  # type: ignore[arg-type]
+        pmv.io.save_and_compress_svg("not a figure", "test")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_powerups.py
+++ b/tests/test_powerups.py
@@ -7,6 +7,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 import pytest
 from plotly.graph_objs.layout import Updatemenu
+from plotly.graph_objs.layout.annotation import Font
 from plotly.subplots import make_subplots
 
 from pymatviz import powerups
@@ -16,6 +17,25 @@ if TYPE_CHECKING:
     from typing import Any
 
 np_rng = np.random.default_rng(seed=0)
+
+
+def test_powerups_custom_metrics_and_font_preservation() -> None:
+    """Custom metrics and font objects survive annotation handling."""
+    metrics_fig = powerups.annotate_metrics(
+        [1, 2, 3], [1, 2, 3], fig=go.Figure(), metrics={"Custom": 1.23}
+    )
+    assert metrics_fig.layout.annotations[0].text == "Custom = 1.23<br>"
+
+    fit_fig = powerups.add_best_fit_line(
+        go.Figure(),
+        xs=[1, 2, 3],
+        ys=[1, 2, 3],
+        annotate_params={"color": "red", "font": Font(family="Arial", size=13)},
+    )
+    anno_font = fit_fig.layout.annotations[0].font
+    assert anno_font.color == "red"
+    assert anno_font.family == "Arial"
+    assert anno_font.size == 13
 
 
 @pytest.mark.parametrize(
@@ -177,7 +197,7 @@ def test_add_ecdf_line_raises() -> None:
             TypeError,
             match=f"{fig=} must be instance of go.Figure",
         ):
-            powerups.add_ecdf_line(fig)  # type: ignore[arg-type]
+            powerups.add_ecdf_line(fig)
 
     # check ValueError when x-values cannot be auto-determined
     fig_violin = px.violin(x=[1, 2, 3], y=[4, 5, 6])
@@ -365,7 +385,7 @@ def test_multiple_powerups(plotly_scatter: go.Figure) -> None:
         assert muni_i == Updatemenu(powerup), f"{idx=}"
         assert isinstance(muni_i, Updatemenu)
         assert muni_i.type == powerup["type"]
-        assert len(muni_i.buttons) == len(powerup["buttons"])  # type: ignore[arg-type]
+        assert len(muni_i.buttons) == len(powerup["buttons"])  # ty: ignore[invalid-argument-type]
 
 
 def test_add_ecdf_line_color_matching() -> None:

--- a/tests/test_process_data.py
+++ b/tests/test_process_data.py
@@ -107,9 +107,10 @@ def test_count_elements_exclude_elements() -> None:
 def test_count_elements_exclude_invalid_elements() -> None:
     compositions = [Composition("Fe2O3")] * 5 + [Composition("Fe4P4O16")] * 3
     exclude_elements = ["Fe", "P", "Zz"]
+    excluded_elements = list(exclude_elements)
     with pytest.raises(
         ValueError,
-        match=re.escape(f"Unexpected symbol(s) Zz in {exclude_elements=}"),
+        match=re.escape(f"Unexpected symbol(s) Zz in {excluded_elements=}"),
     ):
         pmv_pd.count_elements(
             compositions,
@@ -461,19 +462,24 @@ def test_normalize_to_dict(cls: type[Structure | DummyClass | Lattice]) -> None:
     result = pmv_pd.normalize_to_dict(single_instance, cls=cls)
     assert isinstance(result, dict)
     assert len(result) == 1
-    assert "" in result
-    assert isinstance(result[""], cls)
+    expected_key = {
+        Structure: "Si1",
+        DummyClass: "dummy",
+        Lattice: "Lattice",
+    }[cls]
+    assert set(result) == {expected_key}
+    assert isinstance(result[expected_key], cls)
 
     # Test with a list of instances
-    instance_list = [single_instance, single_instance]
+    instance_list = [single_instance, single_instance, single_instance]
     result = pmv_pd.normalize_to_dict(instance_list, cls=cls)
     assert isinstance(result, dict)
-    assert len(result) == 2
+    assert len(result) == 3
     assert all(isinstance(s, cls) for s in result.values())
     expected_keys = {
-        Structure: {"Si1", "Si1 1"},
-        DummyClass: {"dummy", "dummy 1"},
-        Lattice: {"Lattice", "Lattice 1"},
+        Structure: {"Si1", "Si1 1", "Si1 2"},
+        DummyClass: {"dummy", "dummy 1", "dummy 2"},
+        Lattice: {"Lattice", "Lattice 1", "Lattice 2"},
     }[cls]
     assert set(result) == expected_keys
 
@@ -489,7 +495,7 @@ def test_normalize_to_dict(cls: type[Structure | DummyClass | Lattice]) -> None:
         pmv_pd.normalize_to_dict("invalid input", cls=cls)
 
     # Test with mixed valid and invalid inputs in a list
-    with pytest.raises(TypeError, match=err_msg):
+    with pytest.raises(TypeError, match="Invalid item in inputs, expected"):
         pmv_pd.normalize_to_dict([single_instance, "invalid"], cls=cls)
 
 
@@ -515,7 +521,7 @@ def test_normalize_to_dict_mixed_classes(
 
     with pytest.raises(
         TypeError,
-        match=f"Invalid inputs, expected {cls_name} or dict/list/tuple of {cls_name}",
+        match=f"Invalid item in inputs, expected {cls_name}",
     ):
         pmv_pd.normalize_to_dict([instance1, instance2], cls=cls1)
 

--- a/tests/test_rainclouds.py
+++ b/tests/test_rainclouds.py
@@ -126,26 +126,33 @@ def test_rainclouds_scale(
 
 
 @pytest.mark.parametrize(
-    ("hover_data", "expected_columns"),
+    ("hover_data", "expected_first", "expected_last"),
     [
-        (None, ["value"]),
-        (["category"], ["value", "category"]),
-        ({"Group": ["extra"]}, ["value", "extra"]),
+        (None, ["value"], ["value"]),
+        (["category"], ["value", "category"], ["value", "category"]),
+        ({"Group": ["extra"]}, ["value", "extra"], ["value", "extra"]),
+        (
+            {"Group": {"source": [f"source-{idx}" for idx in range(100)]}},
+            ["value", "source: source-0"],
+            ["value", "source: source-99"],
+        ),
     ],
 )
 def test_rainclouds_hover_data(
     sample_dataframe: pd.DataFrame,
-    hover_data: Sequence[str] | dict[str, Sequence[str]] | None,
-    expected_columns: Sequence[str],
+    hover_data: (
+        Sequence[str] | dict[str, Sequence[str] | dict[str, Sequence[object]]] | None
+    ),
+    expected_first: Sequence[str],
+    expected_last: Sequence[str],
 ) -> None:
     data = {"Group": (sample_dataframe, "value")}
     fig = pmv.rainclouds(data, hover_data=hover_data)
     scatter_trace = next(
         trace for trace in fig.data if getattr(trace, "mode", None) == "markers"
     )
-    assert all(
-        all(col in text for col in expected_columns) for text in scatter_trace.hovertext
-    )
+    assert all(text in scatter_trace.hovertext[0] for text in expected_first)
+    assert all(text in scatter_trace.hovertext[-1] for text in expected_last)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sunburst.py
+++ b/tests/test_sunburst.py
@@ -46,7 +46,7 @@ def test_spacegroup_sunburst(show_counts: ShowCounts) -> None:
 def test_spacegroup_sunburst_invalid_show_counts() -> None:
     """Test that invalid show_counts values raise ValueError."""
     with pytest.raises(ValueError, match=r"Invalid.*show_counts"):
-        spacegroup_sunburst([1], show_counts="invalid")  # type: ignore[arg-type]
+        spacegroup_sunburst([1], show_counts="invalid")  # ty: ignore[invalid-argument-type]
 
 
 def test_spacegroup_sunburst_single_item() -> None:
@@ -76,7 +76,7 @@ def test_spacegroup_sunburst_other_types(
     assert isinstance(fig, go.Figure)
 
     # test with pymatgen structures
-    fig = spacegroup_sunburst(structures)  # type: ignore[arg-type]
+    fig = spacegroup_sunburst(structures)
     assert isinstance(fig, go.Figure)
 
 
@@ -147,7 +147,7 @@ def test_spacegroup_sunburst_max_slices(
 def test_spacegroup_sunburst_max_slices_mode_invalid() -> None:
     """Test spacegroup_sunburst with invalid max_slices_mode."""
     with pytest.raises(ValueError, match="Invalid max_slices_mode="):
-        pmv.spacegroup_sunburst([1, 2, 3], max_slices=1, max_slices_mode="invalid")  # type: ignore[arg-type]
+        pmv.spacegroup_sunburst([1, 2, 3], max_slices=1, max_slices_mode="invalid")  # ty: ignore[invalid-argument-type]
 
 
 def test_chem_sys_sunburst_basic() -> None:
@@ -242,7 +242,7 @@ def test_chem_sys_sunburst_input_types(structures: list[Structure]) -> None:
 
     # Test with invalid input type
     with pytest.raises(TypeError, match="Expected str, Composition or Structure"):
-        pmv.chem_sys_sunburst([1])  # type: ignore[arg-type]
+        pmv.chem_sys_sunburst([1])
 
 
 def test_chem_sys_sunburst_high_arity() -> None:
@@ -407,7 +407,7 @@ def test_chem_sys_sunburst_max_slices_mode(
 def test_chem_sys_sunburst_max_slices_mode_invalid() -> None:
     """Test chem_sys_sunburst with invalid max_slices_mode."""
     with pytest.raises(ValueError, match="Invalid max_slices_mode="):
-        pmv.chem_sys_sunburst(["Fe2O3"], max_slices=1, max_slices_mode="invalid")  # type: ignore[arg-type]
+        pmv.chem_sys_sunburst(["Fe2O3"], max_slices=1, max_slices_mode="invalid")  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize("show_counts", get_args(ShowCounts))
@@ -641,7 +641,7 @@ def test_chem_env_sunburst_invalid_chem_env_settings() -> None:
     # Invalid string should fall through to ChemEnv path and fail
     # because ChemEnv expects a dictionary, not a string
     with pytest.raises((ImportError, AttributeError, RuntimeError, TypeError)):
-        pmv.chem_env_sunburst([simple_structure], chem_env_settings="invalid_method")  # type: ignore[arg-type]
+        pmv.chem_env_sunburst([simple_structure], chem_env_settings="invalid_method")  # ty: ignore[invalid-argument-type]
 
 
 def test_chem_env_sunburst_empty_coordination_environments() -> None:
@@ -765,7 +765,7 @@ def test_limit_slices_invalid_mode() -> None:
             group_col="group",
             count_col="count",
             max_slices=1,
-            max_slices_mode="invalid",  # type: ignore[arg-type]
+            max_slices_mode="invalid",  # ty: ignore[invalid-argument-type]
         )
 
 

--- a/tests/treemap/test_chem_env_treemap.py
+++ b/tests/treemap/test_chem_env_treemap.py
@@ -471,7 +471,7 @@ def test_chem_env_treemap_invalid_show_counts(mock_structure: MagicMock) -> None
         with pytest.raises(ValueError, match=r"Invalid.*show_counts"):
             chem_env_treemap(
                 mock_structure,
-                show_counts="invalid",  # type: ignore[arg-type]
+                show_counts="invalid",  # ty: ignore[invalid-argument-type]
                 chem_env_settings="chemenv",
             )
 

--- a/tests/treemap/test_py_pkg_treemap.py
+++ b/tests/treemap/test_py_pkg_treemap.py
@@ -73,8 +73,8 @@ pass"""
         """from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import pandas as pd # type: ignore
-    from collections import abc # type: ignore
+    import pandas as pd
+    from collections import abc
 
 def func_typed():
     pass
@@ -1870,4 +1870,4 @@ class TestAdaptivePruning:
     def test_negative_params_raise(self, kwargs: dict[str, int]) -> None:
         """Negative depth/pruning parameters raise ValueError."""
         with pytest.raises(ValueError, match="must be non-negative"):
-            pmv.py_pkg_treemap("deep_pkg", **kwargs)  # type: ignore[arg-type]
+            pmv.py_pkg_treemap("deep_pkg", **kwargs)  # ty: ignore[invalid-argument-type]

--- a/tests/utils/test_plotting.py
+++ b/tests/utils/test_plotting.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
+import numpy as np
 import pytest
 
 import pymatviz as pmv
@@ -11,7 +12,7 @@ from pymatviz.utils.plotting import contrast_ratio
 if TYPE_CHECKING:
     from typing import Literal
 
-    from pymatviz.typing import RgbColorType
+    from pymatviz.typing import ColorType, RgbColorType
 
 
 @pytest.mark.parametrize(
@@ -120,6 +121,14 @@ def test_luminance_with_edge_cases() -> None:
     # Test with invalid color
     with pytest.raises(ValueError, match="Unsupported color format: not_a_color"):
         pmv.utils.luminance("not_a_color")
+
+
+def test_luminance_accepts_numpy_scalar_rgb_tuple() -> None:
+    """Luminance accepts NumPy scalar channels in RGB tuples."""
+    color = (np.int32(128), np.int32(128), np.int32(128))
+    assert pmv.utils.luminance(cast("ColorType", color)) == pytest.approx(
+        0.21586, abs=0.001
+    )
 
 
 def test_pick_max_contrast_color_with_min_contrast_ratio() -> None:

--- a/tests/widgets/test_widget_construction.py
+++ b/tests/widgets/test_widget_construction.py
@@ -649,6 +649,13 @@ def test_heatmap_matrix_accepts_nested_dict_values() -> None:
     assert widget.values["Fe"]["O"] == 0.5
 
 
+def test_heatmap_matrix_scalar_string_axis_items() -> None:
+    """HeatmapMatrixWidget treats scalar string axis items as one label."""
+    widget = HeatmapMatrixWidget(x_items="Fe", y_items="O")
+    assert widget.x_items == [{"key": "Fe", "label": "Fe"}]
+    assert widget.y_items == [{"key": "O", "label": "O"}]
+
+
 def test_rdf_plot_accepts_pymatgen_structure() -> None:
     """RdfPlotWidget normalizes pymatgen Structure to dict via _to_dict."""
     from pymatgen.core import Lattice, Structure
@@ -786,7 +793,7 @@ def test_to_img_format_inference(
     with patch(
         f"{_HEADLESS}.render_widget_headless", return_value=_FAKE_PNG
     ) as mock_render:
-        widget.to_img(filename=resolved, fmt=explicit_fmt)  # type: ignore[arg-type]
+        widget.to_img(filename=resolved, fmt=explicit_fmt)  # ty: ignore[invalid-argument-type]
 
     assert mock_render.call_args.kwargs["fmt"] == expected_capture_fmt
 


### PR DESCRIPTION
## Summary
- Replace stale mypy-style type ignores with ty-specific suppressions and remove broad ignores where straightforward narrowing works.
- Tighten typing around ptable split orientations, Brillouin structure mappings, widget assets, and related examples/tests.
- Refresh README source links after line-number shifts.

## Validation
- `prek ty --all-files`
- `pytest tests/test_brillouin.py`
- `pytest tests/ptable/plotly/test_ptable_heatmap_splits_plotly.py`
- `pytest tests/test_process_data.py tests/cluster/composition/test_plot.py tests/ptable/plotly/test_ptable_scatter_plotly.py tests/ptable/plotly/test_ptable_heatmap_splits_plotly.py tests/ptable/plotly/test_ptable_heatmap_plotly.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer error messages and stricter validation in plotting, classification, and widget setup; safer asset handling and color-tuple validation.

* **Improvements**
  * Broadened accepted input types (axis items, hover/tooltip formats); centralized periodic-table orientation typing; more robust luminance/color handling.

* **Tests**
  * Added/updated tests for confusion-matrix errors, luminance with NumPy scalars, and heatmap widget normalization.

* **Documentation**
  * Updated README links.

* **Chores**
  * Updated pre-commit config and web/dev tooling/config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->