### PR TITLE
Improve widget and plot data input handling

### DIFF
--- a/examples/widgets/marimo_demo.py
+++ b/examples/widgets/marimo_demo.py
@@ -560,9 +560,9 @@ def _(np_rng, pmv):
     pmv.ScatterPlot3DWidget(
         series=[
             {
-                "x": np_rng.normal(0, 1, 50).tolist(),
-                "y": np_rng.normal(0, 1, 50).tolist(),
-                "z": np_rng.normal(0, 1, 50).tolist(),
+                "x": np_rng.normal(0, 1, 50),
+                "y": np_rng.normal(0, 1, 50),
+                "z": np_rng.normal(0, 1, 50),
                 "label": "Random points",
             }
         ],

--- a/examples/widgets/vscode_interactive_demo.py
+++ b/examples/widgets/vscode_interactive_demo.py
@@ -526,9 +526,9 @@ ptable_widget.show()
 scatter_3d_widget = pmv.ScatterPlot3DWidget(
     series=[
         {
-            "x": np_rng.normal(0, 1, 50).tolist(),
-            "y": np_rng.normal(0, 1, 50).tolist(),
-            "z": np_rng.normal(0, 1, 50).tolist(),
+            "x": np_rng.normal(0, 1, 50),
+            "y": np_rng.normal(0, 1, 50),
+            "z": np_rng.normal(0, 1, 50),
             "label": "Random points",
         }
     ],
@@ -569,9 +569,9 @@ heatmap_widget.show()
 
 
 # %% SpacegroupBarPlot — space group frequencies
+spacegroup_counts = {1: 2, 2: 3, 12: 2, 14: 4, 15: 2, 62: 5, 63: 2, 139: 3, 141: 2, 148: 2, 166: 4, 167: 2, 194: 4, 216: 2, 221: 3, 225: 5, 227: 3, 229: 2}  # fmt: skip  # noqa: E501
 spacegroup_widget = pmv.SpacegroupBarPlotWidget(
-    data=[225, 225, 225, 166, 166, 62, 62, 62, 62, 139, 139, 12, 14, 14, 14, 14],
-    style="height: 350px;",
+    data=spacegroup_counts, style="height: 350px;"
 )
 spacegroup_widget.show()
 

--- a/pymatviz/histogram.py
+++ b/pymatviz/histogram.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any, Literal
 
+    import pandas as pd
+
     from pymatviz.typing import ElemValues
 
 
@@ -60,9 +62,9 @@ def elements_hist(
     if show_values is not None:
         if show_values == "percent":
             sum_elements = non_zero.sum()
-            text_labels = [f"{el / sum_elements:.0%}" for el in non_zero.values]
+            text_labels = [f"{el / sum_elements:.0%}" for el in non_zero.to_numpy()]
         else:
-            text_labels = [str(int(val)) for val in non_zero.values]
+            text_labels = [str(int(val)) for val in non_zero.to_numpy()]
 
     fig = go.Figure(**fig_kwargs or {})
     fig.add_bar(
@@ -87,7 +89,10 @@ def elements_hist(
 
 
 def histogram(
-    values: Sequence[float] | dict[str, Sequence[float] | np.ndarray],
+    values: Sequence[float]
+    | np.ndarray
+    | pd.Series
+    | dict[str, Sequence[float] | np.ndarray | pd.Series],
     *,
     bins: int | Sequence[float] | str = 200,
     x_range: tuple[float | None, float | None] | None = None,
@@ -152,7 +157,7 @@ def histogram(
 
     fig = go.Figure(**fig_kwargs or {})
     for label, vals in data.items():
-        hist_vals, _ = np.histogram(vals, bins=bin_edges, density=density)
+        hist_vals, _ = np.histogram(np.asarray(vals), bins=bin_edges, density=density)
         fig.add_bar(
             x=bin_edges[:-1],
             y=hist_vals,

--- a/pymatviz/histogram.py
+++ b/pymatviz/histogram.py
@@ -133,8 +133,7 @@ def histogram(
     Returns:
         go.Figure: The Plotly figure object containing the histogram.
     """
-    # if values was a Series, extract the name attribute to use as legend label
-    x_axis_title = getattr(values, "name", "Value")
+    x_axis_title = "Value" if (name := getattr(values, "name", None)) is None else name
     data = values if isinstance(values, dict) else {x_axis_title: values}
     data_arrays = {label: np.asarray(vals, dtype=float) for label, vals in data.items()}
     if not data_arrays:

--- a/pymatviz/histogram.py
+++ b/pymatviz/histogram.py
@@ -57,19 +57,20 @@ def elements_hist(
     if keep_top is not None:
         non_zero = non_zero.head(keep_top)
 
+    non_zero_values = non_zero.to_numpy()
     # Prepare text labels for bars
     text_labels = None
     if show_values is not None:
         if show_values == "percent":
             sum_elements = non_zero.sum()
-            text_labels = [f"{el / sum_elements:.0%}" for el in non_zero.to_numpy()]
+            text_labels = [f"{el / sum_elements:.0%}" for el in non_zero_values]
         else:
-            text_labels = [str(int(val)) for val in non_zero.to_numpy()]
+            text_labels = [str(int(val)) for val in non_zero_values]
 
     fig = go.Figure(**fig_kwargs or {})
     fig.add_bar(
         x=non_zero.index,
-        y=non_zero.values,
+        y=non_zero_values,
         text=text_labels,
         textposition="outside",
         opacity=opacity,
@@ -116,9 +117,8 @@ def histogram(
         px.histogram(gaussian)  # ran for 3m45s before crashing the Jupyter kernel
 
     Args:
-        values (Sequence[float] or dict[str, Sequence[float] | np.ndarray]): The values
-            to plot as a histogram. If a dict is provided, the keys are used as legend
-            labels.
+        values: Values to plot as a histogram. Accepts a sequence, NumPy array, pandas
+            Series, or dict of named series. Dict keys are used as legend labels.
         bins (int or sequence, optional): The number of bins or the bin edges to use for
             the histogram. If not provided, a default value will be used.
         x_range (tuple, optional): The range of values to include in the histogram. If
@@ -136,16 +136,27 @@ def histogram(
     # if values was a Series, extract the name attribute to use as legend label
     x_axis_title = getattr(values, "name", "Value")
     data = values if isinstance(values, dict) else {x_axis_title: values}
+    data_arrays = {label: np.asarray(vals, dtype=float) for label, vals in data.items()}
+    if not data_arrays:
+        raise ValueError("histogram values must not be empty.")
+    for label, vals in data_arrays.items():
+        if vals.ndim != 1 or len(vals) == 0:
+            raise ValueError(
+                f"histogram values for {label!r} must be a non-empty 1D array."
+            )
 
     # Calculate the maximum data range across all datasets
-    all_values = np.concatenate(list(data.values()))
+    all_values = np.concatenate(list(data_arrays.values()))
     global_min = np.min(all_values)
     global_max = np.max(all_values)
 
     if x_range is None:
         x_range = (global_min, global_max)
     else:
-        x_range = (x_range[0] or global_min, x_range[1] or global_max)
+        x_range = (
+            global_min if x_range[0] is None else x_range[0],
+            global_max if x_range[1] is None else x_range[1],
+        )
 
     # Calculate bin edges
     if isinstance(bins, int):
@@ -156,8 +167,8 @@ def histogram(
         bin_edges = np.asarray(bins)
 
     fig = go.Figure(**fig_kwargs or {})
-    for label, vals in data.items():
-        hist_vals, _ = np.histogram(np.asarray(vals), bins=bin_edges, density=density)
+    for label, vals in data_arrays.items():
+        hist_vals, _ = np.histogram(vals, bins=bin_edges, density=density)
         fig.add_bar(
             x=bin_edges[:-1],
             y=hist_vals,

--- a/pymatviz/rainclouds.py
+++ b/pymatviz/rainclouds.py
@@ -103,12 +103,15 @@ def rainclouds(
         color = qualitative.Plotly[idx % len(qualitative.Plotly)]
         rgba_color = rgba_from_hex(color, alpha)
         pos = positions[idx]
+        df_i: pd.DataFrame | None = None
+        col: str | None = None
+        if isinstance(data_itm, tuple) and len(data_itm) == 2:
+            data_frame, column = data_itm
+        else:
+            data_frame, column = None, None
 
-        if (
-            len(data_itm) == 2
-            and isinstance(df_i := data_itm[0], pd.DataFrame)
-            and isinstance(col := data_itm[1], str)
-        ):
+        if isinstance(data_frame, pd.DataFrame) and isinstance(column, str):
+            df_i, col = data_frame, column
             values = df_i[col]
             if hover_data is None:
                 hover_data = [col]
@@ -193,7 +196,7 @@ def rainclouds(
         if show_points:  # the rain
             rng = np.random.default_rng(seed=0)
             jitter_values = rng.normal(0, jitter, size=len(values))
-            hover_key = data_itm[1] if isinstance(data_itm, tuple) else "value"
+            hover_key = col or "value"
             hover_text = [f"{label}<br>{hover_key}: {val:.3g}" for val in values]
 
             if hover_data is not None:
@@ -206,23 +209,21 @@ def rainclouds(
                     else None
                 )
                 if isinstance(extra_hover, Mapping):
-                    for col, col_data in extra_hover.items():
+                    for hover_col, col_data in extra_hover.items():
                         if isinstance(col_data, (str, bytes)):
                             continue
                         col_values = list(cast("Sequence[object]", col_data))
                         if len(col_values) != len(hover_text):
                             warnings.warn(
-                                f"Skipping hover column {col!r}: "
+                                f"Skipping hover column {hover_col!r}: "
                                 f"{len(col_values)=} != {len(hover_text)=}",
                                 stacklevel=2,
                             )
                             continue
                         for val_idx, val in enumerate(col_values):
-                            hover_text[val_idx] += f"<br>{col}: {val}"
+                            hover_text[val_idx] += f"<br>{hover_col}: {val}"
                 elif (
-                    len(data_itm) == 2
-                    and isinstance(df_i := data_itm[0], pd.DataFrame)
-                    and isinstance(data_itm[1], str)
+                    df_i is not None
                     and (
                         cols_to_show := extra_hover
                         if isinstance(hover_data, Mapping)

--- a/pymatviz/rainclouds.py
+++ b/pymatviz/rainclouds.py
@@ -20,7 +20,9 @@ if TYPE_CHECKING:
 
 
 def rainclouds(
-    data: Mapping[str, Sequence[float] | tuple[pd.DataFrame, str]],
+    data: Mapping[
+        str, Sequence[float] | np.ndarray | pd.Series | tuple[pd.DataFrame, str]
+    ],
     *,
     orientation: Literal["h", "v"] = "h",
     alpha: float = 0.7,

--- a/pymatviz/widgets/_normalize.py
+++ b/pymatviz/widgets/_normalize.py
@@ -116,13 +116,16 @@ def normalize_plot_json(value: Any, label: str) -> Any:
         TypeError: If value cannot be serialized to JSON-safe primitives.
         ValueError: If value contains non-finite numbers.
     """
-    if value is None or isinstance(value, (bool, str, int)):
+    if value is None or isinstance(value, (bool, str)):
         return value
+
+    if isinstance(value, int):
+        return int(value)
 
     if isinstance(value, float):
         if not math.isfinite(value):
             raise ValueError(f"{label} contains non-finite float value: {value!r}.")
-        return value
+        return float(value)
 
     # Convert numpy scalars (.item()) and arrays (.tolist()) to native Python
     for method_name in ("item", "tolist"):
@@ -257,8 +260,16 @@ def _parse_formula_to_dict(formula: str) -> dict[str, float]:
     Returns:
         Dict mapping element symbols to their counts.
     """
+    if not formula.strip():
+        raise ValueError("Formula must not be empty.")
+    if any(char in formula for char in "()[]{}"):
+        raise ValueError(f"Unsupported grouping in formula: {formula!r}.")
+
     composition: dict[str, float] = {}
-    for match in re.finditer(r"([A-Z][a-z]?)(\d*\.?\d*)", formula):
+    matches = list(re.finditer(r"([A-Z][a-z]?)(\d*\.?\d*)", formula))
+    if "".join(match.group(0) for match in matches) != formula:
+        raise ValueError(f"Invalid formula syntax: {formula!r}.")
+    for match in matches:
         element = match.group(1)
         count_str = match.group(2)
         count = float(count_str) if count_str else 1.0

--- a/pymatviz/widgets/spacegroup_bar.py
+++ b/pymatviz/widgets/spacegroup_bar.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from operator import index
 from typing import Any
 
 import traitlets as tl
@@ -42,14 +43,22 @@ class SpacegroupBarPlotWidget(MatterVizWidget):
             data: Space group numbers/Hermann-Mauguin symbols or count mapping.
             **kwargs: Additional widget properties.
         """
-        if isinstance(data, Mapping):
-            if any(count < 0 for count in data.values()):
-                raise ValueError("Space group counts must be non-negative.")
-            data = [spg for spg, count in data.items() for _ in range(count)]
+        normalized_data: Any = data
+        if isinstance(normalized_data, Mapping):
+            try:
+                counts = {spg: index(count) for spg, count in normalized_data.items()}
+            except TypeError as exc:
+                raise TypeError("Space group counts must be integers.") from exc
+            if any(count < 0 for count in counts.values()):
+                raise ValueError("Space group counts must be non-negative integers.")
+            normalized_data = [
+                spg for spg, count in counts.items() for _ in range(count)
+            ]
         super().__init__(
             widget_type="spacegroup_bar",
             data=normalize_plot_json(
-                [] if data is None else data, "SpacegroupBarPlot.data"
+                [] if normalized_data is None else normalized_data,
+                "SpacegroupBarPlot.data",
             ),
             **kwargs,
         )

--- a/pymatviz/widgets/spacegroup_bar.py
+++ b/pymatviz/widgets/spacegroup_bar.py
@@ -43,22 +43,18 @@ class SpacegroupBarPlotWidget(MatterVizWidget):
             data: Space group numbers/Hermann-Mauguin symbols or count mapping.
             **kwargs: Additional widget properties.
         """
-        normalized_data: Any = data
-        if isinstance(normalized_data, Mapping):
+        if data is None:
+            data = []
+        elif isinstance(data, Mapping):
             try:
-                counts = {spg: index(count) for spg, count in normalized_data.items()}
+                counts = {spg: index(count) for spg, count in data.items()}
             except TypeError as exc:
                 raise TypeError("Space group counts must be integers.") from exc
             if any(count < 0 for count in counts.values()):
                 raise ValueError("Space group counts must be non-negative integers.")
-            normalized_data = [
-                spg for spg, count in counts.items() for _ in range(count)
-            ]
+            data = [spg for spg, count in counts.items() for _ in range(count)]
         super().__init__(
             widget_type="spacegroup_bar",
-            data=normalize_plot_json(
-                [] if normalized_data is None else normalized_data,
-                "SpacegroupBarPlot.data",
-            ),
+            data=normalize_plot_json(data, "SpacegroupBarPlot.data"),
             **kwargs,
         )

--- a/pymatviz/widgets/spacegroup_bar.py
+++ b/pymatviz/widgets/spacegroup_bar.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import traitlets as tl
@@ -13,8 +14,8 @@ from pymatviz.widgets.matterviz import MatterVizWidget
 class SpacegroupBarPlotWidget(MatterVizWidget):
     """MatterViz widget for space group frequency bar plots.
 
-    Accepts a list of space group numbers or symbols and renders a bar chart
-    showing their frequency distribution.
+    Accepts space group numbers/symbols or ``{spacegroup: count}`` mappings and
+    renders a bar chart showing their frequency distribution.
 
     Examples:
         >>> from pymatviz import SpacegroupBarPlotWidget
@@ -23,6 +24,7 @@ class SpacegroupBarPlotWidget(MatterVizWidget):
 
     data = tl.List(allow_none=True).tag(sync=True)
     show_counts = tl.Bool(default_value=True).tag(sync=True)
+    show_legend = tl.Bool(default_value=False).tag(sync=True)
     orientation = tl.CaselessStrEnum(
         values=["vertical", "horizontal"], default_value="vertical"
     ).tag(sync=True)
@@ -31,17 +33,23 @@ class SpacegroupBarPlotWidget(MatterVizWidget):
 
     def __init__(
         self,
-        data: list[int | str] | None = None,
+        data: Any = None,
         **kwargs: Any,
     ) -> None:
         """Initialize a space group bar plot widget.
 
         Args:
-            data: List of space group numbers or Hermann-Mauguin symbols.
+            data: Space group numbers/Hermann-Mauguin symbols or count mapping.
             **kwargs: Additional widget properties.
         """
+        if isinstance(data, Mapping):
+            if any(count < 0 for count in data.values()):
+                raise ValueError("Space group counts must be non-negative.")
+            data = [spg for spg, count in data.items() for _ in range(count)]
         super().__init__(
             widget_type="spacegroup_bar",
-            data=normalize_plot_json(data or [], "SpacegroupBarPlot.data"),
+            data=normalize_plot_json(
+                [] if data is None else data, "SpacegroupBarPlot.data"
+            ),
             **kwargs,
         )

--- a/pymatviz/widgets/web/anywidget.ts
+++ b/pymatviz/widgets/web/anywidget.ts
@@ -496,7 +496,14 @@ const render_spacegroup_bar: Render = ({ model, el }) => {
     model,
     el,
     SpacegroupBarPlot,
-    pick_props(model, [`data`, `show_counts`, `orientation`, `x_axis`, `y_axis`]),
+    pick_props(model, [
+      `data`,
+      `show_counts`,
+      `show_legend`,
+      `orientation`,
+      `x_axis`,
+      `y_axis`,
+    ]),
   )
 }
 

--- a/readme.md
+++ b/readme.md
@@ -319,7 +319,7 @@ See [`pymatviz/bar.py`](pymatviz/bar.py).
 
 See [`pymatviz/histogram.py`](pymatviz/histogram.py).
 
-| [`elements_hist(compositions, log=True, bar_values='count')`](pymatviz/histogram.py#L23) [![fig-icon]](assets/scripts/histogram/elements_hist.py) | [`histogram({'key1': values1, 'key2': values2})`](pymatviz/histogram.py#L91) [![fig-icon]](assets/scripts/histogram/histogram.py) |
+| [`elements_hist(compositions, log=True, bar_values='count')`](pymatviz/histogram.py#L23) [![fig-icon]](assets/scripts/histogram/elements_hist.py) | [`histogram({'key1': values1, 'key2': values2})`](pymatviz/histogram.py#L92) [![fig-icon]](assets/scripts/histogram/histogram.py) |
 | :-----------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------: |
 |                                                                 ![elements-hist]                                                                  |                                                         ![histogram-ecdf]                                                         |
 

--- a/readme.md
+++ b/readme.md
@@ -319,7 +319,7 @@ See [`pymatviz/bar.py`](pymatviz/bar.py).
 
 See [`pymatviz/histogram.py`](pymatviz/histogram.py).
 
-| [`elements_hist(compositions, log=True, bar_values='count')`](pymatviz/histogram.py#L21) [![fig-icon]](assets/scripts/histogram/elements_hist.py) | [`histogram({'key1': values1, 'key2': values2})`](pymatviz/histogram.py#L89) [![fig-icon]](assets/scripts/histogram/histogram.py) |
+| [`elements_hist(compositions, log=True, bar_values='count')`](pymatviz/histogram.py#L23) [![fig-icon]](assets/scripts/histogram/elements_hist.py) | [`histogram({'key1': values1, 'key2': values2})`](pymatviz/histogram.py#L91) [![fig-icon]](assets/scripts/histogram/histogram.py) |
 | :-----------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------: |
 |                                                                 ![elements-hist]                                                                  |                                                         ![histogram-ecdf]                                                         |
 

--- a/tests/structure/test_structure_plotly.py
+++ b/tests/structure/test_structure_plotly.py
@@ -1640,8 +1640,6 @@ def test_disordered_site_constants() -> None:
 
 def test_spherical_wedge_mesh_generation() -> None:
     """Test the spherical wedge mesh generation function."""
-    import numpy as np
-
     center = np.array([0.0, 0.0, 0.0])
     radius = 1.0
     start_angle = 0.0

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -12,6 +12,9 @@ from tests.conftest import df_regr, y_true
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    import numpy as np
+    import pandas as pd
+
 
 def test_hist_elemental_prevalence(glass_formulas: list[str]) -> None:
     """Test elements histogram with various parameters."""
@@ -37,8 +40,10 @@ def test_hist_elemental_prevalence(glass_formulas: list[str]) -> None:
 
 @pytest.mark.parametrize("log_y", [True, False])
 @pytest.mark.parametrize("bins", [20, 100])
-@pytest.mark.parametrize("values", [y_true.tolist(), df_regr.y_true.tolist()])
-def test_histogram(values: Sequence[float], log_y: bool, bins: int) -> None:
+@pytest.mark.parametrize("values", [y_true, df_regr.y_true])
+def test_histogram(
+    values: Sequence[float] | np.ndarray | pd.Series, log_y: bool, bins: int
+) -> None:
     """Test histogram function with Plotly backend."""
     fig = histogram(values, log_y=log_y, bins=bins)
     assert isinstance(fig, go.Figure)

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import plotly.graph_objects as go
 import pytest
@@ -60,3 +60,23 @@ def test_histogram(
     assert y_max == pytest.approx(y_max_exp)
 
     assert fig.layout.yaxis.title.text == "Count"
+
+
+@pytest.mark.parametrize(
+    ("values", "match"),
+    [
+        ({}, "must not be empty"),
+        ([], "non-empty 1D"),
+        ([[1, 2], [3, 4]], "non-empty 1D"),
+    ],
+)
+def test_histogram_rejects_invalid_values(values: Any, match: str) -> None:
+    """Histogram rejects empty and non-1D inputs."""
+    with pytest.raises(ValueError, match=match):
+        histogram(values)
+
+
+def test_histogram_preserves_zero_x_range_boundary() -> None:
+    """Histogram treats zero x_range bounds as explicit values."""
+    fig = histogram([1, 2, 3], x_range=(0, None), bins=3)
+    assert fig.data[0].x[0] == 0

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import pandas as pd
 import plotly.graph_objects as go
 import pytest
 
@@ -13,7 +14,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     import numpy as np
-    import pandas as pd
 
 
 def test_hist_elemental_prevalence(glass_formulas: list[str]) -> None:
@@ -80,3 +80,16 @@ def test_histogram_preserves_zero_x_range_boundary() -> None:
     """Histogram treats zero x_range bounds as explicit values."""
     fig = histogram([1, 2, 3], x_range=(0, None), bins=3)
     assert fig.data[0].x[0] == 0
+
+
+@pytest.mark.parametrize(
+    ("series_name", "expected_title"),
+    [(None, "Value"), ("my_col", "my_col"), (0, "0"), ("", "")],
+)
+def test_histogram_series_xaxis_title(
+    series_name: str | int | None, expected_title: str
+) -> None:
+    """Histogram uses series name as x-axis title; only None falls back to 'Value'."""
+    fig = histogram(pd.Series([1.0, 2.0, 3.0], name=series_name))
+    assert fig.layout.xaxis.title.text == expected_title
+    assert fig.data[0].name == expected_title

--- a/tests/test_rainclouds.py
+++ b/tests/test_rainclouds.py
@@ -19,10 +19,11 @@ if TYPE_CHECKING:
 @pytest.fixture
 def sample_data() -> dict[str, np.ndarray]:
     rng = np.random.default_rng(seed=0)
-    arr1 = rng.normal(0, 1, 100)
-    arr2 = rng.normal(2, 1.5, 80)
-    arr3 = rng.normal(-1, 0.5, 120)
-    return {"A": arr1, "B": arr2, "C": arr3}
+    return {
+        "A": rng.normal(0, 1, 100),
+        "B": rng.normal(2, 1.5, 80),
+        "C": rng.normal(-1, 0.5, 120),
+    }
 
 
 @pytest.fixture
@@ -85,6 +86,12 @@ def test_rainclouds_with_dataframe(sample_dataframe: pd.DataFrame) -> None:
     fig = pmv.rainclouds(data, hover_data=["category", "extra"])
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == 6
+
+
+def test_rainclouds_accepts_two_item_series_with_non_default_index() -> None:
+    """Rainclouds treats two-item Series as data, not DataFrame-column tuples."""
+    fig = pmv.rainclouds({"S": pd.Series([1.0, 2.0], index=[10, 11])})
+    assert len(fig.data) == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/test_rainclouds.py
+++ b/tests/test_rainclouds.py
@@ -17,13 +17,12 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def sample_data() -> dict[str, Sequence[float]]:
+def sample_data() -> dict[str, np.ndarray]:
     rng = np.random.default_rng(seed=0)
-    return {
-        "A": rng.normal(0, 1, 100).tolist(),
-        "B": rng.normal(2, 1.5, 80).tolist(),
-        "C": rng.normal(-1, 0.5, 120).tolist(),
-    }
+    arr1 = rng.normal(0, 1, 100)
+    arr2 = rng.normal(2, 1.5, 80)
+    arr3 = rng.normal(-1, 0.5, 120)
+    return {"A": arr1, "B": arr2, "C": arr3}
 
 
 @pytest.fixture
@@ -50,7 +49,7 @@ def sample_dataframe() -> pd.DataFrame:
     ],
 )
 def test_rainclouds_basic(
-    sample_data: dict[str, Sequence[float]], kwargs: dict[str, Any]
+    sample_data: dict[str, np.ndarray], kwargs: dict[str, Any]
 ) -> None:
     fig = pmv.rainclouds(sample_data, **kwargs)
     assert isinstance(fig, go.Figure)
@@ -81,7 +80,7 @@ def test_rainclouds_data_shapes(
 def test_rainclouds_with_dataframe(sample_dataframe: pd.DataFrame) -> None:
     data = {
         "X": (sample_dataframe, "value"),
-        "Y": sample_dataframe[sample_dataframe["category"] == "Y"]["value"].tolist(),
+        "Y": sample_dataframe[sample_dataframe["category"] == "Y"]["value"],
     }
     fig = pmv.rainclouds(data, hover_data=["category", "extra"])
     assert isinstance(fig, go.Figure)
@@ -92,7 +91,7 @@ def test_rainclouds_with_dataframe(sample_dataframe: pd.DataFrame) -> None:
     ("orientation", "expected_axis"), [("h", "yaxis"), ("v", "xaxis")]
 )
 def test_rainclouds_orientation(
-    sample_data: dict[str, Sequence[float]],
+    sample_data: dict[str, np.ndarray],
     orientation: Literal["h", "v"],
     expected_axis: str,
 ) -> None:
@@ -109,7 +108,7 @@ def test_rainclouds_orientation(
     ],
 )
 def test_rainclouds_scale(
-    sample_data: dict[str, Sequence[float]],
+    sample_data: dict[str, np.ndarray],
     scale: Literal["area", "count", "width"],
     expected_range: tuple[float, float] | None,
 ) -> None:
@@ -174,7 +173,7 @@ def test_rainclouds_invalid_input(
         pmv.rainclouds(data_input)
 
 
-def test_rainclouds_long_labels(sample_data: dict[str, Sequence[float]]) -> None:
+def test_rainclouds_long_labels(sample_data: dict[str, np.ndarray]) -> None:
     long_labels = {
         f"Very long label {idx}": data
         for idx, (_, data) in enumerate(sample_data.items())
@@ -197,7 +196,7 @@ def test_rainclouds_long_labels(sample_data: dict[str, Sequence[float]]) -> None
     ],
 )
 def test_rainclouds_trace_visibility(
-    sample_data: dict[str, Sequence[float]],
+    sample_data: dict[str, np.ndarray],
     show_violin: bool,
     show_box: bool,
     show_points: bool,

--- a/tests/treemap/test_py_pkg_treemap.py
+++ b/tests/treemap/test_py_pkg_treemap.py
@@ -729,8 +729,6 @@ def test_normalize_package_input() -> None:
     assert pmv.treemap.py_pkg._normalize_package_input("numpy") == "numpy"
 
     # Test module object input
-    import numpy as np
-
     assert pmv.treemap.py_pkg._normalize_package_input(np) == "numpy"
 
     # Test submodule object input
@@ -748,10 +746,7 @@ def test_normalize_package_input() -> None:
 
 def test_py_pkg_treemap_with_module_objects() -> None:
     """Test py_pkg_treemap with module objects instead of strings."""
-    import numpy as np
-
-    # Test single module object
-    fig = pmv.py_pkg_treemap(np)
+    fig = pmv.py_pkg_treemap(np)  # Test single module object
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == 1
 

--- a/tests/widgets/test_normalize.py
+++ b/tests/widgets/test_normalize.py
@@ -16,6 +16,7 @@ from pymatviz.widgets._normalize import (
     _parse_formula_to_dict,
     _to_dict,
     normalize_convex_hull_entries,
+    normalize_plot_json,
     normalize_plot_series,
     normalize_structure_for_bz,
     normalize_xrd_pattern,
@@ -338,37 +339,29 @@ def test_normalize_structure_for_bz_unsupported_type() -> None:
 def test_normalize_plot_series_from_array_like_inputs(
     x_values: Any, y_values: Any
 ) -> None:
-    """Array-backed values and scalar subclasses normalize to Python primitives."""
+    """Array-backed series values normalize to Python primitives."""
+    normalized = normalize_plot_series(
+        [{"x": x_values, "y": y_values, "label": "A"}],
+        component_name="ScatterPlot",
+    )
+    assert normalized == [{"x": [0.0, 1.0, 2.0], "y": [0.1, 0.2, 0.3], "label": "A"}]
+
+
+def test_normalize_plot_json_scalar_subclasses() -> None:
+    """Scalar subclasses normalize to JSON-safe Python primitives."""
 
     class MockIntEnum(IntEnum):
         """Mock integer enum for JSON-safe int subclass normalization."""
 
         VALUE = 42
 
-    normalized = normalize_plot_series(
-        [
-            {
-                "x": x_values,
-                "y": y_values,
-                "label": "A",
-                "size": np.float64(4.5),
-                "rank": MockIntEnum.VALUE,
-            }
-        ],
-        component_name="ScatterPlot",
-    )
-    assert normalized is not None
-    assert normalized == [
-        {
-            "x": [0.0, 1.0, 2.0],
-            "y": [0.1, 0.2, 0.3],
-            "label": "A",
-            "size": 4.5,
-            "rank": 42,
-        }
-    ]
-    assert type(normalized[0]["size"]) is float
-    assert type(normalized[0]["rank"]) is int
+    for value, expected, expected_type in [
+        (np.float64(4.5), 4.5, float),
+        (MockIntEnum.VALUE, 42, int),
+    ]:
+        normalized = normalize_plot_json(value, "test")
+        assert normalized == expected
+        assert type(normalized) is expected_type
 
 
 @pytest.mark.parametrize(

--- a/tests/widgets/test_normalize.py
+++ b/tests/widgets/test_normalize.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
+from enum import IntEnum
 from typing import Any
 
 import numpy as np
+import pandas as pd
 import pytest
 from pymatgen.core import Composition, Lattice, Structure
 
@@ -69,6 +71,13 @@ def test_to_dict_raises_for_unsupported_type(label: str) -> None:
 def test_parse_formula_to_dict(formula: str, expected: dict[str, float]) -> None:
     """Formula strings are parsed to element-count dicts."""
     assert _parse_formula_to_dict(formula) == expected
+
+
+@pytest.mark.parametrize("formula", ["", "   ", "(Li)2O", "Li[Fe]O2", "2LiO", "Li2O!"])
+def test_parse_formula_to_dict_rejects_malformed(formula: str) -> None:
+    """Malformed formulas raise instead of silently dropping invalid tokens."""
+    with pytest.raises(ValueError, match=r"Formula|Unsupported|Invalid"):
+        _parse_formula_to_dict(formula)
 
 
 # === _normalize_entry_compositions ===
@@ -319,13 +328,47 @@ def test_normalize_structure_for_bz_unsupported_type() -> None:
 # === normalize_plot_series ===
 
 
-def test_normalize_plot_series_from_numpy_arrays() -> None:
-    """Series arrays from NumPy must normalize to finite Python floats."""
+@pytest.mark.parametrize(
+    ("x_values", "y_values"),
+    [
+        (np.array([0, 1, 2]), np.array([0.1, 0.2, 0.3])),
+        (pd.Series([0, 1, 2]), pd.Series([0.1, 0.2, 0.3])),
+    ],
+)
+def test_normalize_plot_series_from_array_like_inputs(
+    x_values: Any, y_values: Any
+) -> None:
+    """Array-backed values and scalar subclasses normalize to Python primitives."""
+
+    class MockIntEnum(IntEnum):
+        """Mock integer enum for JSON-safe int subclass normalization."""
+
+        VALUE = 42
+
     normalized = normalize_plot_series(
-        [{"x": np.array([0, 1, 2]), "y": np.array([0.1, 0.2, 0.3]), "label": "A"}],
+        [
+            {
+                "x": x_values,
+                "y": y_values,
+                "label": "A",
+                "size": np.float64(4.5),
+                "rank": MockIntEnum.VALUE,
+            }
+        ],
         component_name="ScatterPlot",
     )
-    assert normalized == [{"x": [0.0, 1.0, 2.0], "y": [0.1, 0.2, 0.3], "label": "A"}]
+    assert normalized is not None
+    assert normalized == [
+        {
+            "x": [0.0, 1.0, 2.0],
+            "y": [0.1, 0.2, 0.3],
+            "label": "A",
+            "size": 4.5,
+            "rank": 42,
+        }
+    ]
+    assert type(normalized[0]["size"]) is float
+    assert type(normalized[0]["rank"]) is int
 
 
 @pytest.mark.parametrize(

--- a/tests/widgets/test_widget_construction.py
+++ b/tests/widgets/test_widget_construction.py
@@ -659,8 +659,12 @@ def test_spacegroup_bar_data_inputs() -> None:
     assert widget.data == [225, 166, 62]
     widget = SpacegroupBarPlotWidget(data={225: np.int64(2), 166: 0, "P2_1/c": 1})
     assert widget.data == [225, 225, "P2_1/c"]
-    with pytest.raises(ValueError, match="non-negative"):
-        SpacegroupBarPlotWidget(data={225: -1})
+    for bad_data, error_cls, match in [
+        ({225: -1}, ValueError, "non-negative"),
+        ({225: 1.5}, TypeError, "integer"),
+    ]:
+        with pytest.raises(error_cls, match=match):
+            SpacegroupBarPlotWidget(data=bad_data)
 
 
 def test_heatmap_matrix_values_none_passthrough() -> None:

--- a/tests/widgets/test_widget_construction.py
+++ b/tests/widgets/test_widget_construction.py
@@ -355,6 +355,7 @@ def test_widget_construction_and_type(
             {
                 "data",
                 "show_counts",
+                "show_legend",
                 "orientation",
                 "x_axis",
                 "y_axis",
@@ -363,11 +364,7 @@ def test_widget_construction_and_type(
         (
             ChemPotDiagramWidget,
             {"entries": [{"name": "Li", "energy": -1.9}]},
-            {
-                "entries",
-                "config",
-                "temperature",
-            },
+            {"entries", "config", "temperature"},
         ),
     ],
 )
@@ -384,11 +381,7 @@ def test_to_dict_includes_subclass_fields(
     assert base_fields <= set(state), f"Missing base fields in {widget_cls.__name__}"
 
     all_expected = base_fields | expected_fields
-    assert set(state) == all_expected, (
-        f"{widget_cls.__name__}: to_dict keys mismatch.\n"
-        f"  Extra: {set(state) - all_expected}\n"
-        f"  Missing: {all_expected - set(state)}"
-    )
+    assert set(state) == all_expected
 
 
 def test_to_dict_reflects_constructor_values() -> None:
@@ -446,6 +439,7 @@ _MINIMAL_KWARGS: dict[type, dict[str, Any]] = {
         (HeatmapMatrixWidget, "tile_size", "50px"),
         (HeatmapMatrixWidget, "gap", "0px"),
         (SpacegroupBarPlotWidget, "show_counts", True),
+        (SpacegroupBarPlotWidget, "show_legend", False),
         (SpacegroupBarPlotWidget, "orientation", "vertical"),
         (RdfPlotWidget, "cutoff", 15),
         (RdfPlotWidget, "n_bins", 75),
@@ -619,6 +613,12 @@ def test_new_widgets_construct_with_no_data(
             "heatmap_values",
             [1.0, 4.0, 6.9],
         ),
+        (
+            SpacegroupBarPlotWidget,
+            {"data": np.array([225, 166, 62])},
+            "data",
+            [225, 166, 62],
+        ),
     ],
 )
 def test_widget_normalizes_numpy_values(
@@ -629,6 +629,38 @@ def test_widget_normalizes_numpy_values(
     result = getattr(widget, attr)
     assert result == expected
     assert type(result) is list
+
+
+@pytest.mark.parametrize(
+    "widget_cls", [ScatterPlotWidget, BarPlotWidget, HistogramWidget]
+)
+@pytest.mark.parametrize("input_kind", ["numpy", "pandas"])
+def test_xy_plot_widgets_accept_array_backed_series_values(
+    widget_cls: type, input_kind: str
+) -> None:
+    """XY plot widgets accept NumPy arrays and pandas Series in series values."""
+    if input_kind == "numpy":
+        x_values, y_values = np.array([0, 1, 2]), np.array([0.1, 0.2, 0.3])
+    else:
+        pd = pytest.importorskip("pandas")
+        x_values, y_values = pd.Series([0, 1, 2]), pd.Series([0.1, 0.2, 0.3])
+
+    widget = widget_cls(
+        series=[{"x": x_values, "y": y_values, "label": "A"}],
+    )
+    expected_series = [{"x": [0.0, 1.0, 2.0], "y": [0.1, 0.2, 0.3], "label": "A"}]
+    assert widget.series == expected_series
+
+
+def test_spacegroup_bar_data_inputs() -> None:
+    """SpacegroupBarPlotWidget normalizes supported data inputs."""
+    pd = pytest.importorskip("pandas")
+    widget = SpacegroupBarPlotWidget(data=pd.Series([225, 166, 62]))
+    assert widget.data == [225, 166, 62]
+    widget = SpacegroupBarPlotWidget(data={225: np.int64(2), 166: 0, "P2_1/c": 1})
+    assert widget.data == [225, 225, "P2_1/c"]
+    with pytest.raises(ValueError, match="non-negative"):
+        SpacegroupBarPlotWidget(data={225: -1})
 
 
 def test_heatmap_matrix_values_none_passthrough() -> None:


### PR DESCRIPTION
## Summary
- Normalize array-backed widget inputs more consistently, including NumPy scalars, pandas Series, and stricter formula parser failures.
- Add count-map input and `show_legend` syncing for `SpacegroupBarPlotWidget`, with validation for negative counts.
- Let histogram and raincloud helpers accept NumPy arrays and pandas Series directly, with README source links updated by hooks.

## Validation
- Commit hooks passed: ruff, ruff format, ty, README source-link check, marimo check, oxlint, Svelte type check, and file hygiene hooks.
- Focused pytest runs passed for widget construction, normalization, histogram, and raincloud coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Widgets accept NumPy arrays and pandas Series; Spacegroup bar plot accepts count-mapping inputs and adds a show-legend toggle.

* **Improvements**
  * Histogram and raincloud input handling broadened with stricter validation, consistent numeric coercion, and preserved axis/title behavior.
  * Normalization: better scalar handling and stricter formula validation.

* **Documentation**
  * README example anchors updated.

* **Tests**
  * Expanded coverage for array/Series inputs, validation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->