### PR TITLE
Tighten data validation and simplify tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.13
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/pymatviz/chem_env.py
+++ b/pymatviz/chem_env.py
@@ -104,11 +104,17 @@ def classify_local_env_with_order_params(
         )
 
         # Find the geometry with the highest order parameter
-        best_value = max(
-            (val for val in local_order_params if val is not None), default=0
+        best_match_idx, best_value = max(
+            (
+                (idx, val)
+                for idx, val in enumerate(local_order_params)
+                if val is not None
+            ),
+            key=lambda item: item[1],
+            default=(0, 0),
         )
         if best_value > 0.5:  # Only use if reasonably good match
-            return f"{names[local_order_params.index(best_value)]}:{cn_val}"
+            return f"{names[best_match_idx]}:{cn_val}"
 
     except (ImportError, RuntimeError, ValueError, IndexError):
         # Fallback to generic CN-based label

--- a/pymatviz/chem_env.py
+++ b/pymatviz/chem_env.py
@@ -59,61 +59,57 @@ def classify_local_env_with_order_params(
         str: String describing the coordination environment (e.g. "T:4", "O:6", "CN:8")
     """
     from pymatgen.analysis import local_env
+    from pymatgen.core import Structure
 
     try:
-        if not 0 <= site_idx < len(structure):
+        analysis_structure = Structure.from_sites(structure)
+        if not 0 <= site_idx < len(analysis_structure):
             return f"CN:{cn_val}"
 
         # Check if we have order parameters for this coordination number
-        if cn_val not in [int(k_cn) for k_cn in local_env.CN_OPT_PARAMS]:
+        cn_params = local_env.CN_OPT_PARAMS.get(cn_val)
+        if cn_params is None:
             return f"CN:{cn_val}"
 
         # Get the parameter names and settings for this CN
-        names = list(local_env.CN_OPT_PARAMS[cn_val])
-        types = []
-        params = []
-        for name in names:
-            types.append(local_env.CN_OPT_PARAMS[cn_val][name][0])
-            tmp = (
-                local_env.CN_OPT_PARAMS[cn_val][name][1]
-                if len(local_env.CN_OPT_PARAMS[cn_val][name]) > 1
+        names = list(cn_params)
+        order_params = list(cn_params.values())
+        types = [str(order_param[0]) for order_param in order_params]
+        params = [
+            (
+                order_param[1]
+                if len(order_param) > 1 and isinstance(order_param[1], dict)
                 else None
             )
-            params.append(tmp)
+            for order_param in order_params
+        ]
 
         # Create LocalStructOrderParams instance
         local_ops = local_env.LocalStructOrderParams(types, parameters=params)
 
         # Get neighboring sites using CrystalNN
-        crystal_nn = local_env.CrystalNN()
-        nn_info = crystal_nn.get_nn_info(structure=structure, n=site_idx)
+        nn_info = local_env.CrystalNN().get_nn_info(
+            structure=analysis_structure, n=site_idx
+        )
 
-        # Create sites list: central site + neighbors
-        sites = [structure[site_idx]] + [info["site"] for info in nn_info]
+        # Create local structure: central site + neighbors
+        sites = [analysis_structure[site_idx]] + [info["site"] for info in nn_info]
+        local_structure = Structure.from_sites(sites)
 
         # Calculate order parameters
-        neighbor_indices = list(range(1, len(sites)))
         local_order_params = local_ops.get_order_parameters(
-            structure=sites,
+            structure=local_structure,
             n=0,
-            indices_neighs=neighbor_indices,
+            indices_neighs=list(range(1, len(sites))),
         )
 
         # Find the geometry with the highest order parameter
-        best_match_idx = 0
-        best_value = 0.0
-
-        for idx, op_val in enumerate(local_order_params):
-            if op_val is not None and op_val > best_value:
-                best_value = op_val
-                best_match_idx = idx
-
-        # Return the best matching geometry name with CN
+        best_value = max((val for val in local_order_params if val), default=0)
         if best_value > 0.5:  # Only use if reasonably good match
+            best_match_idx = local_order_params.index(best_value)
             return f"{names[best_match_idx]}:{cn_val}"
 
     except (ImportError, RuntimeError, ValueError, IndexError):
         # Fallback to generic CN-based label
-        return f"CN:{cn_val}"
-    else:
-        return f"CN:{cn_val}"  # Fallback to generic CN label
+        pass
+    return f"CN:{cn_val}"  # Fallback to generic CN label

--- a/pymatviz/chem_env.py
+++ b/pymatviz/chem_env.py
@@ -31,9 +31,10 @@ def get_cn_from_symbol(ce_symbol: str, symbol_cn_mapping: dict[str, int]) -> int
 
     if ce_symbol.startswith("M:"):
         try:
-            return int(ce_symbol.split(":")[1])
+            cn_val = int(ce_symbol.split(":")[1])
         except (ValueError, IndexError):
             return 0
+        return max(0, cn_val)
 
     if ce_symbol in ("NULL", "UNKNOWN"):
         return 0
@@ -60,6 +61,9 @@ def classify_local_env_with_order_params(
     from pymatgen.analysis import local_env
 
     try:
+        if not 0 <= site_idx < len(structure):
+            return f"CN:{cn_val}"
+
         # Check if we have order parameters for this coordination number
         if cn_val not in [int(k_cn) for k_cn in local_env.CN_OPT_PARAMS]:
             return f"CN:{cn_val}"
@@ -90,7 +94,7 @@ def classify_local_env_with_order_params(
         # Calculate order parameters
         neighbor_indices = list(range(1, len(sites)))
         local_order_params = local_ops.get_order_parameters(
-            structure=structure,
+            structure=sites,
             n=0,
             indices_neighs=neighbor_indices,
         )

--- a/pymatviz/chem_env.py
+++ b/pymatviz/chem_env.py
@@ -104,10 +104,11 @@ def classify_local_env_with_order_params(
         )
 
         # Find the geometry with the highest order parameter
-        best_value = max((val for val in local_order_params if val), default=0)
+        best_value = max(
+            (val for val in local_order_params if val is not None), default=0
+        )
         if best_value > 0.5:  # Only use if reasonably good match
-            best_match_idx = local_order_params.index(best_value)
-            return f"{names[best_match_idx]}:{cn_val}"
+            return f"{names[local_order_params.index(best_value)]}:{cn_val}"
 
     except (ImportError, RuntimeError, ValueError, IndexError):
         # Fallback to generic CN-based label

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -157,24 +157,26 @@ def save_fig(
                 file.write(text.replace("<div ", f"<div {style=} ", 1))
     else:
         orig_template = fig.layout.template
-        if is_pdf and template:
-            fig.layout.template = template
-        # hide click-to-show traces in PDF
         hidden_traces = []
-        for trace in fig.data:
-            if trace.visible == "legendonly":
-                trace.visible = False
-                hidden_traces.append(trace)
-        fig.write_image(path, **kwargs)
-        if is_pdf:
-            # write PDFs twice to get rid of "Loading [MathJax]/extensions/MathMenu.js"
-            # see https://github.com/plotly/plotly.py/issues/3469#issuecomment-994907721
-            sleep(pdf_sleep)
+        try:
+            if is_pdf and template:
+                fig.layout.template = template
+            # hide click-to-show traces in PDF
+            for trace in fig.data:
+                if trace.visible == "legendonly":
+                    trace.visible = False
+                    hidden_traces.append(trace)
             fig.write_image(path, **kwargs)
-
-            fig.layout.template = orig_template
-        for trace in hidden_traces:
-            trace.visible = "legendonly"
+            if is_pdf:
+                # write PDFs twice to get rid of MathJax loading text
+                # see https://github.com/plotly/plotly.py/issues/3469
+                sleep(pdf_sleep)
+                fig.write_image(path, **kwargs)
+        finally:
+            if is_pdf:
+                fig.layout.template = orig_template
+            for trace in hidden_traces:
+                trace.visible = "legendonly"
 
 
 def save_and_compress_svg(

--- a/pymatviz/io.py
+++ b/pymatviz/io.py
@@ -161,7 +161,7 @@ def save_fig(
         try:
             if is_pdf and template:
                 fig.layout.template = template
-            # hide click-to-show traces in PDF
+            # Hide legendonly (click-to-show) traces for static exports.
             for trace in fig.data:
                 if trace.visible == "legendonly":
                     trace.visible = False

--- a/pymatviz/process_data.py
+++ b/pymatviz/process_data.py
@@ -121,6 +121,12 @@ def count_elements(
         )
         srs.index = srs.index.map(map_atomic_num_to_elem_symbol)
 
+    bad_symbols = srs.index.difference(df_ptable.index)
+    if len(bad_symbols) > 0:
+        raise ValueError(
+            f"Unexpected element symbol(s): {', '.join(map(str, bad_symbols))}"
+        )
+
     # Ensure all elements are present in returned Series (with value zero if they
     # weren't in values before)
     srs = srs.reindex(df_ptable.index, fill_value=fill_value).rename("count")
@@ -169,6 +175,10 @@ def count_formulas(
         ValueError: If data is empty or contains invalid formulas/elements.
         TypeError: If data contains unsupported types.
     """
+    valid_group_by = ("formula", "reduced_formula", "chem_sys")
+    if group_by not in valid_group_by:
+        raise ValueError(f"Invalid {group_by=}, must be one of {valid_group_by}")
+
     if len(data) == 0:
         raise ValueError("Empty input: data sequence is empty")
 
@@ -229,7 +239,7 @@ def count_formulas(
 
         # Remove duplicates and sort elements
         elems = sorted(set(elems))
-        if not all(elem.isalpha() for elem in elems):
+        if not all(elem in df_ptable.index for elem in elems):
             raise ValueError(f"Invalid elements in system: {item}")
         systems += [tuple(elems)]
         if group_by != Key.chem_sys:
@@ -247,7 +257,7 @@ def count_formulas(
     df_systems[Key.chem_sys] = df_systems["system"].str.join("-")
 
     # Count occurrences of each system
-    group_cols = ["arity_name", Key.chem_sys]
+    group_cols = [Key.arity, "arity_name", Key.chem_sys]
     if group_by != Key.chem_sys:
         group_cols += [Key.formula]
 
@@ -255,7 +265,14 @@ def count_formulas(
     df_counts.columns = [*group_cols, Key.count]  # preserve original column names
 
     # Sort by arity and chemical system for consistent ordering
-    return df_counts.sort_values(["arity_name", Key.chem_sys])
+    sort_cols = [
+        Key.arity,
+        Key.chem_sys,
+        *([Key.formula] if group_by != Key.chem_sys else []),
+    ]
+    return (
+        df_counts.sort_values(sort_cols).drop(columns=Key.arity).reset_index(drop=True)
+    )
 
 
 STRUCTURE_CLASSES = [

--- a/pymatviz/widgets/web/package.json
+++ b/pymatviz/widgets/web/package.json
@@ -15,6 +15,7 @@
     "anywidget": "^0.11.0",
     "matterviz": "^0.3.4",
     "svelte": "^5.55.5",
+    "svelte-multiselect": "11.7.0",
     "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.20",
     "vite-plus": "^0.1.20"
   },
@@ -22,6 +23,7 @@
     "@sveltejs/vite-plugin-svelte": {
       "vite": "$vite"
     },
-    "svelte": "$svelte"
+    "svelte": "$svelte",
+    "svelte-multiselect": "11.7.0"
   }
 }

--- a/pymatviz/widgets/web/vite.config.ts
+++ b/pymatviz/widgets/web/vite.config.ts
@@ -5,8 +5,6 @@ import { gunzipSync } from 'node:zlib'
 import { defineConfig } from 'vite-plus'
 import { off, shared_fmt, shared_lint } from './vite.shared.ts'
 
-const __dirname = import.meta.dirname
-
 export default defineConfig({
   fmt: shared_fmt,
   lint: {
@@ -51,7 +49,7 @@ export default defineConfig({
   build: {
     outDir: `build`,
     lib: {
-      entry: resolve(__dirname, `anywidget.ts`),
+      entry: resolve(import.meta.dirname, `anywidget.ts`),
       formats: [`es`],
       fileName: `matterviz`,
       cssFileName: `matterviz`,

--- a/site/package.json
+++ b/site/package.json
@@ -21,25 +21,26 @@
   "devDependencies": {
     "@iconify/svelte": "^5.2.1",
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.59.0",
-    "@sveltejs/vite-plugin-svelte": "^7.0.0",
+    "@sveltejs/kit": "^2.60.1",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "highlight.js": "^11.11.1",
     "mdsvex": "^0.12.7",
     "rehype-starry-night": "^2.2.0",
     "rehype-stringify": "^10.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
-    "svelte": "^5.55.5",
-    "svelte-check-rs": "^0.9.7",
+    "svelte": "^5.55.7",
+    "svelte-check-rs": "^0.9.8",
     "svelte-multiselect": "11.7.0",
     "svelte-toc": "^0.6.3",
     "tslib": "^2.8.1",
     "typescript": "^6.0.3",
     "unified": "^11.0.5",
-    "vite": "^8.0.10",
-    "vite-plus": "^0.1.20"
+    "vite": "^8.0.13",
+    "vite-plus": "^0.1.21"
   },
   "overrides": {
-    "svelte": "$svelte"
+    "svelte": "$svelte",
+    "svelte-multiselect": "11.7.0"
   }
 }

--- a/site/src/routes/+layout.server.ts
+++ b/site/src/routes/+layout.server.ts
@@ -3,7 +3,7 @@ import { redirect } from '@sveltejs/kit'
 import type { LayoutServerLoad } from './$types'
 
 export const load: LayoutServerLoad = ({ url }) => {
-  if (/^\/(examples|pymatviz|citation)/.test(url.pathname)) {
+  if (/^\/(examples|pymatviz|citation)/u.test(url.pathname)) {
     const gh_file_url = `https://github.com/janosh/pymatviz/blob/-${url.pathname}`
     throw redirect(307, gh_file_url)
   }

--- a/site/src/routes/+layout.svelte
+++ b/site/src/routes/+layout.svelte
@@ -24,7 +24,7 @@
   const file_routes = Object.keys(import.meta.glob(`./**/+page.{svx,svelte,md}`))
     .filter((key) => !key.includes(`/[`))
     .map((filename) =>
-      filename.replace(/^\./, ``).replace(/\/\+page\.\w+$/, ``) || `/`
+      filename.replace(/^\./u, ``).replace(/\/\+page\.\w+$/u, ``) || `/`
     )
 
   let actions = $derived([...new Set([...file_routes, ...data.notebook_routes])].map(

--- a/tests/test_chem_env.py
+++ b/tests/test_chem_env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 from pymatgen.core import Lattice, Structure
 
@@ -9,163 +10,103 @@ from pymatviz import chem_env
 
 
 @pytest.mark.parametrize(
-    ("symbol", "symbol_cn_mapping", "expected_cn"),
+    ("symbol", "mapping", "expected_cn"),
     [
-        # Known symbols from mapping
         ("T:4", {"T:4": 4, "O:6": 6, "C:8": 8, "PP:5": 5}, 4),
         ("O:6", {"T:4": 4, "O:6": 6, "C:8": 8, "PP:5": 5}, 6),
         ("C:8", {"T:4": 4, "O:6": 6, "C:8": 8, "PP:5": 5}, 8),
         ("PP:5", {"T:4": 4, "O:6": 6, "C:8": 8, "PP:5": 5}, 5),
-        # Special case: S:1
+        ("CUSTOM:3", {"CUSTOM:3": 3, "X:Y:7": 7}, 3),
+        ("X:Y:7", {"CUSTOM:3": 3, "X:Y:7": 7}, 7),
         ("S:1", {}, 1),
-        ("S:1", {"other": 10}, 1),  # Should work regardless of mapping
-        # M: prefix parsing
-        ("M:7", {}, 7),
-        ("M:12", {}, 12),
+        ("S:1", {"other": 10}, 1),
         ("M:1", {}, 1),
+        ("M:6", {}, 6),
+        ("M:7", {}, 7),
+        ("M:8", {"T:4": 4}, 8),
+        ("M:10", {"T:4": 4, "O:6": 6, "C:8": 8, "PP:5": 5}, 10),
+        ("M:12", {}, 12),
+        ("M:15", {}, 15),
         ("M:24", {}, 24),
         ("M:100", {}, 100),
-        # NULL and UNKNOWN
         ("NULL", {}, 0),
+        ("NULL", {"T:4": 4}, 0),
         ("UNKNOWN", {}, 0),
-        ("NULL", {"T:4": 4}, 0),  # Should work regardless of mapping
         ("UNKNOWN", {"T:4": 4}, 0),
-        # Invalid cases
-        ("M:", {}, 0),  # Malformed M: symbol
-        ("M:abc", {}, 0),  # Non-numeric after M:
-        ("M:3.5", {}, 0),  # Float after M:
-        ("M:-5", {}, 0),  # Negative after M:
+        ("O:6", {"T:4": 4}, 0),
+        ("M:", {}, 0),
+        ("M:abc", {}, 0),
+        ("M:3.5", {}, 0),
+        ("M:-5", {}, 0),
+        ("INVALID_SYMBOL", {}, 0),
         ("UNKNOWN_SYMBOL", {}, 0),
-        ("", {}, 0),  # Empty string
-        (":", {}, 0),  # Just colon
-        ("T:", {}, 0),  # Symbol without CN
+        ("", {}, 0),
+        (":", {}, 0),
+        ("T:", {}, 0),
+        ("invalid", {}, 0),
         ("random_text", {}, 0),
-        ("123", {}, 0),  # Just numbers
-        ("T:4:extra", {"T:4": 4}, 0),  # Extra parts
+        ("123", {}, 0),
+        ("T:4:extra", {"T:4": 4}, 0),
     ],
 )
 def test_get_cn_from_symbol(
-    symbol: str, symbol_cn_mapping: dict[str, int], expected_cn: int
+    symbol: str, mapping: dict[str, int], expected_cn: int
 ) -> None:
-    """Test extraction of CN from ChemEnv symbols."""
-    assert chem_env.get_cn_from_symbol(symbol, symbol_cn_mapping) == expected_cn
+    result = chem_env.get_cn_from_symbol(symbol, mapping)
+    assert result == expected_cn
+    assert isinstance(result, int)
+    assert result >= 0
 
 
 @pytest.mark.parametrize(
-    ("symbol", "expected_cn"),
+    ("site_idx", "cn_val", "exact"),
     [
-        # Test with empty mapping - should still handle special cases
-        ("S:1", 1),
-        ("M:6", 6),
-        ("M:15", 15),
-        ("NULL", 0),
-        ("UNKNOWN", 0),
-        ("invalid", 0),
-    ],
-)
-def test_get_cn_from_symbol_empty_mapping(symbol: str, expected_cn: int) -> None:
-    """Test behavior with empty symbol mapping."""
-    symbol_cn_mapping: dict[str, int] = {}
-    assert chem_env.get_cn_from_symbol(symbol, symbol_cn_mapping) == expected_cn
-
-
-@pytest.mark.parametrize(
-    ("site_idx", "cn_val", "expected_format"),
-    [
-        # Basic functionality tests
-        (0, 6, "string_with_colon_or_cn_prefix"),
-        (0, 4, "string_with_colon_or_cn_prefix"),
-        (0, 8, "string_with_colon_or_cn_prefix"),
-        (0, 12, "string_with_colon_or_cn_prefix"),
-        # Edge cases
-        (0, 0, "CN:0"),  # Zero CN
-        (0, -1, "CN:-1"),  # Negative CN
-        (0, 99, "CN:99"),  # Unsupported CN
-        (0, 1000, "CN:1000"),  # Very large CN
-        # More common CNs
-        (0, 1, "string_with_colon_or_cn_prefix"),
-        (0, 2, "string_with_colon_or_cn_prefix"),
-        (0, 3, "string_with_colon_or_cn_prefix"),
-        (0, 5, "string_with_colon_or_cn_prefix"),
-        (0, 7, "string_with_colon_or_cn_prefix"),
-        (0, 9, "string_with_colon_or_cn_prefix"),
-        (0, 10, "string_with_colon_or_cn_prefix"),
-        (0, 11, "string_with_colon_or_cn_prefix"),
-        # Invalid site indices should still return generic CN
-        (999, 6, "CN:6"),  # Invalid site index
-        (-1, 4, "CN:4"),  # Negative site index
-        (100, 8, "CN:8"),  # Out of bounds site index
+        *[(0, cn, None) for cn in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)],
+        *[(0, cn, None) for cn in range(13, 25)],
+        (0, 0, "CN:0"),
+        (0, -1, "CN:-1"),
+        (0, 99, "CN:99"),
+        (0, 1000, "CN:1000"),
+        (999, 6, "CN:6"),
+        (-1, 4, "CN:4"),
+        (100, 8, "CN:8"),
     ],
 )
 def test_classify_local_env_with_order_params_cubic(
     structures: tuple[Structure, Structure],
     site_idx: int,
     cn_val: int,
-    expected_format: str,
+    exact: str | None,
 ) -> None:
-    """Test local environment classification with structures from conftest."""
-    # Use the first structure from conftest.py
-    structure = structures[0]
-    result = chem_env.classify_local_env_with_order_params(structure, site_idx, cn_val)
+    result = chem_env.classify_local_env_with_order_params(
+        structures[0], site_idx, cn_val
+    )
 
     assert isinstance(result, str)
     assert len(result) > 0
-
-    if expected_format == "string_with_colon_or_cn_prefix":
-        # Should either be "GEOMETRY:CN" or start with "CN"
-        assert ":" in result or result.startswith("CN")
+    if exact:
+        assert result == exact
     else:
-        # Exact match expected
-        assert result == expected_format
-
-    # Verify format consistency
+        assert ":" in result or result.startswith("CN")
     if ":" in result:
         parts = result.split(":")
         assert len(parts) == 2
-        if not result.startswith("CN:"):
-            # If not generic CN format, second part should match cn_val
-            assert parts[1] == str(cn_val)
-
-
-@pytest.mark.parametrize(
-    "cn_val",
-    list(range(1, 25)),  # Test CN 1-24
-)
-def test_classify_local_env_return_format_consistency(
-    structures: tuple[Structure, Structure], cn_val: int
-) -> None:
-    """Test that return format is consistent across all CN values."""
-    # Use the first structure from conftest.py
-    structure = structures[0]
-    site_idx = 0
-    result = chem_env.classify_local_env_with_order_params(structure, site_idx, cn_val)
-
-    # Should be string
-    assert isinstance(result, str)
-    assert len(result) > 0
-
-    # Should either be "GEOMETRY:CN" or "CN:N" format
-    if ":" in result:
-        parts = result.split(":")
-        assert len(parts) == 2
-        # Second part should be numeric
         try:
             int(parts[1])
         except ValueError:
             pytest.fail(f"Second part of '{result}' is not numeric")
+        if not result.startswith("CN:"):
+            assert parts[1] == str(cn_val)
 
 
-def test_classify_local_env_different_structures(
-    structures: tuple[Structure, Structure],
+@pytest.mark.parametrize("struct_idx", [0, 1])
+@pytest.mark.parametrize("cn_val", [0, 1, 2, 4, 6, 8, 12, 13, 20, 50, 100])
+def test_classify_local_env_fixture_structures(
+    structures: tuple[Structure, Structure], struct_idx: int, cn_val: int
 ) -> None:
-    """Test with different structure types."""
-    # Use the second structure from conftest.py
-    structure = structures[1]
-    site_idx = 0
-    cn_val = 12  # Test with CN 12
-
-    result = chem_env.classify_local_env_with_order_params(structure, site_idx, cn_val)
-
+    result = chem_env.classify_local_env_with_order_params(
+        structures[struct_idx], 0, cn_val
+    )
     assert isinstance(result, str)
     assert len(result) > 0
     assert ":" in result or result.startswith("CN")
@@ -197,13 +138,14 @@ def test_classify_local_env_uses_requested_site_neighbors(
             structure: Structure,
             n: int,
             indices_neighs: list[int],
-        ) -> list[float]:
+        ) -> np.ndarray:
             assert isinstance(structure, Structure)
+            assert structure[0].species_string == "O"
             assert n == 0
             assert indices_neighs == [1, 2]
-            return [1.0 if structure[0].species_string == "O" else 0.0]
+            return np.array([0.0, 1.0])
 
-    monkeypatch.setitem(local_env.CN_OPT_PARAMS, 4, {"T": ("tet",)})
+    monkeypatch.setitem(local_env.CN_OPT_PARAMS, 4, {"Z": ("zero",), "T": ("tet",)})
     monkeypatch.setattr(local_env, "CrystalNN", FakeCrystalNN)
     monkeypatch.setattr(local_env, "LocalStructOrderParams", FakeOrderParams)
 
@@ -213,13 +155,10 @@ def test_classify_local_env_uses_requested_site_neighbors(
 @pytest.mark.parametrize(
     ("lattice_param", "species", "coords"),
     [
-        # Different lattice parameters
         (2.0, ["Li", "F"], [[0, 0, 0], [0.5, 0.5, 0.5]]),
         (6.0, ["K", "Br"], [[0, 0, 0], [0.5, 0.5, 0.5]]),
-        # Single atom structures
         (4.0, ["Fe"], [[0, 0, 0]]),
         (3.0, ["Al"], [[0, 0, 0]]),
-        # More complex structures
         (
             4.0,
             ["Ca", "Ti", "O", "O", "O"],
@@ -230,122 +169,22 @@ def test_classify_local_env_uses_requested_site_neighbors(
 def test_classify_local_env_various_structures(
     lattice_param: float, species: list[str], coords: list[list[float]]
 ) -> None:
-    """Test classification with various structure types."""
-    lattice = Lattice.cubic(lattice_param)
-    structure = Structure(lattice, species, coords)
-
-    # Test with different CN values
-    for cn_val in [4, 6, 8, 12]:
+    structure = Structure(Lattice.cubic(lattice_param), species, coords)
+    for cn_val in [0, 1, 2, 4, 6, 8, 12, 13, 20, 50, 100]:
         for site_idx in range(len(species)):
             result = chem_env.classify_local_env_with_order_params(
                 structure, site_idx, cn_val
             )
             assert isinstance(result, str)
             assert len(result) > 0
+            assert ":" in result or result.startswith("CN")
 
 
 def test_chem_env_functions_integration(
     structures: tuple[Structure, Structure],
 ) -> None:
-    """Test that chemenv functions work together."""
-    # Test symbol mapping
-    symbol_cn_mapping = {"T:4": 4, "O:6": 6, "C:8": 8}
-
-    # Test get_cn_from_symbol
-    cn = chem_env.get_cn_from_symbol("T:4", symbol_cn_mapping)
+    cn = chem_env.get_cn_from_symbol("T:4", {"T:4": 4, "O:6": 6, "C:8": 8})
     assert cn == 4
-
-    # Use structure from conftest.py
-    structure = structures[0]
-
-    # Test classify_local_env_with_order_params with extracted CN
-    result = chem_env.classify_local_env_with_order_params(structure, 0, cn)
+    result = chem_env.classify_local_env_with_order_params(structures[0], 0, cn)
     assert isinstance(result, str)
     assert len(result) > 0
-
-
-@pytest.mark.parametrize(
-    ("invalid_symbol", "invalid_structure_params"),
-    [
-        ("INVALID_SYMBOL", None),
-        ("", None),
-        ("M:not_a_number", None),
-        (None, "empty_species"),  # Will be handled in test
-    ],
-)
-def test_error_handling_consistency(
-    invalid_symbol: str | None,
-    invalid_structure_params: str | None,
-    structures: tuple[Structure, Structure],
-) -> None:
-    """Test that error handling is consistent across functions."""
-    symbol_cn_mapping: dict[str, int] = {}
-
-    if invalid_symbol is not None:
-        # get_cn_from_symbol should return 0 for unknown symbols
-        result_cn = chem_env.get_cn_from_symbol(invalid_symbol, symbol_cn_mapping)
-        assert result_cn == 0
-
-    # Test classify_local_env_with_order_params error handling
-    if invalid_structure_params != "empty_species":
-        # Use structure from conftest.py
-        structure = structures[0]
-
-        # Should handle gracefully even if analysis fails
-        result = chem_env.classify_local_env_with_order_params(structure, 0, 6)
-        assert isinstance(result, str)
-        assert len(result) > 0
-
-
-@pytest.mark.parametrize(
-    ("symbol_mapping", "test_symbols"),
-    [
-        # Empty mapping
-        ({}, ["S:1", "M:6", "NULL", "UNKNOWN", "invalid"]),
-        # Partial mapping
-        ({"T:4": 4}, ["T:4", "O:6", "S:1", "M:8"]),
-        # Full mapping
-        (
-            {"T:4": 4, "O:6": 6, "C:8": 8, "PP:5": 5},
-            ["T:4", "O:6", "C:8", "PP:5", "M:10"],
-        ),
-        # Complex mapping with edge cases
-        ({"CUSTOM:3": 3, "X:Y:7": 7}, ["CUSTOM:3", "X:Y:7", "S:1", "NULL"]),
-    ],
-)
-def test_get_cn_from_symbol_various_mappings(
-    symbol_mapping: dict[str, int], test_symbols: list[str]
-) -> None:
-    """Test get_cn_from_symbol with various symbol mappings."""
-    for symbol in test_symbols:
-        result = chem_env.get_cn_from_symbol(symbol, symbol_mapping)
-        assert isinstance(result, int)
-        assert result >= 0  # CN should never be negative from this function
-
-
-@pytest.mark.parametrize(
-    ("structure_type", "expected_behavior"),
-    [
-        ("simple_cubic", "should_work"),  # Uses SI2_STRUCT from conftest
-        ("multi_element", "should_work"),  # Uses si2_ru2_pr2_struct from conftest
-    ],
-)
-def test_classify_local_env_structure_robustness(
-    structure_type: str,
-    expected_behavior: str,
-    structures: tuple[Structure, Structure],
-) -> None:
-    """Test robustness across different structure types."""
-    structure = structures[0 if structure_type == "simple_cubic" else 1]
-
-    # Test with edge case CN values
-    edge_case_cns = [0, 1, 2, 13, 20, 50, 100]
-
-    for cn_val in edge_case_cns:
-        result = chem_env.classify_local_env_with_order_params(structure, 0, cn_val)
-
-        if expected_behavior == "should_work":
-            assert isinstance(result, str)
-            assert len(result) > 0
-            # Should handle gracefully - either return specific geometry or generic CN
-            assert ":" in result or result.startswith("CN")

--- a/tests/test_chem_env.py
+++ b/tests/test_chem_env.py
@@ -194,10 +194,11 @@ def test_classify_local_env_uses_requested_site_neighbors(
 
         def get_order_parameters(
             self,
-            structure: list,
+            structure: Structure,
             n: int,
             indices_neighs: list[int],
         ) -> list[float]:
+            assert isinstance(structure, Structure)
             assert n == 0
             assert indices_neighs == [1, 2]
             return [1.0 if structure[0].species_string == "O" else 0.0]

--- a/tests/test_chem_env.py
+++ b/tests/test_chem_env.py
@@ -34,7 +34,7 @@ from pymatviz import chem_env
         ("M:", {}, 0),  # Malformed M: symbol
         ("M:abc", {}, 0),  # Non-numeric after M:
         ("M:3.5", {}, 0),  # Float after M:
-        ("M:-5", {}, -5),  # Negative after M:
+        ("M:-5", {}, 0),  # Negative after M:
         ("UNKNOWN_SYMBOL", {}, 0),
         ("", {}, 0),  # Empty string
         (":", {}, 0),  # Just colon
@@ -169,6 +169,44 @@ def test_classify_local_env_different_structures(
     assert isinstance(result, str)
     assert len(result) > 0
     assert ":" in result or result.startswith("CN")
+
+
+def test_classify_local_env_uses_requested_site_neighbors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for using site 0/order-param neighbors for every site."""
+    from pymatgen.analysis import local_env
+
+    structure = Structure(
+        Lattice.cubic(4),
+        ["Li", "O", "O"],
+        [[0, 0, 0], [0.5, 0.5, 0.5], [0.5, 0, 0]],
+    )
+
+    class FakeCrystalNN:
+        def get_nn_info(self, structure: Structure, n: int) -> list[dict[str, object]]:
+            assert n == 1
+            return [{"site": structure[0]}, {"site": structure[2]}]
+
+    class FakeOrderParams:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def get_order_parameters(
+            self,
+            structure: list,
+            n: int,
+            indices_neighs: list[int],
+        ) -> list[float]:
+            assert n == 0
+            assert indices_neighs == [1, 2]
+            return [1.0 if structure[0].species_string == "O" else 0.0]
+
+    monkeypatch.setitem(local_env.CN_OPT_PARAMS, 4, {"T": ("tet",)})
+    monkeypatch.setattr(local_env, "CrystalNN", FakeCrystalNN)
+    monkeypatch.setattr(local_env, "LocalStructOrderParams", FakeOrderParams)
+
+    assert chem_env.classify_local_env_with_order_params(structure, 1, 4) == "T:4"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -196,6 +196,21 @@ def test_save_fig_pdf_template_and_hidden_traces(
     assert fig.data[0].visible == "legendonly"
 
 
+def test_save_fig_restores_pdf_mutations_on_write_error(tmp_path: Path) -> None:
+    fig = go.Figure()
+    fig.add_scatter(x=[1, 2], y=[3, 4], visible="legendonly")
+    orig_template = fig.layout.template
+
+    with (
+        patch.object(fig, "write_image", side_effect=RuntimeError("write failed")),
+        pytest.raises(RuntimeError, match="write failed"),
+    ):
+        pmv.save_fig(fig, f"{tmp_path}/fig.pdf", env_disable=[])
+
+    assert fig.layout.template == orig_template
+    assert fig.data[0].visible == "legendonly"
+
+
 def test_save_and_compress_svg_type_error() -> None:
     """save_and_compress_svg raises TypeError for non-Figure."""
     with pytest.raises(TypeError, match="fig must be a plotly Figure"):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -197,6 +197,7 @@ def test_save_fig_pdf_template_and_hidden_traces(
 
 
 def test_save_fig_restores_pdf_mutations_on_write_error(tmp_path: Path) -> None:
+    """Ensure save_fig restores layout/data mutations when write_image errors."""
     fig = go.Figure()
     fig.add_scatter(x=[1, 2], y=[3, 4], visible="legendonly")
     orig_template = fig.layout.template

--- a/tests/test_powerups.py
+++ b/tests/test_powerups.py
@@ -20,7 +20,6 @@ np_rng = np.random.default_rng(seed=0)
 
 
 def test_powerups_custom_metrics_and_font_preservation() -> None:
-    """Custom metrics and font objects survive annotation handling."""
     metrics_fig = powerups.annotate_metrics(
         [1, 2, 3], [1, 2, 3], fig=go.Figure(), metrics={"Custom": 1.23}
     )
@@ -67,8 +66,6 @@ def test_add_ecdf_line(
     assert fig.layout.yaxis2.title.text == expected_name
     assert dev_fig.layout.yaxis2.color in (expected_color, "#444")
 
-    # Check that legendgroup is set, ensuring ECDF line toggles with its trace when
-    # clicking legend handle
     assert ecdf_trace.legendgroup == "0"
 
 
@@ -90,9 +87,8 @@ def test_add_ecdf_line_stacked() -> None:
     assert ecdf_trace.yaxis == "y2"
     assert fig.layout.yaxis2.range == (0, 1)
     assert fig.layout.yaxis2.title.text == "Cumulative"
-    # Verify ecdf trace data
     assert len(ecdf_trace.x) == len(np.concatenate([y1, y2]))
-    assert ecdf_trace.y[-1] == 1.0  # Last ECDF value should be 1.0
+    assert ecdf_trace.y[-1] == 1.0
 
 
 def test_add_ecdf_line_faceted() -> None:
@@ -106,22 +102,17 @@ def test_add_ecdf_line_faceted() -> None:
     n_orig_traces = len(fig.data)
     assert n_orig_traces == 4
 
-    # Use default behavior (all traces)
     fig = powerups.add_ecdf_line(fig)
 
-    # We should have exactly 8 traces: 4 original + 4 ECDF traces (1 per original trace)
     assert len(fig.data) == 2 * n_orig_traces
     assert len(fig.data) == 8
 
-    # Check that the original trace names are included in the ECDF trace names
     found_names = set()
     for i, trace in enumerate(fig.data[4:]):
-        # Find traces with "Cumulative" name pattern
         assert "Cumulative" in trace.name
         assert f"Trace {(i // 2) + 1}{(i % 2) + 1}" in trace.name
         found_names.add(trace.name)
 
-    # Should have Cumulative trace for each of the original traces
     assert len(found_names) == 4
     assert "Cumulative (Trace 11)" in found_names
     assert "Cumulative (Trace 12)" in found_names
@@ -130,26 +121,17 @@ def test_add_ecdf_line_faceted() -> None:
 
 
 def test_add_ecdf_line_all_traces() -> None:
-    """Test that add_ecdf_line defaults to adding one ECDF line per trace."""
     fig = go.Figure()
     fig.add_scatter(x=[1, 2, 3], y=[1, 2, 3], name="Trace 1")
     fig.add_scatter(x=[4, 5, 6], y=[4, 5, 6], name="Trace 2")
 
-    # Default behavior should now be all traces
     fig = powerups.add_ecdf_line(fig)
 
-    # Should have 2 original traces + 2 ECDF traces
     assert len(fig.data) == 4
-
-    # Check that ECDF trace names include original trace names
     assert fig.data[2].name == "Cumulative (Trace 1)"
     assert fig.data[3].name == "Cumulative (Trace 2)"
-
-    # Check that ECDF traces use secondary y-axis
     assert fig.data[2].yaxis == "y2"
     assert fig.data[3].yaxis == "y2"
-
-    # Check legendgroup matching
     assert fig.data[2].legendgroup == "0"
     assert fig.data[3].legendgroup == "1"
 
@@ -160,12 +142,10 @@ def test_add_ecdf_line_histogram() -> None:
 
     assert len(fig.data) == 2
     ecdf_trace = fig.data[-1]
-    # Since it's a single trace, no name appending happens
     assert ecdf_trace.name == "Cumulative"
     assert ecdf_trace.yaxis == "y2"
     assert ecdf_trace.legendgroup == "0"
 
-    # Check y values are in ascending order from 0 to 1
     assert ecdf_trace.y[0] > 0
     assert ecdf_trace.y[-1] == 1.0
     assert all(
@@ -179,27 +159,24 @@ def test_add_ecdf_line_bar() -> None:
 
     assert len(fig.data) == 2
     ecdf_trace = fig.data[-1]
-    # Since it's a single trace, no name appending happens
     assert ecdf_trace.name == "Cumulative"
     assert ecdf_trace.yaxis == "y2"
     assert ecdf_trace.legendgroup == "0"
 
-    # Check y values start at 0.25 (1/4) and end at 1.0
     assert ecdf_trace.y[0] == 0.1
     assert ecdf_trace.y[-1] == 1.0
     assert len(ecdf_trace.y) == 10
 
 
 def test_add_ecdf_line_raises() -> None:
-    # check TypeError when passing invalid fig
-    for fig in (None, "foo", 42.0):
+    invalid_figs: tuple[Any, ...] = (None, "foo", 42.0)
+    for fig in invalid_figs:
         with pytest.raises(
             TypeError,
             match=f"{fig=} must be instance of go.Figure",
         ):
             powerups.add_ecdf_line(fig)
 
-    # check ValueError when x-values cannot be auto-determined
     fig_violin = px.violin(x=[1, 2, 3], y=[4, 5, 6])
     violin_trace = type(fig_violin.data[0])
     qual_name = f"{violin_trace.__module__}.{violin_trace.__qualname__}"
@@ -208,136 +185,117 @@ def test_add_ecdf_line_raises() -> None:
     ):
         powerups.add_ecdf_line(fig_violin)
 
-    # check ValueError disappears when passing x-values explicitly
     fig_with_ecdf = powerups.add_ecdf_line(fig_violin, values=[1, 2, 3])
     assert len(fig_with_ecdf.data) == 2
     assert fig_with_ecdf.data[1].name == "Cumulative"
 
 
-def test_toggle_log_linear_y_axis(plotly_scatter: go.Figure) -> None:
-    fig = plotly_scatter
-    assert isinstance(powerups.toggle_log_linear_y_axis, dict)
-    assert fig.layout.updatemenus == ()
-    fig.layout.updatemenus = [powerups.toggle_log_linear_y_axis]
+@pytest.mark.parametrize(
+    ("powerup", "button_specs"),
+    [
+        (
+            powerups.toggle_log_linear_y_axis,
+            [
+                ("Linear Y", "relayout", {"yaxis.type": "linear"}),
+                ("Log Y", "relayout", {"yaxis.type": "log"}),
+            ],
+        ),
+        (
+            powerups.toggle_log_linear_x_axis,
+            [
+                ("Linear X", "relayout", {"xaxis.type": "linear"}),
+                ("Log X", "relayout", {"xaxis.type": "log"}),
+            ],
+        ),
+        (
+            powerups.toggle_grid,
+            [
+                (
+                    "Show Grid",
+                    "relayout",
+                    {"xaxis.showgrid": True, "yaxis.showgrid": True},
+                ),
+                (
+                    "Hide Grid",
+                    "relayout",
+                    {"xaxis.showgrid": False, "yaxis.showgrid": False},
+                ),
+            ],
+        ),
+    ],
+)
+def test_relayout_powerups(
+    plotly_scatter: go.Figure,
+    powerup: dict[str, Any],
+    button_specs: list[tuple[str, str, dict[str, Any]]],
+) -> None:
+    assert isinstance(powerup, dict)
+    assert plotly_scatter.layout.updatemenus == ()
+    for _label, _method, args in button_specs:
+        for key in args:
+            parent, attr = key.split(".")
+            assert getattr(getattr(plotly_scatter.layout, parent), attr) is None
+    plotly_scatter.layout.updatemenus = [powerup]
 
-    # check that figure now has "Log Y"/"Linear Y" toggle buttons
+    menu = plotly_scatter.layout.updatemenus[0]
+    assert isinstance(menu, Updatemenu)
+    buttons = menu.buttons
+    assert len(buttons) == len(button_specs)
+    for button, (label, method, args) in zip(buttons, button_specs, strict=True):
+        assert (button.label, button.method, button.args[0]) == (label, method, args)
+        plotly_scatter.update_layout(args)
+        for key, val in args.items():
+            parent, attr = key.split(".")
+            assert getattr(getattr(plotly_scatter.layout, parent), attr) == val
+
+
+@pytest.mark.parametrize(
+    ("fig", "powerup", "button_specs", "apply"),
+    [
+        (
+            go.Figure(go.Heatmap(z=[[1, 2], [3, 4]])),
+            powerups.select_colorscale,
+            [
+                (scale, "restyle", {"colorscale": scale})
+                for scale in ["Viridis", "Plasma", "Inferno", "Magma"]
+            ],
+            False,
+        ),
+        (
+            go.Figure(go.Scatter(x=[1, 2], y=[3, 4])),
+            powerups.select_marker_mode,
+            [
+                ("Scatter", "restyle", {"type": "scatter", "mode": "markers"}),
+                ("Line", "restyle", {"type": "scatter", "mode": "lines"}),
+                (
+                    "Line+Markers",
+                    "restyle",
+                    {"type": "scatter", "mode": "lines+markers"},
+                ),
+            ],
+            True,
+        ),
+    ],
+)
+def test_restyle_powerups(
+    fig: go.Figure,
+    powerup: dict[str, Any],
+    button_specs: list[tuple[str, str, dict[str, Any]]],
+    apply: bool,
+) -> None:
+    assert isinstance(powerup, dict)
+    assert fig.layout.updatemenus == ()
+    fig.layout.updatemenus = [powerup]
+
     menu = fig.layout.updatemenus[0]
     assert isinstance(menu, Updatemenu)
     buttons = menu.buttons
-    assert len(buttons) == 2
-    assert fig.layout.yaxis.type is None
-    assert buttons[0].args[0]["yaxis.type"] == "linear"
-    assert buttons[1].args[0]["yaxis.type"] == "log"
-    assert buttons[0].label == "Linear Y"
-    assert buttons[1].label == "Log Y"
-    assert buttons[0].method == "relayout"
-    assert buttons[1].method == "relayout"
-
-    # simulate clicking "Log Y" button
-    fig.update_layout(buttons[0].args[0])
-    assert fig.layout.yaxis.type == "linear"
-    fig.update_layout(buttons[1].args[0])
-    assert fig.layout.yaxis.type == "log"
-
-
-def test_toggle_log_linear_x_axis(plotly_scatter: go.Figure) -> None:
-    fig = plotly_scatter
-    assert isinstance(powerups.toggle_log_linear_x_axis, dict)
-    assert fig.layout.updatemenus == ()
-    fig.layout.updatemenus = [powerups.toggle_log_linear_x_axis]
-
-    # check that figure now has "Log X"/"Linear X" toggle buttons
-    menu = fig.layout.updatemenus[0]
-    assert isinstance(menu, Updatemenu)
-    buttons = menu.buttons
-    assert len(buttons) == 2
-    assert fig.layout.xaxis.type is None
-    assert buttons[0].args[0]["xaxis.type"] == "linear"
-    assert buttons[1].args[0]["xaxis.type"] == "log"
-    assert buttons[0].label == "Linear X"
-    assert buttons[1].label == "Log X"
-    assert buttons[0].method == "relayout"
-    assert buttons[1].method == "relayout"
-
-    # simulate clicking buttons
-    fig.update_layout(buttons[0].args[0])
-    assert fig.layout.xaxis.type == "linear"
-    fig.update_layout(buttons[1].args[0])
-    assert fig.layout.xaxis.type == "log"
-
-
-def test_toggle_grid(plotly_scatter: go.Figure) -> None:
-    fig = plotly_scatter
-    assert isinstance(powerups.toggle_grid, dict)
-    assert fig.layout.updatemenus == ()
-    fig.layout.updatemenus = [powerups.toggle_grid]
-
-    # check that figure now has "Show Grid"/"Hide Grid" toggle buttons
-    menu = fig.layout.updatemenus[0]
-    assert isinstance(menu, Updatemenu)
-    buttons = menu.buttons
-    assert len(buttons) == 2
-    assert fig.layout.xaxis.showgrid is None
-    assert fig.layout.yaxis.showgrid is None
-    assert buttons[0].args[0]["xaxis.showgrid"] is True
-    assert buttons[0].args[0]["yaxis.showgrid"] is True
-    assert buttons[1].args[0]["xaxis.showgrid"] is False
-    assert buttons[1].args[0]["yaxis.showgrid"] is False
-    assert buttons[0].label == "Show Grid"
-    assert buttons[1].label == "Hide Grid"
-    assert buttons[0].method == "relayout"
-    assert buttons[1].method == "relayout"
-
-    # simulate clicking buttons
-    fig.update_layout(buttons[0].args[0])
-    assert fig.layout.xaxis.showgrid is True
-    assert fig.layout.yaxis.showgrid is True
-    fig.update_layout(buttons[1].args[0])
-    assert fig.layout.xaxis.showgrid is False
-    assert fig.layout.yaxis.showgrid is False
-
-
-def test_select_colorscale() -> None:
-    # make a dummy heatmap
-    fig = go.Figure(go.Heatmap(z=[[1, 2], [3, 4]]))
-    assert isinstance(powerups.select_colorscale, dict)
-    assert fig.layout.updatemenus == ()
-    fig.layout.updatemenus = [powerups.select_colorscale]
-
-    # check that figure now has colorscale toggle buttons
-    menu = fig.layout.updatemenus[0]
-    assert isinstance(menu, Updatemenu)
-    buttons = menu.buttons
-    assert len(buttons) == 4
-    colorscales = ["Viridis", "Plasma", "Inferno", "Magma"]
-    for button, colorscale in zip(buttons, colorscales, strict=True):
-        assert button.args[0]["colorscale"] == colorscale
-        assert button.label == colorscale
-        assert button.method == "restyle"
-
-
-def test_select_marker_mode(plotly_scatter: go.Figure) -> None:
-    fig = plotly_scatter
-    assert isinstance(powerups.select_marker_mode, dict)
-    assert fig.layout.updatemenus == ()
-    fig.layout.updatemenus = [powerups.select_marker_mode]
-
-    # check that figure now has plot type toggle buttons
-    menu = fig.layout.updatemenus[0]
-    assert isinstance(menu, Updatemenu)
-    buttons = menu.buttons
-    assert len(buttons) == 3
-    plot_types = ["markers", "lines", "lines+markers"]
-    labels = ["Scatter", "Line", "Line+Markers"]
-    for button, plot_type, label in zip(buttons, plot_types, labels, strict=True):
-        assert button.args[0]["mode"] == plot_type
-        assert button.label == label
-        assert button.method == "restyle"
-
-    # simulate clicking each plot type button
-    for button in buttons:
-        fig.update_traces(button.args[0])
-        assert fig.data[0].mode == button.args[0]["mode"]
+    assert len(buttons) == len(button_specs)
+    for button, (label, method, args) in zip(buttons, button_specs, strict=True):
+        assert (button.label, button.method, button.args[0]) == (label, method, args)
+        if apply:
+            fig.update_traces(args)
+            assert fig.data[0].mode == args["mode"]
 
 
 @pytest.mark.parametrize(
@@ -381,7 +339,7 @@ def test_multiple_powerups(plotly_scatter: go.Figure) -> None:
 
     assert len(fig.layout.updatemenus) == len(powerup_list)
     for idx, powerup in enumerate(powerup_list):
-        muni_i: Updatemenu = fig.layout.updatemenus[idx]
+        muni_i = fig.layout.updatemenus[idx]
         assert muni_i == Updatemenu(powerup), f"{idx=}"
         assert isinstance(muni_i, Updatemenu)
         assert muni_i.type == powerup["type"]
@@ -389,11 +347,6 @@ def test_multiple_powerups(plotly_scatter: go.Figure) -> None:
 
 
 def test_add_ecdf_line_color_matching() -> None:
-    """Test that ECDF line colors match their corresponding trace colors.
-
-    Covers explicit colors, default colorway, and mixed cases.
-    """
-    # --- Case 1: Explicit Colors ---
     fig_explicit = go.Figure()
     explicit_colors = ("red", "blue", "green", "purple")
     for idx, color in enumerate(explicit_colors):
@@ -404,70 +357,49 @@ def test_add_ecdf_line_color_matching() -> None:
             marker=dict(color=color),
         )
 
-    # Add ECDF lines one by one (mimics adding to specific traces)
     for idx in range(len(fig_explicit.data)):
         fig_explicit = powerups.add_ecdf_line(fig_explicit, traces=idx)
 
     assert len(fig_explicit.data) == 2 * len(explicit_colors)
-
-    # Check that ECDF lines have matching explicit colors
     dev_fig_explicit = fig_explicit.full_figure_for_development(warn=False)
     for idx, color in enumerate(explicit_colors):
         ecdf_trace_dev = dev_fig_explicit.data[idx + len(explicit_colors)]
         assert ecdf_trace_dev.line.color == color
         assert fig_explicit.data[idx + len(explicit_colors)].legendgroup == str(idx)
 
-    # --- Case 2: Default Colorway ---
     fig_colorway = go.Figure()
     n_traces_colorway = 3
     for idx in range(n_traces_colorway):
-        # No explicit color set, should use default colorway
         fig_colorway.add_histogram(x=np_rng.normal(idx * 5, 1, 100), name=f"Hist {idx}")
 
-    # Get the default colorway for comparison
     default_colorway = px.colors.qualitative.Plotly
-
-    # Add ECDF lines using the default (all traces)
     fig_colorway = powerups.add_ecdf_line(fig_colorway)
 
     assert len(fig_colorway.data) == 2 * n_traces_colorway
-
     dev_fig_colorway = fig_colorway.full_figure_for_development(warn=False)
     for idx in range(n_traces_colorway):
         expected_color = default_colorway[idx % len(default_colorway)]
         ecdf_trace_dev = dev_fig_colorway.data[idx + n_traces_colorway]
         original_trace_dev = dev_fig_colorway.data[idx]
-
-        # Check original trace color matches colorway
         assert original_trace_dev.marker.color.casefold() == expected_color.casefold()
-        # Check ECDF line color matches original trace color
         assert ecdf_trace_dev.line.color.casefold() == expected_color.casefold()
         assert fig_colorway.data[idx + n_traces_colorway].legendgroup == str(idx)
         assert f"Cumulative (Hist {idx})" == fig_colorway.data[idx + 3].name
 
-    # --- Case 3: Mixed Explicit and Colorway ---
     fig_mixed = go.Figure()
-    mixed_colors = ("orange", None, "cyan", None)  # None should use colorway
-    expected_final_colors = [
-        "orange",
-        default_colorway[1],  # First None uses 2nd colorway color
-        "cyan",
-        default_colorway[3],  # Second None uses 4th colorway color
-    ]
-
+    mixed_colors = ("orange", None, "cyan", None)
     for idx, mixed_color in enumerate(mixed_colors):
         marker_dict = dict(color=mixed_color) if mixed_color else {}
         fig_mixed.add_scatter(
             x=[idx, idx + 1], y=[1, 2], name=f"Mixed {idx}", marker=marker_dict
         )
-
-    # Add ECDF lines using the default (all traces)
     fig_mixed = powerups.add_ecdf_line(fig_mixed)
 
     assert len(fig_mixed.data) == 2 * len(mixed_colors)
-
     dev_fig_mixed = fig_mixed.full_figure_for_development(warn=False)
-    for idx, expected_color in enumerate(expected_final_colors):
+    for idx, expected_color in enumerate(
+        ["orange", default_colorway[1], "cyan", default_colorway[3]]
+    ):
         ecdf_trace_dev = dev_fig_mixed.data[idx + len(mixed_colors)]
         assert ecdf_trace_dev.line.color.casefold() == expected_color.casefold()
         assert fig_mixed.data[idx + len(mixed_colors)].legendgroup == str(idx)
@@ -477,39 +409,27 @@ def test_add_ecdf_line_color_matching() -> None:
 
 
 def test_add_ecdf_line_annotation_positioning() -> None:
-    """Test that multiple ECDF lines have vertically offset annotations."""
-    # Create a figure with multiple traces
     fig = go.Figure()
-    fig.add_scatter(x=[1, 2, 3, 4, 5], y=[1, 2, 3, 4, 5], name="Trace 1")
-    fig.add_scatter(x=[1, 2, 3, 4, 5], y=[5, 4, 3, 2, 1], name="Trace 2")
+    for y_vals, name in [
+        ([1, 2, 3, 4, 5], "Trace 1"),
+        ([5, 4, 3, 2, 1], "Trace 2"),
+    ]:
+        fig.add_scatter(x=[1, 2, 3, 4, 5], y=y_vals, name=name)
+    for idx, text in enumerate(["Annotation 1", "Annotation 2"]):
+        fig = powerups.add_ecdf_line(fig, traces=idx, trace_kwargs={"text": text})
 
-    # Add ECDF line with text annotation
-    trace_kwargs = {"text": "Annotation 1"}
-    fig = powerups.add_ecdf_line(fig, traces=0, trace_kwargs=trace_kwargs)
+    assert len(fig.data) == 4
+    for trace, legendgroup, text in zip(
+        fig.data[2:], ["0", "1"], ["Annotation 1", "Annotation 2"], strict=True
+    ):
+        assert trace.name == "Cumulative"
+        assert trace.legendgroup == legendgroup
+        assert trace.text == text
 
-    # Add second ECDF line with text annotation
-    trace_kwargs = {"text": "Annotation 2"}
-    fig = powerups.add_ecdf_line(fig, traces=1, trace_kwargs=trace_kwargs)
-
-    # Check that we have the right number of traces
-    assert len(fig.data) == 4  # 2 original traces + 2 ECDF lines
-
-    # Check ECDF trace properties
-    assert fig.data[2].name == "Cumulative"
-    assert fig.data[3].name == "Cumulative"
-    assert fig.data[2].legendgroup == "0"
-    assert fig.data[3].legendgroup == "1"
-    assert fig.data[2].text == "Annotation 1"
-    assert fig.data[3].text == "Annotation 2"
-
-    # For the last test, create a new trace and add an ECDF line for it
     fig.add_scatter(x=[1, 2, 3, 4, 5], y=[3, 3, 3, 3, 3], name="Trace 3")
-
-    # Now add a third ECDF line
     fig = powerups.add_ecdf_line(fig, traces=4, trace_kwargs={"text": "Annotation 3"})
 
-    # Check that the operation was successful
-    assert len(fig.data) == 6  # 3 original traces + 3 ECDF lines
+    assert len(fig.data) == 6
     assert fig.data[5].name == "Cumulative"
-    assert fig.data[5].legendgroup == "4"  # Should match the index of the trace (4)
+    assert fig.data[5].legendgroup == "4"
     assert fig.data[5].text == "Annotation 3"

--- a/tests/test_process_data.py
+++ b/tests/test_process_data.py
@@ -53,6 +53,11 @@ def test_count_elements_by_atomic_nums() -> None:
     pd.testing.assert_series_equal(expected, el_cts)
 
 
+def test_count_elements_invalid_symbol_keys() -> None:
+    with pytest.raises(ValueError, match=r"Unexpected element symbol\(s\): Zz"):
+        pmv_pd.count_elements({"Fe": 1, "Zz": 2})
+
+
 @pytest.mark.parametrize("range_limits", [(-1, 10), (100, 200)])
 def test_count_elements_bad_atomic_nums(range_limits: tuple[int, int]) -> None:
     with pytest.raises(ValueError, match="assumed to represent atomic numbers"):
@@ -158,12 +163,24 @@ def test_count_formulas_basic() -> None:
     [
         ([], "Empty input: data sequence is empty"),
         (["Fe2O3", "NotAFormula"], "Invalid formula"),
+        (["Fe-Zz"], "Invalid elements in system"),
     ],
 )
 def test_count_formulas_raises(data: list, error_match: str) -> None:
     """Test count_formulas error handling."""
     with pytest.raises(ValueError, match=error_match):
         pmv_pd.count_formulas(data)
+
+
+def test_count_formulas_invalid_group_by() -> None:
+    with pytest.raises(ValueError, match="Invalid group_by="):
+        pmv_pd.count_formulas(["Fe2O3"], group_by="invalid")  # ty: ignore[invalid-argument-type]
+
+
+def test_count_formulas_sorts_by_arity_before_name() -> None:
+    df_out = pmv_pd.count_formulas(["Li2O", "Fe2O3", "NaCl", "C", "Li-Fe-O"])
+
+    assert list(df_out["chem_sys"]) == ["C", "Cl-Na", "Fe-O", "Li-O", "Fe-Li-O"]
 
 
 def test_count_formulas_composition_objects() -> None:

--- a/tests/test_process_data.py
+++ b/tests/test_process_data.py
@@ -29,6 +29,14 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize(
+    "inputs",
+    [
+        ["Fe2 O3"] * 5 + ["Fe4 P4 O16"] * 3,
+        [Composition("Fe2O3")] * 5 + [Composition("Fe4P4O16")] * 3,
+    ],
+    ids=["strings", "compositions"],
+)
+@pytest.mark.parametrize(
     ("count_mode", "counts"),
     [
         (ElemCountMode.composition, {"Fe": 22, "O": 63, "P": 12}),
@@ -37,10 +45,12 @@ if TYPE_CHECKING:
         (ElemCountMode.occurrence, {"Fe": 8, "O": 8, "P": 3}),
     ],
 )
-def test_count_elements(count_mode: ElemCountMode, counts: dict[str, float]) -> None:
-    series = pmv_pd.count_elements(
-        ["Fe2 O3"] * 5 + ["Fe4 P4 O16"] * 3, count_mode=count_mode
-    )
+def test_count_elements(
+    inputs: list[str] | list[Composition],
+    count_mode: ElemCountMode,
+    counts: dict[str, float],
+) -> None:
+    series = pmv_pd.count_elements(inputs, count_mode=count_mode)
     expected = pd.Series(counts, index=pmv.df_ptable.index, name="count")
     pd.testing.assert_series_equal(series, expected, check_dtype=False)
 
@@ -64,27 +74,7 @@ def test_count_elements_bad_atomic_nums(range_limits: tuple[int, int]) -> None:
         pmv_pd.count_elements(dict.fromkeys(range(*range_limits), 0))
 
     with pytest.raises(ValueError, match="assumed to represent atomic numbers"):
-        # string and integer keys for atomic numbers should be handled equally
         pmv_pd.count_elements({str(idx): 0 for idx in range(*range_limits)})
-
-
-@pytest.mark.parametrize(
-    ("count_mode", "expected_counts"),
-    [
-        (ElemCountMode.composition, {"Fe": 22, "O": 63, "P": 12}),
-        (ElemCountMode.fractional_composition, {"Fe": 2.5, "O": 5, "P": 0.5}),
-        (ElemCountMode.reduced_composition, {"Fe": 13, "O": 27, "P": 3}),
-        (ElemCountMode.occurrence, {"Fe": 8, "O": 8, "P": 3}),
-    ],
-)
-def test_count_elements_composition_objects(
-    count_mode: ElemCountMode, expected_counts: dict[str, float]
-) -> None:
-    """Test count_elements with Composition objects and various count modes."""
-    compositions = [Composition("Fe2O3")] * 5 + [Composition("Fe4P4O16")] * 3
-    series = pmv_pd.count_elements(compositions, count_mode=count_mode)
-    expected = pd.Series(expected_counts, index=pmv.df_ptable.index, name="count")
-    pd.testing.assert_series_equal(series, expected, check_dtype=False)
 
 
 def test_count_elements_mixed_input() -> None:
@@ -126,36 +116,33 @@ def test_count_elements_exclude_invalid_elements() -> None:
 
 def test_count_elements_fill_value() -> None:
     compositions = [Composition("Fe2O3")] * 5 + [Composition("Fe4P4O16")] * 3
-    series = pmv_pd.count_elements(compositions, count_mode=ElemCountMode.composition)
     expected = pd.Series(
         {"Fe": 22, "O": 63, "P": 12}, index=pmv.df_ptable.index, name="count"
     )
-    pd.testing.assert_series_equal(series, expected, check_dtype=False)
-
-    # Test previous default value (fill_value = 0)
-    compositions = [Composition("Fe2O3")] * 5 + [Composition("Fe4P4O16")] * 3
-    series = pmv_pd.count_elements(
-        compositions, count_mode=ElemCountMode.composition, fill_value=0
+    pd.testing.assert_series_equal(
+        pmv_pd.count_elements(compositions, count_mode=ElemCountMode.composition),
+        expected,
+        check_dtype=False,
     )
-    expected = pd.Series(
-        {"Fe": 22, "O": 63, "P": 12}, index=pmv.df_ptable.index, name="count"
-    ).fillna(0)
-    pd.testing.assert_series_equal(series, expected, check_dtype=False)
+    pd.testing.assert_series_equal(
+        pmv_pd.count_elements(
+            compositions, count_mode=ElemCountMode.composition, fill_value=0
+        ),
+        expected.fillna(0),
+        check_dtype=False,
+    )
 
 
 def test_count_formulas_basic() -> None:
-    """Test basic functionality with formula strings."""
     data = ["Fe2O3", "Fe4O6", "FeO", "Li2O", "LiFeO2"]
     df_out = pmv_pd.count_formulas(data)
 
-    # Test DataFrame structure
     assert set(df_out.columns) == {"arity_name", "chem_sys", "count"}
-    assert len(df_out) == 3  # 2 binary systems (Fe-O, Li-O) and 1 ternary (Li-Fe-O)
+    assert len(df_out) == 3
 
-    # Test arity counts
     arity_counts = df_out.groupby("arity_name")["count"].sum()
-    assert arity_counts["binary"] == 4  # Fe2O3, Fe4O6, FeO, Li2O
-    assert arity_counts["ternary"] == 1  # LiFeO2
+    assert arity_counts["binary"] == 4
+    assert arity_counts["ternary"] == 1
 
 
 @pytest.mark.parametrize(
@@ -167,7 +154,6 @@ def test_count_formulas_basic() -> None:
     ],
 )
 def test_count_formulas_raises(data: list, error_match: str) -> None:
-    """Test count_formulas error handling."""
     with pytest.raises(ValueError, match=error_match):
         pmv_pd.count_formulas(data)
 
@@ -184,22 +170,19 @@ def test_count_formulas_sorts_by_arity_before_name() -> None:
 
 
 def test_count_formulas_composition_objects() -> None:
-    """Test handling of Composition objects."""
     data = [
         Composition("Fe2O3"),
-        Composition("Fe4O6"),  # same as Fe2O3 when reduced
+        Composition("Fe4O6"),
         Composition("FeO"),
         Composition("Li2O"),
     ]
     df_out = pmv_pd.count_formulas(data, group_by="reduced_formula")
 
-    # Should have 3 unique reduced formulas: Fe2O3 (2 entries), FeO, Li2O
     assert len(df_out) == 3
     assert df_out["count"].sum() == 4
 
-    # Test that Fe2O3 and Fe4O6 are counted together
     fe_o_counts = df_out[df_out["formula"].str.contains("Fe")]
-    assert len(fe_o_counts) == 2  # Fe2O3 and FeO
+    assert len(fe_o_counts) == 2
     assert fe_o_counts[fe_o_counts["formula"] == "Fe2O3"]["count"].iloc[0] == 2
 
 
@@ -208,17 +191,17 @@ def test_count_formulas_composition_objects() -> None:
     [
         (
             "formula",
-            ["Fe2O3", "Fe4O6", "FeO"],  # all formulas kept separate
+            ["Fe2O3", "Fe4O6", "FeO"],
             [1, 1, 1],
         ),
         (
             "reduced_formula",
-            ["Fe2O3", "FeO"],  # Fe4O6 -> Fe2O3
+            ["Fe2O3", "FeO"],
             [2, 1],
         ),
         (
             "chem_sys",
-            ["Fe-O"],  # all Fe-O formulas grouped together
+            ["Fe-O"],
             [3],
         ),
     ],
@@ -226,7 +209,6 @@ def test_count_formulas_composition_objects() -> None:
 def test_count_formulas_grouping_modes(
     group_by: FormulaGroupBy, expected_formulas: list[str], expected_counts: list[int]
 ) -> None:
-    """Test different grouping modes."""
     data = ["Fe2O3", "Fe4O6", "FeO"]
     df_out = pmv_pd.count_formulas(data, group_by=group_by)
 
@@ -238,38 +220,41 @@ def test_count_formulas_grouping_modes(
 
 
 def test_count_formulas_mixed_input() -> None:
-    """Test handling of mixed input types."""
     data = [
         "Fe2O3",
         Composition("Fe4O6"),
-        "Fe-O",  # chemical system string
+        "Fe-O",
         Composition("FeO"),
     ]
     df_out = pmv_pd.count_formulas(data, group_by="chem_sys")
 
-    # All should be grouped into Fe-O system
     assert len(df_out) == 1
     assert df_out["chem_sys"].iloc[0] == "Fe-O"
     assert df_out["count"].iloc[0] == 4
 
 
 PMG_FORMULA_0 = SI_STRUCTS[0].formula
-PMG_FORMULA_1 = SI_STRUCTS[1].formula
-PMG_EXPECTED_DICT = {
-    f"1 {PMG_FORMULA_0}": SI_STRUCTS[0],
-    f"2 {PMG_FORMULA_1}": SI_STRUCTS[1],
-}
-
 SI_ISTRUCTURE_0 = IStructure.from_sites(SI_STRUCTS[0])
 
-# Molecule and IMolecule test fixtures
 H2O_MOL = Molecule(["H", "H", "O"], [[0, 0, 0], [0, 0, 1.5], [0, 0, 0.75]])
 CO2_MOL = Molecule(["C", "O", "O"], [[0, 0, 0], [0, 0, 1.2], [0, 0, -1.2]])
 H2O_IMOL = IMolecule(["H", "H", "O"], [[0, 0, 0], [0, 0, 1.5], [0, 0, 0.75]])
 CO2_IMOL = IMolecule(["C", "O", "O"], [[0, 0, 0], [0, 0, 1.2], [0, 0, -1.2]])
 
+
+def _formula(obj: Structure | IStructure | Molecule | IMolecule) -> str:
+    return obj.formula if hasattr(obj, "formula") else obj.composition.formula
+
+
+def _seq_expected(
+    *items: Structure | IStructure | Molecule | IMolecule,
+) -> dict[str, Structure | IStructure | Molecule | IMolecule]:
+    return {f"{idx} {_formula(item)}": item for idx, item in enumerate(items, start=1)}
+
+
+PMG_EXPECTED_DICT = _seq_expected(*SI_STRUCTS)
+
 _test_cases_normalize_structures = [
-    # (test_case_name, input_to_normalize_structures, expected_dictionary_output)
     ("single_pmg_structure", SI_STRUCTS[0], {PMG_FORMULA_0: SI_STRUCTS[0]}),
     ("single_istructure", SI_ISTRUCTURE_0, {PMG_FORMULA_0: SI_ISTRUCTURE_0}),
     ("list_of_pmg_structures", SI_STRUCTS, PMG_EXPECTED_DICT),
@@ -285,32 +270,16 @@ _test_cases_normalize_structures = [
         {"a0_key": SI_ATOMS[0], "a1_key": SI_ATOMS[1]},
         {"a0_key": SI_STRUCTS[0], "a1_key": SI_STRUCTS[1]},
     ),
-    # mixed list: Pymatgen Structure and ASE Atoms object
     ("mixed_list_pmg_and_ase", [SI_STRUCTS[0], SI_ATOMS[1]], PMG_EXPECTED_DICT),
     (
         "mixed_dict_pmg_and_ase",
         {"pmg_key": SI_STRUCTS[0], "ase_key": SI_ATOMS[1]},
         {"pmg_key": SI_STRUCTS[0], "ase_key": SI_STRUCTS[1]},
     ),
-    # Molecule/IMolecule tests (single, list, dict, mixed)
     ("single_molecule", H2O_MOL, {H2O_MOL.composition.formula: H2O_MOL}),
     ("single_imolecule", H2O_IMOL, {H2O_IMOL.composition.formula: H2O_IMOL}),
-    (
-        "list_molecules",
-        [H2O_MOL, CO2_MOL],
-        {
-            f"1 {H2O_MOL.composition.formula}": H2O_MOL,
-            f"2 {CO2_MOL.composition.formula}": CO2_MOL,
-        },
-    ),
-    (
-        "list_imolecules",
-        [H2O_IMOL, CO2_IMOL],
-        {
-            f"1 {H2O_IMOL.composition.formula}": H2O_IMOL,
-            f"2 {CO2_IMOL.composition.formula}": CO2_IMOL,
-        },
-    ),
+    ("list_molecules", [H2O_MOL, CO2_MOL], _seq_expected(H2O_MOL, CO2_MOL)),
+    ("list_imolecules", [H2O_IMOL, CO2_IMOL], _seq_expected(H2O_IMOL, CO2_IMOL)),
     (
         "dict_molecules",
         {"h2o": H2O_MOL, "co2": CO2_MOL},
@@ -324,10 +293,7 @@ _test_cases_normalize_structures = [
     (
         "mixed_struct_mol",
         [SI_STRUCTS[0], H2O_MOL],
-        {
-            f"1 {SI_STRUCTS[0].formula}": SI_STRUCTS[0],
-            f"2 {H2O_MOL.composition.formula}": H2O_MOL,
-        },
+        _seq_expected(SI_STRUCTS[0], H2O_MOL),
     ),
     (
         "mixed_dict_struct_mol",
@@ -337,27 +303,24 @@ _test_cases_normalize_structures = [
     (
         "mixed_istruct_imol",
         [SI_ISTRUCTURE_0, H2O_IMOL],
-        {
-            f"1 {SI_ISTRUCTURE_0.formula}": SI_ISTRUCTURE_0,
-            f"2 {H2O_IMOL.composition.formula}": H2O_IMOL,
-        },
+        _seq_expected(SI_ISTRUCTURE_0, H2O_IMOL),
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    ("test_case_name", "input_raw", "expected_output_dict"),
-    _test_cases_normalize_structures,
-    ids=[case[0] for case in _test_cases_normalize_structures],
+    ("input_raw", "expected_output_dict"),
+    [
+        pytest.param(input_raw, expected_output_dict, id=test_case_name)
+        for test_case_name, input_raw, expected_output_dict in (
+            _test_cases_normalize_structures
+        )
+    ],
 )
 def test_normalize_structures(
-    test_case_name: str,
     input_raw: Any,
     expected_output_dict: dict[Hashable, Structure | IStructure | Molecule | IMolecule],
 ) -> None:
-    """Test normalize_structures with various inputs including Molecules."""
-    del test_case_name
-
     result_dict = pmv_pd.normalize_structures(input_raw)
 
     assert result_dict == expected_output_dict
@@ -372,7 +335,6 @@ def test_normalize_structures(
     ],
 )
 def test_normalize_structures_errors(invalid_input: Any, error_match: str) -> None:
-    """Test error messages include Molecule and IMolecule types."""
     with pytest.raises(TypeError, match=error_match):
         pmv_pd.normalize_structures(invalid_input)
 
@@ -388,7 +350,6 @@ def test_normalize_structures_errors(invalid_input: Any, error_match: str) -> No
 def test_normalize_structures_pandas_series(
     series_input: pd.Series, expected_keys: set[str]
 ) -> None:
-    """Test normalize_structures with pandas Series (Structures and Molecules)."""
     result = pmv_pd.normalize_structures(series_input)
     assert set(result.keys()) == expected_keys
     for key in expected_keys:
@@ -397,29 +358,21 @@ def test_normalize_structures_pandas_series(
 
 @pytest.mark.parametrize("empty_input", [[], {}])
 def test_normalize_structures_empty(empty_input: list | dict) -> None:
-    """Test normalize_structures raises error on empty inputs."""
     with pytest.raises(ValueError, match="Cannot plot empty set of structures"):
         pmv_pd.normalize_structures(empty_input)
 
 
-# Mock classes for testing is_ase_atoms
 class MockAseAtoms:
-    """Mock ASE Atoms class for testing."""
-
     __module__ = "ase.atoms"
     __qualname__ = "Atoms"
 
 
 class MockMsonAtoms:
-    """Mock MSONAtoms class for testing."""
-
     __module__ = "pymatgen.io.ase"
     __qualname__ = "MSONAtoms"
 
 
 class NotAse:
-    """A mock class that is not an ASE Atoms object."""
-
     __module__ = "some.other.module"
     __qualname__ = "SomeClass"
 
@@ -439,12 +392,10 @@ class NotAse:
     ],
 )
 def test_is_ase_atoms(obj: object, expected: bool) -> None:
-    """Test the is_ase_atoms function with various inputs."""
     assert pmv_pd.is_ase_atoms(obj) == expected
 
 
 def test_is_phonopy_atoms() -> None:
-    """Test is_phonopy_atoms with real PhonopyAtoms object."""
     pytest.importorskip("phonopy")
     from phonopy.structure.atoms import PhonopyAtoms
 
@@ -458,19 +409,17 @@ def test_is_phonopy_atoms() -> None:
     "obj", [Structure(Lattice.cubic(5), ["Si"], [[0, 0, 0]]), "string", 123, None]
 )
 def test_is_phonopy_atoms_false(obj: object) -> None:
-    """Test is_phonopy_atoms returns False for non-PhonopyAtoms objects."""
     assert pmv_pd.is_phonopy_atoms(obj) is False
 
 
 class DummyClass:
     def __init__(self, name: str) -> None:
         self.name = name
-        self.formula = name  # Add a formula attribute to mimic Structure
+        self.formula = name
 
 
 @pytest.mark.parametrize("cls", [Structure, DummyClass, Lattice])
 def test_normalize_to_dict(cls: type[Structure | DummyClass | Lattice]) -> None:
-    # Test with a single instance
     single_instance = {
         Structure: Structure(Lattice.cubic(5), ["Si"], [[0, 0, 0]]),
         DummyClass: DummyClass("dummy"),
@@ -487,7 +436,6 @@ def test_normalize_to_dict(cls: type[Structure | DummyClass | Lattice]) -> None:
     assert set(result) == {expected_key}
     assert isinstance(result[expected_key], cls)
 
-    # Test with a list of instances
     instance_list = [single_instance, single_instance, single_instance]
     result = pmv_pd.normalize_to_dict(instance_list, cls=cls)
     assert isinstance(result, dict)
@@ -500,18 +448,15 @@ def test_normalize_to_dict(cls: type[Structure | DummyClass | Lattice]) -> None:
     }[cls]
     assert set(result) == expected_keys
 
-    # Test with a dictionary of instances
     instance_dict = {"item1": single_instance, "item2": single_instance}
     result = pmv_pd.normalize_to_dict(instance_dict, cls=cls)
     assert result == instance_dict
 
-    # Test with invalid input
     cls_name = cls.__name__
     err_msg = f"Invalid inputs, expected {cls_name} or dict/list/tuple of {cls_name}"
     with pytest.raises(TypeError, match=err_msg):
         pmv_pd.normalize_to_dict("invalid input", cls=cls)
 
-    # Test with mixed valid and invalid inputs in a list
     with pytest.raises(TypeError, match="Invalid item in inputs, expected"):
         pmv_pd.normalize_to_dict([single_instance, "invalid"], cls=cls)
 

--- a/tests/treemap/test_py_pkg_treemap.py
+++ b/tests/treemap/test_py_pkg_treemap.py
@@ -651,9 +651,15 @@ def test_py_pkg_treemap_cell_size_fn(
         "n_external_imports",
         "n_type_checking_imports",
     }
+
+    def coerce_numeric_or_value(row: pd.Series[Any], field: str) -> Any:
+        """Return 0 for missing numeric fields, otherwise the row value."""
+        value = row[field]
+        return 0 if field in numeric_fields and pd.isna(value) else value
+
     for _, row in df_passed_to_plotly.iterrows():
         metrics_instance = pmv.treemap.py_pkg.ModuleStats._make(
-            0 if field in numeric_fields and pd.isna(row[field]) else row[field]
+            coerce_numeric_or_value(row, field)
             for field in pmv.treemap.py_pkg.ModuleStats._fields
         )
         expected_val = (

--- a/tests/treemap/test_py_pkg_treemap.py
+++ b/tests/treemap/test_py_pkg_treemap.py
@@ -18,7 +18,7 @@ import pymatviz as pmv
 
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
     from pathlib import Path
 
     from pymatviz.treemap.py_pkg import CellSizeFn, ModuleFormatter, ShowCounts
@@ -30,25 +30,18 @@ def dummy_pkg_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     src_dir = tmp_path_factory.mktemp("src")
 
     # my_pkg structure
-    my_pkg_dir = src_dir / "my_pkg"
-    my_pkg_dir.mkdir()
-    (my_pkg_dir / "__init__.py").touch()
-    (my_pkg_dir / "module1.py").write_text(
-        """# comment
+    files = {
+        "my_pkg/__init__.py": "",
+        "my_pkg/module1.py": """# comment
 import os
 
 def func1():
     pass # another comment
 
 x = 1
-y = 2"""
-    )
-
-    submodule_dir = my_pkg_dir / "submodule"
-    submodule_dir.mkdir()
-    (submodule_dir / "__init__.py").touch()
-    (submodule_dir / "module2.py").write_text(
-        """# comment1
+y = 2""",
+        "my_pkg/submodule/__init__.py": "",
+        "my_pkg/submodule/module2.py": """# comment1
 # comment2
 
 import sys
@@ -63,14 +56,10 @@ class MyClass:
 
 z = MyClass()
 z.method()
-print(sys.path)"""
-    )
-    (submodule_dir / "module3.py").write_text(
-        """# Just a comment
-pass"""
-    )
-    (submodule_dir / "module4_typed.py").write_text(
-        """from typing import TYPE_CHECKING
+print(sys.path)""",
+        "my_pkg/submodule/module3.py": """# Just a comment
+pass""",
+        "my_pkg/submodule/module4_typed.py": """from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -78,19 +67,21 @@ if TYPE_CHECKING:
 
 def func_typed():
     pass
-"""
-    )
+""",
+    }
 
     # another_pkg structure
-    another_pkg_dir = src_dir / "another_pkg"
-    another_pkg_dir.mkdir()
-    (another_pkg_dir / "__init__.py").touch()
-    (another_pkg_dir / "main.py").write_text(
-        """# Main module
+    files |= {
+        "another_pkg/__init__.py": "",
+        "another_pkg/main.py": """# Main module
 print("Running main")
 
-VAR = 100"""
-    )
+VAR = 100""",
+    }
+    for rel_path, content in files.items():
+        file_path = src_dir / rel_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content)
 
     return src_dir
 
@@ -174,26 +165,16 @@ def test_find_package_path_fallbacks(dummy_pkg_path: Path) -> None:
     expected_abs_path = str(dummy_pkg_path / target_pkg).replace("\\", "/")
 
     # Test fallback to importlib.util when importlib.resources fails
-    with (
-        patch("importlib.resources.files", side_effect=ImportError, create=True),
-        patch("importlib.util.find_spec") as mock_find_spec,
-    ):
-        mock_spec = MagicMock()
-        mock_spec.origin = str(dummy_pkg_path / target_pkg / "__init__.py")
-        mock_find_spec.return_value = mock_spec
-        found_path = pmv.treemap.py_pkg.find_package_path(target_pkg)
-        assert found_path.replace("\\", "/") == expected_abs_path
-
-    # Test fallback when find_spec returns spec for a single module
-    with (
-        patch("importlib.resources.files", side_effect=ImportError, create=True),
-        patch("importlib.util.find_spec") as mock_find_spec,
-    ):
-        mock_spec = MagicMock()
-        mock_spec.origin = str(dummy_pkg_path / target_pkg / "module1.py")
-        mock_find_spec.return_value = mock_spec
-        found_path = pmv.treemap.py_pkg.find_package_path(target_pkg)
-        assert found_path.replace("\\", "/") == expected_abs_path
+    for origin in ("__init__.py", "module1.py"):
+        with (
+            patch("importlib.resources.files", side_effect=ImportError, create=True),
+            patch("importlib.util.find_spec") as mock_find_spec,
+        ):
+            mock_find_spec.return_value = MagicMock(
+                origin=str(dummy_pkg_path / target_pkg / origin)
+            )
+            found_path = pmv.treemap.py_pkg.find_package_path(target_pkg)
+            assert found_path.replace("\\", "/") == expected_abs_path
 
     # Test fallback to site-packages check
     with (
@@ -281,16 +262,14 @@ def test_py_pkg_treemap_base_url(test_base_url: str | None, expect_link: bool) -
     trace = fig.data[0]
 
     # Check texttemplate and textinfo
-    if expect_link:
-        expected_texttemplate = (
-            "<a href='%{customdata[3]}' target='_blank'>%{customdata[2]}</a><br>"
-            "%{value:,}<br>%{percentEntry}"
-        )
-        assert trace.texttemplate == expected_texttemplate
-        assert trace.textinfo == "none"
-    else:  # For value+percent without base_url, custom template is used for formatting
-        assert trace.texttemplate == "%{label}<br>%{value:,}<br>%{percentEntry}"
-        assert trace.textinfo == "none"
+    expected_texttemplate = (
+        "<a href='%{customdata[3]}' target='_blank'>%{customdata[2]}</a><br>"
+        "%{value:,}<br>%{percentEntry}"
+        if expect_link
+        else "%{label}<br>%{value:,}<br>%{percentEntry}"
+    )
+    assert trace.texttemplate == expected_texttemplate
+    assert trace.textinfo == "none"
 
     # Check customdata structure
     custom_data = trace.customdata
@@ -299,13 +278,10 @@ def test_py_pkg_treemap_base_url(test_base_url: str | None, expect_link: bool) -
 
     file_urls = custom_data[:, 3]  # Index 3 is file_url
     if expect_link:
-        file_node_indices = [
-            idx for idx, id_val in enumerate(trace.ids) if ".py" in id_val
-        ]
         assert all(
-            str(test_base_url) in str(file_urls[i])
-            for i in file_node_indices
-            if file_urls[i] is not None
+            str(test_base_url) in str(file_urls[idx])
+            for idx, id_val in enumerate(trace.ids)
+            if ".py" in id_val and file_urls[idx] is not None
         )
     else:
         assert not any(
@@ -323,10 +299,6 @@ def test_py_pkg_treemap_base_url(test_base_url: str | None, expect_link: bool) -
 def test_py_pkg_treemap_analysis_scenarios() -> None:
     """Test various analysis scenarios including failures."""
     pkg_name = "my_pkg"
-
-    # Test normal analysis
-    fig_normal = pmv.py_pkg_treemap(pkg_name)
-    assert isinstance(fig_normal, go.Figure)
 
     # Test analysis failure
     failed_result = {
@@ -347,32 +319,31 @@ def test_py_pkg_treemap_analysis_scenarios() -> None:
 
 def test_collect_package_modules_not_found() -> None:
     """Test collect_package_modules with a package that cannot be found."""
-    df_modules = pmv.treemap.py_pkg.collect_package_modules(
+    assert pmv.treemap.py_pkg.collect_package_modules(
         ["non_existent_package_12345"]
-    )
-    assert df_modules.empty
+    ).empty
 
 
 def test_internal_imports(dummy_pkg_path: Path) -> None:
     """Test counting of internal imports using AST analysis."""
     pkg_name = "my_pkg"
-    internal_import_content = (
+    (dummy_pkg_path / pkg_name / "internal_user.py").write_text(
         "from .submodule import module2 # internal import from sibling dir\n"
         "from . import module1 # internal import from same dir\n"
-        "import os # external import\n"
-        "\n"
-        "class InternalUser:\n"
-        "    pass\n"
+        "import os # external import\n\n"
+        "class InternalUser:\n    pass\n"
     )
-    (dummy_pkg_path / pkg_name / "internal_user.py").write_text(internal_import_content)
 
     fig = pmv.py_pkg_treemap(pkg_name)
     hovertemplate = fig.data[0].hovertemplate
     assert hovertemplate is not None
 
-    assert "Internal Imports: %{customdata[7]:,}<br>" in hovertemplate
-    assert "External Imports: %{customdata[8]:,}<br>" in hovertemplate
-    assert "Classes: %{customdata[4]:,}<br>" in hovertemplate
+    for hover_field in (
+        "Internal Imports: %{customdata[7]:,}<br>",
+        "External Imports: %{customdata[8]:,}<br>",
+        "Classes: %{customdata[4]:,}<br>",
+    ):
+        assert hover_field in hovertemplate
 
     ids = fig.data[0].ids
     custom_data = fig.data[0].customdata
@@ -381,17 +352,14 @@ def test_internal_imports(dummy_pkg_path: Path) -> None:
     )
     assert internal_user_idx != -1
 
-    assert int(custom_data[internal_user_idx, 7]) == 2  # n_internal_imports
-    assert int(custom_data[internal_user_idx, 8]) == 1  # n_external_imports
-    assert int(custom_data[internal_user_idx, 4]) == 1  # n_classes
+    assert [int(custom_data[internal_user_idx, idx]) for idx in (7, 8, 4)] == [2, 1, 1]
 
 
 def test_top_level_module(dummy_pkg_path: Path) -> None:
     """Test handling of Python files directly under the package root."""
-    pkg_name = "my_pkg"
-    (dummy_pkg_path / pkg_name / "top_level_mod.py").write_text("print('top level')")
+    (dummy_pkg_path / "my_pkg" / "top_level_mod.py").write_text("print('top level')")
 
-    fig = pmv.py_pkg_treemap(pkg_name, group_by="module")
+    fig = pmv.py_pkg_treemap("my_pkg", group_by="module")
     assert "top_level_mod" in fig.data[0].labels
     assert any(id_val.endswith("/top_level_mod") for id_val in fig.data[0].ids)
 
@@ -583,21 +551,23 @@ def test_py_pkg_treemap_tooltip_data(mock_pkg_data: pd.DataFrame) -> None:
 
         # Test specific percentage calculation
         generated_customdata_df = pd.DataFrame(
-            data=passed_custom_data_arg,
-            columns=[
-                "package_name_raw",
-                "repo_path_segment",
-                "leaf_label",
-                "file_url",
-                "n_classes",
-                "n_functions",
-                "n_methods",
-                "n_internal_imports",
-                "n_external_imports",
-                "n_type_checking_imports",
-                "percent_of_package_cell_value",
-                "line_count",
-            ],
+            passed_custom_data_arg,
+            columns=pd.Index(
+                [
+                    "package_name_raw",
+                    "repo_path_segment",
+                    "leaf_label",
+                    "file_url",
+                    "n_classes",
+                    "n_functions",
+                    "n_methods",
+                    "n_internal_imports",
+                    "n_external_imports",
+                    "n_type_checking_imports",
+                    "percent_of_package_cell_value",
+                    "line_count",
+                ]
+            ),
         )
 
         pkg1_mod_a_percent = generated_customdata_df[
@@ -671,52 +641,29 @@ def test_py_pkg_treemap_cell_size_fn(
     assert actual_filenames >= expected_filenames
 
     # Verify cell_value calculations match expectations
-    for _idx, row in df_passed_to_plotly.iterrows():
-        module_metrics_dict = row.to_dict()
-        metrics_keys = pmv.treemap.py_pkg.ModuleStats._fields
-        filtered_metrics_dict = {
-            key: module_metrics_dict[key]
+    metrics_keys = pmv.treemap.py_pkg.ModuleStats._fields
+    numeric_keys = {
+        "n_classes",
+        "n_functions",
+        "n_methods",
+        "n_internal_imports",
+        "n_external_imports",
+        "n_type_checking_imports",
+    }
+    for _, row in df_passed_to_plotly.iterrows():
+        row_dict = row.to_dict()
+        metrics_dict = {
+            key: 0
+            if key in numeric_keys and pd.isna(row_dict.get(key))
+            else row_dict[key]
             for key in metrics_keys
-            if key in module_metrics_dict
         }
-
-        for key in [
-            "n_classes",
-            "n_functions",
-            "n_methods",
-            "n_internal_imports",
-            "n_external_imports",
-            "n_type_checking_imports",
-        ]:
-            if pd.isna(filtered_metrics_dict.get(key)):
-                filtered_metrics_dict[key] = 0
-
-        metrics_instance = pmv.treemap.py_pkg.ModuleStats(
-            package=filtered_metrics_dict.get("package", ""),
-            full_module=filtered_metrics_dict.get("full_module", ""),
-            filename=filtered_metrics_dict.get("filename", ""),
-            directory=filtered_metrics_dict.get("directory", ""),
-            top_module=filtered_metrics_dict.get("top_module", ""),
-            line_count=filtered_metrics_dict.get("line_count", 0),
-            file_path=filtered_metrics_dict.get("file_path", ""),
-            repo_path_segment=filtered_metrics_dict.get("repo_path_segment", ""),
-            leaf_label=filtered_metrics_dict.get("leaf_label", ""),
-            module_parts=filtered_metrics_dict.get("module_parts", []),
-            depth=filtered_metrics_dict.get("depth", 0),
-            n_classes=filtered_metrics_dict.get("n_classes", 0),
-            n_functions=filtered_metrics_dict.get("n_functions", 0),
-            n_methods=filtered_metrics_dict.get("n_methods", 0),
-            n_internal_imports=filtered_metrics_dict.get("n_internal_imports", 0),
-            n_external_imports=filtered_metrics_dict.get("n_external_imports", 0),
-            n_type_checking_imports=filtered_metrics_dict.get(
-                "n_type_checking_imports", 0
-            ),
+        metrics_instance = pmv.treemap.py_pkg.ModuleStats(**metrics_dict)  # ty: ignore[invalid-argument-type]
+        expected_val = (
+            metrics_instance.line_count
+            if calculator is None
+            else calculator(metrics_instance)
         )
-
-        if calculator is None:
-            expected_val = metrics_instance.line_count
-        else:
-            expected_val = calculator(metrics_instance)
 
         assert expected_val > 0
         assert int(row["cell_value"]) == expected_val
@@ -772,29 +719,53 @@ def mock_coverage_data(tmp_path: Path) -> Path:
 
 
 @pytest.mark.parametrize(
-    "file_type",
-    ["valid", "missing", "invalid_json"],
+    ("file_type", "expected_len"),
+    [("valid", 3), ("missing", None), ("invalid_json", None)],
 )
 def test_collect_coverage_data(
-    tmp_path: Path, mock_coverage_data: Path, file_type: str
+    tmp_path: Path, mock_coverage_data: Path, file_type: str, expected_len: int | None
 ) -> None:
-    """Test collect_coverage_data with various file conditions."""
+    """Test collect_coverage_data with valid, missing, and malformed files."""
     if file_type == "valid":
         coverage_map = pmv.treemap.py_pkg.collect_coverage_data(str(mock_coverage_data))
-        assert len(coverage_map) == 3
-        # Check absolute paths and values
+        assert len(coverage_map) == expected_len
         coverage_dir = str(mock_coverage_data.parent)
         module1_path = os.path.normpath(f"{coverage_dir}/my_pkg/module1.py")
         assert coverage_map[module1_path] == 85.5
     elif file_type == "missing":
-        non_existent_path = str(tmp_path / "missing.json")
         with pytest.raises(FileNotFoundError):
-            pmv.treemap.py_pkg.collect_coverage_data(non_existent_path)
-    elif file_type == "invalid_json":
+            pmv.treemap.py_pkg.collect_coverage_data(str(tmp_path / "missing.json"))
+    else:
         invalid_json = tmp_path / "invalid.json"
         invalid_json.write_text("invalid json content")
         with pytest.raises(json.JSONDecodeError):
             pmv.treemap.py_pkg.collect_coverage_data(str(invalid_json))
+
+
+def _assert_colorbar_title(fig: go.Figure, expected: str) -> None:
+    """Assert the Plotly colorbar title text."""
+    coloraxis = fig.layout.coloraxis
+    assert coloraxis.colorbar is not None
+    assert coloraxis.colorbar.title.text == expected
+
+
+def _numeric_marker_colors(fig: go.Figure) -> list[float]:
+    """Return numeric marker colors from the first treemap trace."""
+    return [
+        color for color in fig.data[0].marker.colors if isinstance(color, (int, float))
+    ]
+
+
+def _write_package_files(pkg_dir: Path, files: dict[str, int]) -> None:
+    """Create a package tree with files containing the requested line counts."""
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    for rel_path, n_lines in files.items():
+        file_path = pkg_dir / rel_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        for parent in [pkg_dir, *file_path.parent.parents]:
+            if parent == pkg_dir or pkg_dir in parent.parents:
+                (parent / "__init__.py").touch()
+        _write_py_lines(file_path, n_lines)
 
 
 @pytest.mark.parametrize(
@@ -802,11 +773,7 @@ def test_collect_coverage_data(
     [
         (
             {"color_by": "coverage", "color_continuous_scale": "RdYlGn"},
-            {
-                "has_colors": True,
-                "customdata_cols": 13,
-                "colorbar_title": "Coverage (%)",
-            },
+            {"customdata_cols": 13, "title": "Coverage (%)"},
         ),
         (
             {
@@ -814,132 +781,98 @@ def test_collect_coverage_data(
                 "color_range": (0, 100),
                 "color_continuous_scale": "RdYlGn",
             },
-            {
-                "has_colors": True,
-                "color_range": (0, 100),
-                "colorbar_title": "Coverage (%)",
-            },
+            {"range": (0, 100), "title": "Coverage (%)"},
         ),
-        (
-            {"color_by": {}, "color_continuous_scale": "Viridis"},
-            {"has_colors": True, "use_custom_dict": True},
-        ),
+        ({"color_by": {}, "color_continuous_scale": "Viridis"}, {"custom": True}),
         (
             {"color_by": "coverage", "color_continuous_scale": "RdYlGn"},
-            {
-                "has_colors": True,
-                "customdata_cols": 13,
-                "colorbar_title": "Coverage (%)",
-                "test_ambiguous_filename": True,
-            },
+            {"ambiguous": True, "customdata_cols": 13, "title": "Coverage (%)"},
         ),
     ],
 )
 def test_py_pkg_treemap_coverage_scenarios(
-    mock_coverage_data: Path,
-    kwargs: dict[str, Any],
-    expectations: dict[str, Any],
+    mock_coverage_data: Path, kwargs: dict[str, Any], expectations: dict[str, Any]
 ) -> None:
-    """Test py_pkg_treemap with various coverage scenarios."""
-    # Setup custom color dict if needed
-    if expectations.get("use_custom_dict"):
+    """Test py_pkg_treemap with coverage and custom color scenarios."""
+    if expectations.get("custom"):
         df_modules = pmv.treemap.py_pkg.collect_package_modules(["my_pkg"])
-        if not df_modules.empty:
-            custom_colors = {
-                row["file_path"]: float(idx * 25 + 50)
-                for idx, row in enumerate(df_modules.head(2).to_dict(orient="records"))
-            }
-            kwargs["color_by"] = custom_colors
-
-    # Handle ambiguous filename test case
-    if expectations.get("test_ambiguous_filename"):
-        # Create coverage data with multiple files having the same basename
-        coverage_with_ambiguous = {
-            "files": {
-                "different/path/module1.py": {"summary": {"percent_covered": 75.0}},
-                "another/different/path/module1.py": {
-                    "summary": {"percent_covered": 90.0}
-                },
-                "some/other/path/module2.py": {"summary": {"percent_covered": 80.0}},
-            }
+        kwargs["color_by"] = {
+            row["file_path"]: float(idx * 25 + 50)
+            for idx, row in enumerate(df_modules.head(2).to_dict(orient="records"))
         }
+    elif expectations.get("ambiguous"):
         coverage_file = mock_coverage_data.parent / "coverage_ambiguous.json"
-        coverage_file.write_text(json.dumps(coverage_with_ambiguous))
+        coverage_file.write_text(
+            json.dumps(
+                {
+                    "files": {
+                        "different/path/module1.py": {
+                            "summary": {"percent_covered": 75.0}
+                        },
+                        "another/different/path/module1.py": {
+                            "summary": {"percent_covered": 90.0}
+                        },
+                        "some/other/path/module2.py": {
+                            "summary": {"percent_covered": 80.0}
+                        },
+                    }
+                }
+            )
+        )
         kwargs["coverage_data_file"] = str(coverage_file)
     elif kwargs.get("color_by") == "coverage":
-        # Add coverage data file for coverage tests
         kwargs["coverage_data_file"] = str(mock_coverage_data)
 
     fig = pmv.py_pkg_treemap("my_pkg", **kwargs)
-    assert isinstance(fig, go.Figure)
     trace = fig.data[0]
+    assert trace.marker.colors is not None
 
-    # Check color data
-    if expectations.get("has_colors"):
-        assert hasattr(trace, "marker")
-        if hasattr(trace.marker, "colors"):
-            assert trace.marker.colors is not None
-
-    # Check customdata shape
-    if expectations.get("customdata_cols"):
-        assert trace.customdata is not None
-        assert trace.customdata.shape[1] == expectations["customdata_cols"]
+    if customdata_cols := expectations.get("customdata_cols"):
+        assert trace.customdata.shape[1] == customdata_cols
         assert "Coverage:" in trace.hovertemplate
-
-    # Check color range
-    if expectations.get("color_range"):
-        assert fig.layout.coloraxis is not None
-        assert fig.layout.coloraxis.cmin == expectations["color_range"][0]
-        assert fig.layout.coloraxis.cmax == expectations["color_range"][1]
+    if color_range := expectations.get("range"):
+        assert fig.layout.coloraxis.cmin == color_range[0]
+        assert fig.layout.coloraxis.cmax == color_range[1]
         assert fig.layout.coloraxis.cmid == 50
-
-    # Check colorbar title
-    if expectations.get("colorbar_title"):
-        assert hasattr(fig.layout, "coloraxis")
-        coloraxis = fig.layout.coloraxis
-        if hasattr(coloraxis, "colorbar") and coloraxis.colorbar is not None:
-            assert coloraxis.colorbar.title.text == expectations["colorbar_title"]
+    if title := expectations.get("title"):
+        _assert_colorbar_title(fig, title)
 
 
 def test_py_pkg_treemap_coverage_path_matching(tmp_path: Path) -> None:
     """Test coverage path matching with src/ prefix."""
-    coverage_with_src = {
-        "files": {
-            "src/my_pkg/module1.py": {"summary": {"percent_covered": 75.0}},
-            "src/my_pkg/submodule/module2.py": {"summary": {"percent_covered": 80.0}},
-        }
-    }
     coverage_file = tmp_path / "coverage_src.json"
-    coverage_file.write_text(json.dumps(coverage_with_src))
-
+    coverage_file.write_text(
+        json.dumps(
+            {
+                "files": {
+                    "src/my_pkg/module1.py": {"summary": {"percent_covered": 75.0}},
+                    "src/my_pkg/submodule/module2.py": {
+                        "summary": {"percent_covered": 80.0}
+                    },
+                }
+            }
+        )
+    )
     fig = pmv.py_pkg_treemap(
         "my_pkg", color_by="coverage", coverage_data_file=str(coverage_file)
     )
-    assert isinstance(fig, go.Figure)
-
-    # Check that some coverage values were matched (not all zeros)
-    trace = fig.data[0]
-    if hasattr(trace.marker, "colors") and trace.marker.colors is not None:
-        colors = list(trace.marker.colors)
-        assert any(c > 0 for c in colors if isinstance(c, (int, float)))
+    assert any(color > 0 for color in _numeric_marker_colors(fig))
 
 
 @pytest.mark.parametrize(
-    ("scenario", "returncode", "coverage_data", "expects_call", "expected_result"),
+    ("scenario", "returncode", "coverage_data", "expected_result"),
     [
         (
             "file_exists",
             None,
             {"files": {"test.py": {"summary": {"percent_covered": 100.0}}}},
-            False,
             1,
         ),
-        ("subprocess_fail", 1, None, True, 0),
+        ("subprocess_fail", 1, None, 0),
         (
             "subprocess_success",
             0,
             {"files": {"/abs/test.py": {"summary": {"percent_covered": 88.5}}}},
-            True,
             1,
         ),
     ],
@@ -949,269 +882,117 @@ def test_collect_coverage_data_subprocess(
     scenario: str,
     returncode: int | None,
     coverage_data: dict[str, Any] | None,
-    expects_call: bool,
     expected_result: int,
 ) -> None:
     """Test collect_coverage_data subprocess behavior."""
-    file_path = None
-    if scenario == "file_exists":  # Create real coverage file
+    if scenario == "file_exists":
         coverage_file = tmp_path / "coverage.json"
         coverage_file.write_text(json.dumps(coverage_data))
-        file_path = str(coverage_file)
-
-    if scenario == "file_exists":  # For file_exists scenario, don't patch file ops
-        coverage_map = pmv.treemap.py_pkg.collect_coverage_data(file_path)
+        coverage_map = pmv.treemap.py_pkg.collect_coverage_data(str(coverage_file))
     else:
-        with (  # For subprocess scenarios, mock everything
+        with (
             patch("subprocess.run") as mock_run,
             patch("tempfile.NamedTemporaryFile") as mock_tempfile,
             patch("builtins.open", create=True),
             patch("os.path.exists", return_value=True),
             patch("os.unlink"),
-            patch("json.load") as mock_json_load,
+            patch("json.load", return_value=coverage_data),
         ):
+            mock_tempfile.return_value.__enter__.return_value.name = (
+                "/tmp/coverage.json"
+            )
             mock_run.return_value = MagicMock(
                 returncode=returncode,
-                stderr="Coverage error" if returncode != 0 else "",
+                stderr="Coverage error" if returncode else "",
             )
+            coverage_map = pmv.treemap.py_pkg.collect_coverage_data()
+            mock_run.assert_called_once()
 
-            # Setup subprocess success scenario
-            if returncode == 0:
-                mock_file = MagicMock()
-                mock_file.name = "/tmp/coverage_temp.json"
-                mock_tempfile.return_value.__enter__.return_value = mock_file
-                mock_json_load.return_value = coverage_data
-
-            coverage_map = pmv.treemap.py_pkg.collect_coverage_data(file_path)
-
-            # Verify subprocess call expectations
-            if expects_call:
-                mock_run.assert_called_once()
-            else:
-                mock_run.assert_not_called()
-
-    # Check results
     assert len(coverage_map) == expected_result
     if scenario == "subprocess_success":
-        assert "/abs/test.py" in coverage_map
         assert coverage_map["/abs/test.py"] == 88.5
 
 
 @pytest.mark.parametrize(
-    ("test_type", "color_by", "colorbar_title", "check_averages", "check_zeros"),
+    ("kwargs", "title", "check"),
     [
-        ("coverage_with_data", "coverage", "Coverage (%)", True, False),
-        ("coverage_no_data", "coverage", "Coverage (%)", False, True),
-        ("custom_dict", {"file1.py": 50.0}, "Color Value", False, False),
-        ("line_count", "line_count", "Line Count", False, False),
+        (
+            {"color_by": "coverage"},
+            "Coverage (%)",
+            lambda fig: any(color > 0 for color in _numeric_marker_colors(fig)),
+        ),
+        ({"color_by": {"file1.py": 50.0}}, "Color Value", lambda _fig: True),
+        ({"color_by": "line_count"}, "Line Count", lambda _fig: True),
     ],
 )
 def test_py_pkg_treemap_coverage_edge_cases(
     mock_coverage_data: Path,
-    test_type: str,
-    color_by: str | dict[str, float],
-    colorbar_title: str,
-    check_averages: bool,
-    check_zeros: bool,
+    kwargs: dict[str, Any],
+    title: str,
+    check: Callable[[go.Figure], bool],
 ) -> None:
     """Test coverage edge cases and colorbar titles."""
-    # Setup based on test type
-    if test_type == "coverage_with_data":
-        fig = pmv.py_pkg_treemap(
-            "my_pkg",
-            color_by=color_by,
-            coverage_data_file=str(mock_coverage_data),
-        )
-    elif test_type == "line_count":
+    if kwargs == {"color_by": "coverage"}:
+        kwargs = {**kwargs, "coverage_data_file": str(mock_coverage_data)}
+    if kwargs.get("color_by") == "line_count":
         df_modules = pmv.treemap.py_pkg.collect_package_modules(["my_pkg"])
-        if color_by not in df_modules.columns:
-            pytest.skip(f"Column {color_by} not found in module data")
-        fig = pmv.py_pkg_treemap("my_pkg", color_by=color_by)
-    else:
-        fig = pmv.py_pkg_treemap("my_pkg", color_by=color_by)
+        if "line_count" not in df_modules.columns:
+            pytest.skip("Column line_count not found in module data")
+    fig = pmv.py_pkg_treemap("my_pkg", **kwargs)
     assert isinstance(fig, go.Figure)
-    trace = fig.data[0]
+    assert check(fig)
+    _assert_colorbar_title(fig, title)
 
-    # Check weighted averages for parent nodes
-    if (
-        check_averages
-        and hasattr(trace.marker, "colors")
-        and trace.marker.colors is not None
-    ):
-        colors = list(trace.marker.colors)
-        labels = list(trace.labels)
-        package_indices = [
-            idx for idx, label in enumerate(labels) if "my_pkg" in str(label)
-        ]
-        if package_indices:
-            parent_colors = [colors[i] for i in package_indices]
-            assert any(isinstance(c, (int, float)) and c > 0 for c in parent_colors)
 
-    # Check zero coverage when no data
-    if check_zeros:
-        assert trace.customdata is not None
-        coverage_column = trace.customdata[:, -1]  # Last column is coverage
-        assert all(c == 0.0 for c in coverage_column)
-
-    # Check colorbar title
-    if hasattr(fig.layout, "coloraxis"):
-        coloraxis = fig.layout.coloraxis
-        if hasattr(coloraxis, "colorbar") and coloraxis.colorbar is not None:
-            assert coloraxis.colorbar.title.text == colorbar_title
+def test_py_pkg_treemap_missing_coverage_values_are_zero() -> None:
+    """Missing coverage data gives zero customdata values."""
+    fig = pmv.py_pkg_treemap("my_pkg", color_by="coverage")
+    assert all(color == 0 for color in fig.data[0].customdata[:, -1])
 
 
 def test_py_pkg_treemap_submodule_coverage_weighted_averages(
     dummy_pkg_path: Path,
 ) -> None:
-    """Test that submodule coverage shows weighted averages of child modules."""
-    # Use the existing dummy package structure
+    """Submodule coverage shows weighted averages of child modules."""
     pkg_dir = dummy_pkg_path / "my_pkg"
-
-    # Create coverage data for the existing modules
-    coverage_data = {
-        "files": {
-            str(pkg_dir / "module1.py"): {"summary": {"percent_covered": 80.0}},
-            str(pkg_dir / "submodule" / "module2.py"): {
-                "summary": {"percent_covered": 70.0}
-            },
-            str(pkg_dir / "submodule" / "module3.py"): {
-                "summary": {"percent_covered": 90.0}
-            },
-        }
-    }
     coverage_file = dummy_pkg_path / "coverage.json"
-    coverage_file.write_text(json.dumps(coverage_data))
-
-    # Create the treemap with coverage
+    coverage_file.write_text(
+        json.dumps(
+            {
+                "files": {
+                    str(pkg_dir / "module1.py"): {"summary": {"percent_covered": 80.0}},
+                    str(pkg_dir / "submodule" / "module2.py"): {
+                        "summary": {"percent_covered": 70.0}
+                    },
+                    str(pkg_dir / "submodule" / "module3.py"): {
+                        "summary": {"percent_covered": 90.0}
+                    },
+                }
+            }
+        )
+    )
     fig = pmv.py_pkg_treemap(
         "my_pkg", color_by="coverage", coverage_data_file=str(coverage_file)
     )
-
-    assert isinstance(fig, go.Figure)
-    trace = fig.data[0]
-
-    # Check that we have colors
-    assert hasattr(trace.marker, "colors")
-    assert trace.marker.colors is not None
-
-    colors = list(trace.marker.colors)
-    labels = list(trace.labels)
-
-    # Regression prevention: verify the fix works
-    # 1. Check that we have some non-zero coverage values
-    non_zero_coverage = [c for c in colors if isinstance(c, (int, float)) and c > 0]
-    assert len(non_zero_coverage) > 0, "Should have some non-zero coverage values"
-
-    # 2. Check that parent nodes have weighted averages (not all same value)
-    parent_nodes = [idx for idx, label in enumerate(labels) if "(" in str(label)]
-    if len(parent_nodes) > 1:
-        parent_coverage_values = [colors[i] for i in parent_nodes]
-        unique_parent_values = set(parent_coverage_values)
-        assert len(unique_parent_values) > 1, (
-            f"Parent nodes should have different weighted averages, "
-            f"got all same: {parent_coverage_values[0]}"
-        )
-
-    # 3. Check that the main package node has reasonable coverage
-    pkg_node_idx = None
-    for idx, label in enumerate(labels):
-        if "my_pkg" in str(label) and "(" in str(label):  # Parent node
-            pkg_node_idx = idx
-            break
-
-        if pkg_node_idx is not None:
-            pkg_coverage = colors[pkg_node_idx]
-            # Expected weighted average (may include modules without coverage)
-            assert 0.0 <= pkg_coverage <= 100.0, (
-                f"Expected coverage between 0-100, got {pkg_coverage}"
-            )
+    colors = _numeric_marker_colors(fig)
+    assert any(color > 0 for color in colors)
+    assert all(0 <= color <= 100 for color in colors)
+    assert len(set(colors)) > 1
 
 
-def test_py_pkg_treemap_coverage_regression_prevention(tmp_path: Path) -> None:
-    """Test to prevent regression where all submodules show same coverage value."""
-    # Create coverage data that would cause the bug if not fixed
-    coverage_data = {
-        "files": {
-            "pymatgen/io/vasp/input.py": {"summary": {"percent_covered": 75.0}},
-            "pymatgen/io/vasp/output.py": {"summary": {"percent_covered": 85.0}},
-            "pymatgen/io/cp2k/input.py": {"summary": {"percent_covered": 95.0}},
-            "pymatgen/io/qchem/input.py": {"summary": {"percent_covered": 65.0}},
-            "pymatgen/analysis/local_env.py": {"summary": {"percent_covered": 55.0}},
-            "pymatgen/analysis/phase_diagram.py": {
-                "summary": {"percent_covered": 45.0}
-            },
-        }
+def test_py_pkg_treemap_coverage_regression_prevention(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Parent coverage values differ when children have different coverage."""
+    files = {
+        "io/vasp/input.py": 5,
+        "io/vasp/output.py": 15,
+        "io/cp2k/input.py": 10,
+        "io/qchem/input.py": 20,
+        "analysis/local_env.py": 8,
+        "analysis/phase_diagram.py": 12,
     }
-    coverage_file = tmp_path / "regression_coverage.json"
-    coverage_file.write_text(json.dumps(coverage_data))
-
-    # Create package structure
-    pkg_dir = tmp_path / "pymatgen"
-    pkg_dir.mkdir(parents=True)
-    (pkg_dir / "__init__.py").touch()
-
-    # Create io submodules with different line counts
-    io_dir = pkg_dir / "io"
-    io_dir.mkdir()
-    (io_dir / "__init__.py").touch()
-
-    vasp_dir = io_dir / "vasp"
-    vasp_dir.mkdir()
-    (vasp_dir / "__init__.py").touch()
-    (vasp_dir / "input.py").write_text("def func1(): pass\n" * 5)  # 5 lines
-    (vasp_dir / "output.py").write_text("def func2(): pass\n" * 15)  # 15 lines
-
-    cp2k_dir = io_dir / "cp2k"
-    cp2k_dir.mkdir()
-    (cp2k_dir / "__init__.py").touch()
-    (cp2k_dir / "input.py").write_text("def func3(): pass\n" * 10)  # 10 lines
-
-    qchem_dir = io_dir / "qchem"
-    qchem_dir.mkdir()
-    (qchem_dir / "__init__.py").touch()
-    (qchem_dir / "input.py").write_text("def func4(): pass\n" * 20)  # 20 lines
-
-    # Create analysis submodules
-    analysis_dir = pkg_dir / "analysis"
-    analysis_dir.mkdir()
-    (analysis_dir / "__init__.py").touch()
-    (analysis_dir / "local_env.py").write_text("def func5(): pass\n" * 8)  # 8 lines
-    (analysis_dir / "phase_diagram.py").write_text(
-        "def func6(): pass\n" * 12
-    )  # 12 lines
-
-    # Create the treemap
-    fig = pmv.py_pkg_treemap(
-        "pymatgen", color_by="coverage", coverage_data_file=str(coverage_file)
-    )
-
-    assert isinstance(fig, go.Figure)
-    trace = fig.data[0]
-    colors = list(trace.marker.colors)
-    labels = list(trace.labels)
-
-    # Critical regression check: verify parent nodes have different coverage values
-    parent_nodes = [idx for idx, label in enumerate(labels) if "(" in str(label)]
-
-    # Verify we have at least one parent node
-    assert len(parent_nodes) > 0, "Should have at least one parent node present"
-
-    # If we have multiple parent nodes, they should have different coverage values
-    if len(parent_nodes) > 1:
-        parent_coverage_values = [colors[idx] for idx in parent_nodes]
-        unique_values = set(parent_coverage_values)
-        assert len(unique_values) > 1, (
-            f"Different parent nodes should have different coverage values, "
-            f"got all same: {parent_coverage_values[0]}"
-        )
-
-    # Verify the coverage values are reasonable
-    for idx in parent_nodes:
-        coverage_value = colors[idx]
-        assert 0.0 <= coverage_value <= 100.0
-
-    # Verify leaf nodes maintain their original values
-    leaf_expected = {
+    expected_leaf_coverage = {
         "input.py": 75.0,
         "output.py": 85.0,
         "cp2k/input.py": 95.0,
@@ -1219,71 +1000,81 @@ def test_py_pkg_treemap_coverage_regression_prevention(tmp_path: Path) -> None:
         "local_env.py": 55.0,
         "phase_diagram.py": 45.0,
     }
+    _write_package_files(tmp_path / "pymatgen", files)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    coverage_file = tmp_path / "regression_coverage.json"
+    coverage_file.write_text(
+        json.dumps(
+            {
+                "files": {
+                    f"pymatgen/{rel_path}": {
+                        "summary": {"percent_covered": expected_leaf_coverage[key]}
+                    }
+                    for rel_path, key in zip(files, expected_leaf_coverage, strict=True)
+                }
+            }
+        )
+    )
+
+    fig = pmv.py_pkg_treemap(
+        "pymatgen", color_by="coverage", coverage_data_file=str(coverage_file)
+    )
+    trace = fig.data[0]
+    colors = list(trace.marker.colors)
+    labels = list(trace.labels)
+    parent_values = [
+        colors[idx] for idx, label in enumerate(labels) if "(" in str(label)
+    ]
+    assert parent_values
+    if len(parent_values) > 1:
+        assert len(set(parent_values)) > 1
+    assert all(0.0 <= value <= 100.0 for value in parent_values)
 
     for idx, label in enumerate(labels):
-        for leaf_name, expected in leaf_expected.items():
+        for leaf_name, expected in expected_leaf_coverage.items():
             if leaf_name in str(label) and "(" not in str(label):
-                assert colors[idx] == expected, (
-                    f"Leaf {label} should have coverage {expected}, got {colors[idx]}"
-                )
+                assert colors[idx] == expected
 
 
-def test_py_pkg_treemap_cell_border() -> None:
+@pytest.mark.parametrize(
+    ("kwargs", "expected_color", "expected_width"),
+    [
+        ({}, None, None),
+        ({"cell_border": {"color": "black", "width": 2}}, "black", 2),
+        ({"cell_border": {}}, None, None),
+        ({"color_by": "coverage"}, "white", 0.5),
+        (
+            {"color_by": "coverage", "cell_border": {"color": "red", "width": 3}},
+            "red",
+            3,
+        ),
+        ({"color_by": "coverage", "cell_border": {}}, None, None),
+    ],
+)
+def test_py_pkg_treemap_cell_border(
+    kwargs: dict[str, Any], expected_color: str | None, expected_width: float | None
+) -> None:
     """Test cell_border parameter functionality."""
-    # Test default behavior (no borders in non-coverage mode)
-    fig1 = pmv.py_pkg_treemap("my_pkg")
-    assert isinstance(fig1, go.Figure)
-    # Check that no borders are applied by default in non-coverage mode
-    # Plotly creates a Line object but with no properties set
-    assert fig1.data[0].marker.line.color is None
-
-    # Test custom border in non-coverage mode
-    fig2 = pmv.py_pkg_treemap("my_pkg", cell_border={"color": "black", "width": 2})
-    assert isinstance(fig2, go.Figure)
-    assert fig2.data[0].marker.line.color == "black"
-    assert fig2.data[0].marker.line.width == 2
-
-    # Test empty border (no borders) in non-coverage mode
-    fig3 = pmv.py_pkg_treemap("my_pkg", cell_border={})
-    assert isinstance(fig3, go.Figure)
-    # Should have no borders - empty dict means no color/width properties
-    assert fig3.data[0].marker.line.color is None
-
-    # Test coverage mode with default borders (white, width 1)
-    fig4 = pmv.py_pkg_treemap("my_pkg", color_by="coverage")
-    assert isinstance(fig4, go.Figure)
-    assert fig4.data[0].marker.line.color == "white"
-    assert fig4.data[0].marker.line.width == 0.5
-
-    # Test coverage mode with custom borders
-    fig5 = pmv.py_pkg_treemap(
-        "my_pkg", color_by="coverage", cell_border={"color": "red", "width": 3}
-    )
-    assert isinstance(fig5, go.Figure)
-    assert fig5.data[0].marker.line.color == "red"
-    assert fig5.data[0].marker.line.width == 3
-
-    # Test coverage mode with no borders
-    fig6 = pmv.py_pkg_treemap("my_pkg", color_by="coverage", cell_border={})
-    assert isinstance(fig6, go.Figure)
-    # Should have no borders even in coverage mode when explicitly set to empty
-    assert fig6.data[0].marker.line.color is None
+    fig = pmv.py_pkg_treemap("my_pkg", **kwargs)
+    marker_line = fig.data[0].marker.line
+    assert marker_line.color == expected_color
+    if expected_width is not None:
+        assert marker_line.width == expected_width
 
 
 def test_collect_coverage_data_from_url() -> None:
     """Test collecting coverage data from the provided GitHub URL."""
-    url = "https://github.com/user-attachments/files/21545088/2025-07-31-pymatviz-coverage.json"
-
+    url = (
+        "https://github.com/user-attachments/files/21545088/"
+        "2025-07-31-pymatviz-coverage.json"
+    )
     coverage_map = pmv.treemap.py_pkg.collect_coverage_data(url)
-
-    assert len(coverage_map) > 0  # Verify we got some coverage data
-
-    # Verify all values are floats between 0 and 100
+    assert coverage_map
     for file_path, coverage in coverage_map.items():
+        assert isinstance(file_path, str)
+        assert file_path
         assert isinstance(coverage, float)
         assert 0 <= coverage <= 100
-        assert isinstance(file_path, str)
-        assert len(file_path) > 0
 
 
 # === count_lines with comment_prefixes ===
@@ -1319,13 +1110,8 @@ def sample_lcov_file(tmp_path_factory: pytest.TempPathFactory) -> Path:
     lcov.write_text(
         "TN:test\n"
         "SF:/src/analysis/convex_hull.rs\n"
-        "DA:1,1\nDA:2,1\nDA:3,0\n"
-        "LH:2\nLF:3\n"
-        "end_of_record\n"
-        "SF:/src/io/mod.rs\n"
-        "DA:1,1\n"
-        "LH:1\nLF:1\n"
-        "end_of_record\n"
+        "DA:1,1\nDA:2,1\nDA:3,0\nLH:2\nLF:3\nend_of_record\n"
+        "SF:/src/io/mod.rs\nDA:1,1\nLH:1\nLF:1\nend_of_record\n"
     )
     return lcov
 
@@ -1333,7 +1119,6 @@ def sample_lcov_file(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def test_parse_lcov_file(sample_lcov_file: Path) -> None:
     """parse_lcov_file extracts per-file coverage percentages."""
     result = pmv.treemap.py_pkg.parse_lcov_file(str(sample_lcov_file))
-    assert len(result) == 2
     assert result["/src/analysis/convex_hull.rs"] == pytest.approx(66.667, abs=0.01)
     assert result["/src/io/mod.rs"] == pytest.approx(100.0)
 
@@ -1365,24 +1150,18 @@ def rust_like_source_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Create a Rust-like source directory structure."""
     src = tmp_path_factory.mktemp("src")
     (src / "lib.rs").write_text("pub mod analysis;\npub mod io;\n")
-
-    analysis = src / "analysis"
-    analysis.mkdir()
-    (analysis / "mod.rs").write_text("pub mod convex_hull;\n")
-    (analysis / "convex_hull.rs").write_text(
-        "// Convex hull implementation\n"
-        "pub fn compute() -> Vec<f64> {\n"
-        "    vec![1.0, 2.0]\n"
-        "}\n"
-    )
-
-    io_dir = src / "io"
-    io_dir.mkdir()
-    (io_dir / "mod.rs").write_text("pub mod lmdb;\n")
-    lmdb_dir = io_dir / "lmdb"
-    lmdb_dir.mkdir()
-    (lmdb_dir / "dataset.rs").write_text("pub struct Dataset;\n")
-
+    for rel_path, content in {
+        "analysis/mod.rs": "pub mod convex_hull;\n",
+        "analysis/convex_hull.rs": (
+            "// Convex hull implementation\n"
+            "pub fn compute() -> Vec<f64> {\n    vec![1.0, 2.0]\n}\n"
+        ),
+        "io/mod.rs": "pub mod lmdb;\n",
+        "io/lmdb/dataset.rs": "pub struct Dataset;\n",
+    }.items():
+        file_path = src / rel_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content)
     return src
 
 
@@ -1401,62 +1180,61 @@ def test_collect_source_modules_basic(rust_like_source_dir: Path) -> None:
         "repo_path_segment",
     }
     assert (df_result["package"] == "my_crate").all()
-    assert (df_result["n_classes"] == 0).all()
-    assert (df_result["n_functions"] == 0).all()
-
-    stems = set(df_result["filename"])
-    assert stems >= {"lib", "mod", "convex_hull", "dataset"}
+    assert (df_result[["n_classes", "n_functions"]] == 0).all().all()
+    assert set(df_result["filename"]) >= {"lib", "mod", "convex_hull", "dataset"}
 
 
-def test_collect_source_modules_sibling_collision(
+@pytest.mark.parametrize(
+    ("setup", "assertion"),
+    [
+        (
+            "collision",
+            lambda df_result: (
+                df_result[
+                    (df_result["filename"] == "analysis")
+                    & (df_result["directory"] == "root")
+                ].iloc[0]["module_parts"]
+                == ["analysis", "analysis"]
+            ),
+        ),
+        ("extra_md", lambda df_result: "readme" not in set(df_result["filename"])),
+        ("ignored_target", lambda df_result: "debug" not in set(df_result["filename"])),
+    ],
+)
+def test_collect_source_modules_filters(
     rust_like_source_dir: Path,
+    setup: str,
+    assertion: Callable[[pd.DataFrame], bool],
 ) -> None:
-    """Sibling file+dir collision nests the file inside the directory namespace."""
-    collision_file = rust_like_source_dir / "analysis.rs"
-    collision_file.write_text("// new-style mod root\n")
-    try:
-        df_result = pmv.treemap.py_pkg.collect_source_modules_from_dir(
-            str(rust_like_source_dir), ["my_crate"], file_extensions=(".rs",)
-        )
-        collision_rows = df_result[
-            (df_result["filename"] == "analysis") & (df_result["directory"] == "root")
-        ]
-        assert len(collision_rows) == 1
-        assert collision_rows.iloc[0]["module_parts"] == ["analysis", "analysis"]
-    finally:
-        collision_file.unlink(missing_ok=True)
+    """collect_source_modules_from_dir handles filtering cases."""
+    paths_to_remove: list[Path] = []
+    dirs_to_remove: list[Path] = []
+    if setup == "collision":
+        path_to_write = rust_like_source_dir / "analysis.rs"
+        path_to_write.write_text("// new-style mod root\n")
+        paths_to_remove.append(path_to_write)
+    elif setup == "extra_md":
+        path_to_write = rust_like_source_dir / "readme.md"
+        path_to_write.write_text("# Readme\n")
+        paths_to_remove.append(path_to_write)
+    else:
+        target_dir = rust_like_source_dir / "target"
+        target_dir.mkdir(exist_ok=True)
+        path_to_write = target_dir / "debug.rs"
+        path_to_write.write_text("fn main() {}\n")
+        paths_to_remove.append(path_to_write)
+        dirs_to_remove.append(target_dir)
 
-
-def test_collect_source_modules_file_extensions_filter(
-    rust_like_source_dir: Path,
-) -> None:
-    """Only files matching file_extensions are included."""
-    extra_file = rust_like_source_dir / "readme.md"
-    extra_file.write_text("# Readme\n")
-    try:
-        df_result = pmv.treemap.py_pkg.collect_source_modules_from_dir(
-            str(rust_like_source_dir), ["proj"], file_extensions=(".rs",)
-        )
-        assert "readme" not in set(df_result["filename"])
-    finally:
-        extra_file.unlink(missing_ok=True)
-
-
-def test_collect_source_modules_ignored_dirs(
-    rust_like_source_dir: Path,
-) -> None:
-    """Directories listed in ignored_dirs are skipped."""
-    target_dir = rust_like_source_dir / "target"
-    target_dir.mkdir(exist_ok=True)
-    (target_dir / "debug.rs").write_text("fn main() {}\n")
     try:
         df_result = pmv.treemap.py_pkg.collect_source_modules_from_dir(
             str(rust_like_source_dir), ["proj"], file_extensions=(".rs",)
         )
-        assert "debug" not in set(df_result["filename"])
+        assert assertion(df_result)
     finally:
-        (target_dir / "debug.rs").unlink(missing_ok=True)
-        target_dir.rmdir()
+        for path_to_remove in paths_to_remove:
+            path_to_remove.unlink(missing_ok=True)
+        for dir_to_remove in dirs_to_remove:
+            dir_to_remove.rmdir()
 
 
 def test_collect_source_modules_nonexistent_dir() -> None:
@@ -1477,49 +1255,46 @@ def test_collect_source_modules_empty_dir(tmp_path: Path) -> None:
     assert df_result.empty
 
 
-def test_collect_source_modules_mixed_extensions_comment_prefix(
-    tmp_path: Path,
-) -> None:
+def test_collect_source_modules_mixed_extensions_comment_prefix(tmp_path: Path) -> None:
     """Mixed file extensions use per-file comment prefixes, not a union."""
     src = tmp_path / "mixed"
     src.mkdir()
     (src / "helper.py").write_text("# py comment\n// code in python\nx = 1\n")
     (src / "lib.rs").write_text("// rs comment\n# code in rust\nlet x = 1;\n")
-
     df_result = pmv.treemap.py_pkg.collect_source_modules_from_dir(
         str(src), ["proj"], file_extensions=(".py", ".rs")
     )
-    py_row = df_result[df_result["filename"] == "helper"].iloc[0]
-    rs_row = df_result[df_result["filename"] == "lib"].iloc[0]
-    assert py_row["line_count"] == 2, "// is not a comment in Python"
-    assert rs_row["line_count"] == 2, "# is not a comment in Rust"
+    assert df_result.set_index("filename")["line_count"].to_dict() == {
+        "helper": 2,
+        "lib": 2,
+    }
 
 
 # === collect_coverage_data lcov support ===
 
 
 @pytest.mark.parametrize(
-    ("ext", "expected_parser"),
-    [(".info", "lcov"), (".lcov", "lcov"), (".json", "json")],
+    ("ext", "content", "expected"),
+    [
+        (".info", "SF:/src/lib.rs\nDA:1,1\nLH:1\nLF:1\nend_of_record\n", 100.0),
+        (".lcov", "SF:/src/lib.rs\nDA:1,1\nLH:1\nLF:1\nend_of_record\n", 100.0),
+        (
+            ".json",
+            json.dumps(
+                {"files": {"src/lib.py": {"summary": {"percent_covered": 75.0}}}}
+            ),
+            75.0,
+        ),
+    ],
 )
 def test_collect_coverage_data_detects_format(
-    tmp_path: Path, ext: str, expected_parser: str
+    tmp_path: Path, ext: str, content: str, expected: float
 ) -> None:
     """collect_coverage_data auto-detects lcov vs JSON by file extension."""
     cov_file = tmp_path / f"coverage{ext}"
-    if expected_parser == "lcov":
-        cov_file.write_text("SF:/src/lib.rs\nDA:1,1\nLH:1\nLF:1\nend_of_record\n")
-        result = pmv.treemap.py_pkg.collect_coverage_data(str(cov_file))
-        assert result["/src/lib.rs"] == pytest.approx(100.0)
-    else:
-        cov_file.write_text(
-            json.dumps(
-                {"files": {"src/lib.py": {"summary": {"percent_covered": 75.0}}}}
-            )
-        )
-        result = pmv.treemap.py_pkg.collect_coverage_data(str(cov_file))
-        assert len(result) == 1
-        assert next(iter(result.values())) == pytest.approx(75.0)
+    cov_file.write_text(content)
+    result = pmv.treemap.py_pkg.collect_coverage_data(str(cov_file))
+    assert next(iter(result.values())) == pytest.approx(expected)
 
 
 # === py_pkg_treemap with source_dir integration ===
@@ -1531,15 +1306,16 @@ def rust_project(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
     base = tmp_path_factory.mktemp("rust_proj")
     src = base / "src"
     src.mkdir()
-
-    (src / "lib.rs").write_text("pub mod utils;\npub fn main() {}\n")
-    utils = src / "utils"
-    utils.mkdir()
-    (utils / "mod.rs").write_text("pub fn helper() {}\n")
-    (utils / "math.rs").write_text(
-        "// math utilities\npub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n"
-    )
-
+    for rel_path, content in {
+        "lib.rs": "pub mod utils;\npub fn main() {}\n",
+        "utils/mod.rs": "pub fn helper() {}\n",
+        "utils/math.rs": (
+            "// math utilities\npub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n"
+        ),
+    }.items():
+        file_path = src / rel_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content)
     lcov = base / "lcov.info"
     lcov.write_text(
         f"SF:{src}/lib.rs\nLH:2\nLF:2\nend_of_record\n"
@@ -1549,79 +1325,52 @@ def rust_project(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
     return {"src": src, "lcov": lcov}
 
 
-def test_treemap_source_dir_basic(rust_project: dict[str, Path]) -> None:
-    """py_pkg_treemap with source_dir creates a valid figure, omits analysis hover."""
-    fig = pmv.py_pkg_treemap(
-        "my_crate",
-        source_dir=str(rust_project["src"]),
-        file_extensions=(".rs",),
-        base_url=None,
-    )
-    assert isinstance(fig, go.Figure)
-    labels = set(fig.data[0].labels)
-    assert "lib" in labels
-    assert "math" in labels
-
-    hover = fig.data[0].hovertemplate
-    for field in ("Classes:", "Functions:", "Methods:"):
-        assert field not in hover
-
-
-def test_treemap_source_dir_with_coverage(
-    rust_project: dict[str, Path],
+@pytest.mark.parametrize(
+    ("kwargs", "checks"),
+    [
+        ({"base_url": None}, {"labels": {"lib", "math"}, "no_analysis": True}),
+        (
+            {"color_by": "coverage", "base_url": None},
+            {"customdata_cols": 13, "hover": "Coverage:"},
+        ),
+        ({"base_url": "auto"}, {"no_urls": True}),
+        ({"base_url": "https://github.com/test/repo/blob/main"}, {"has_urls": True}),
+    ],
+)
+def test_treemap_source_dir_modes(
+    rust_project: dict[str, Path], kwargs: dict[str, Any], checks: dict[str, Any]
 ) -> None:
-    """py_pkg_treemap with source_dir + lcov coverage applies colors."""
+    """py_pkg_treemap source_dir mode handles labels, coverage, and URLs."""
+    if kwargs.get("color_by") == "coverage":
+        kwargs = {**kwargs, "coverage_data_file": str(rust_project["lcov"])}
     fig = pmv.py_pkg_treemap(
         "my_crate",
         source_dir=str(rust_project["src"]),
         file_extensions=(".rs",),
-        color_by="coverage",
-        coverage_data_file=str(rust_project["lcov"]),
-        base_url=None,
-    )
-    assert isinstance(fig, go.Figure)
-    trace = fig.data[0]
-    assert trace.customdata is not None
-    assert trace.customdata.shape[1] == 13  # 12 base + color_value
-    assert "Coverage:" in trace.hovertemplate
-
-
-def test_treemap_source_dir_auto_base_url_disabled(
-    rust_project: dict[str, Path],
-) -> None:
-    """base_url='auto' is silently disabled when source_dir is provided."""
-    fig = pmv.py_pkg_treemap(
-        "my_crate",
-        source_dir=str(rust_project["src"]),
-        file_extensions=(".rs",),
-        base_url="auto",
-    )
-    assert isinstance(fig, go.Figure)
-    trace = fig.data[0]
-    file_urls = trace.customdata[:, 3]
-    assert not any(isinstance(url, str) and url.startswith("http") for url in file_urls)
-
-
-def test_treemap_source_dir_explicit_base_url(
-    rust_project: dict[str, Path],
-) -> None:
-    """Explicit base_url generates links even in source_dir mode."""
-    base = "https://github.com/test/repo/blob/main"
-    fig = pmv.py_pkg_treemap(
-        "my_crate",
-        source_dir=str(rust_project["src"]),
-        file_extensions=(".rs",),
-        base_url=base,
+        **kwargs,
     )
     trace = fig.data[0]
+    if labels := checks.get("labels"):
+        assert labels <= set(trace.labels)
+    if checks.get("no_analysis"):
+        assert all(
+            field not in trace.hovertemplate
+            for field in ("Classes:", "Functions:", "Methods:")
+        )
+    if customdata_cols := checks.get("customdata_cols"):
+        assert trace.customdata.shape[1] == customdata_cols
+    if hover := checks.get("hover"):
+        assert hover in trace.hovertemplate
     file_urls = [str(url) for url in trace.customdata[:, 3]]
-    assert any(base in url for url in file_urls)
+    if checks.get("no_urls"):
+        assert not any(url.startswith("http") for url in file_urls)
+    if checks.get("has_urls"):
+        assert any(kwargs["base_url"] in url for url in file_urls)
 
 
 def test_treemap_python_includes_analysis_hover() -> None:
     """Standard Python mode still includes analysis fields in hover."""
-    fig = pmv.py_pkg_treemap("my_pkg", base_url=None)
-    hover = fig.data[0].hovertemplate
+    hover = pmv.py_pkg_treemap("my_pkg", base_url=None).data[0].hovertemplate
     assert "Classes:" in hover
     assert "Functions:" in hover
 
@@ -1642,57 +1391,17 @@ def _write_py_lines(path: Path, n_lines: int) -> None:
 
 @pytest.fixture(scope="module")
 def deep_pkg_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Create a package with 3 levels of nesting for depth-pruning tests.
-
-    Structure (line counts chosen to exercise adaptive thresholds):
-      deep_pkg/
-        alpha/           (top module with 3 sub-packages → expandable)
-          big/           (800 lines total → qualifies as significant child)
-            core.py      500
-            helpers.py   300
-          medium/        (400 lines total)
-            utils.py     400
-          tiny/          (50 lines → below min_lines threshold)
-            small.py     50
-        beta/            (top module with >5 sub-packages → too many children)
-          s1.py .. s6.py (100 lines each)
-        gamma/           (top module, single file → no split needed)
-          only.py        200
-    """
+    """Create a package with 3 levels of nesting for depth-pruning tests."""
     src_dir = tmp_path_factory.mktemp("deep_src")
-    pkg = src_dir / "deep_pkg"
-    pkg.mkdir()
-    (pkg / "__init__.py").touch()
-
-    # alpha — 3 sub-packages, suitable for expansion
-    alpha = pkg / "alpha"
-    alpha.mkdir()
-    (alpha / "__init__.py").touch()
-
-    for sub_name, files in {
-        "big": {"core.py": 500, "helpers.py": 300},
-        "medium": {"utils.py": 400},
-        "tiny": {"small.py": 50},
-    }.items():
-        sub_dir = alpha / sub_name
-        sub_dir.mkdir()
-        (sub_dir / "__init__.py").touch()
-        for fname, n_lines in files.items():
-            _write_py_lines(sub_dir / fname, n_lines)
-
-    # beta — 6 sub-files directly under beta (no sub-packages)
-    beta = pkg / "beta"
-    beta.mkdir()
-    (beta / "__init__.py").touch()
-    for idx in range(6):
-        _write_py_lines(beta / f"s{idx}.py", 100)
-
-    # gamma — single file
-    gamma = pkg / "gamma"
-    gamma.mkdir()
-    (gamma / "__init__.py").touch()
-    _write_py_lines(gamma / "only.py", 200)
-
+    files = {
+        "alpha/big/core.py": 500,
+        "alpha/big/helpers.py": 300,
+        "alpha/medium/utils.py": 400,
+        "alpha/tiny/small.py": 50,
+        "gamma/only.py": 200,
+        **{f"beta/s{idx}.py": 100 for idx in range(6)},
+    }
+    _write_package_files(src_dir / "deep_pkg", files)
     return src_dir
 
 
@@ -1712,18 +1421,17 @@ class TestMaxModuleDepth:
     @pytest.mark.parametrize("depth", [1, 2, 3])
     def test_max_depth_limits_nesting(self, depth: int) -> None:
         """Deeper path components should not appear when depth is capped."""
-        fig = pmv.py_pkg_treemap("deep_pkg", max_module_depth=depth, base_url=None)
-        trace = fig.data[0]
+        trace = pmv.py_pkg_treemap(
+            "deep_pkg", max_module_depth=depth, base_url=None
+        ).data[0]
         max_id_depth = max(
             id_val.count("/") for id_val in trace.ids if isinstance(id_val, str)
         )
         assert max_id_depth <= depth
-
         if depth == 1:
-            # At depth 1, only top-level modules appear — no sub-packages
             leaf_labels = {
-                lbl
-                for lbl, parent in zip(trace.labels, trace.parents, strict=False)
+                label
+                for label, parent in zip(trace.labels, trace.parents, strict=False)
                 if parent
             }
             assert leaf_labels >= {"alpha", "beta", "gamma"}
@@ -1734,99 +1442,77 @@ class TestMaxModuleDepth:
 class TestAdaptivePruning:
     """Tests for min_lines_for_split and max_children_for_split."""
 
+    @staticmethod
+    def _trace(**kwargs: Any) -> go.Treemap:
+        """Return a deep_pkg treemap trace for pruning tests."""
+        return pmv.py_pkg_treemap("deep_pkg", base_url=None, **kwargs).data[0]
+
     @pytest.mark.parametrize(
         ("min_lines", "max_children"),
-        [
-            (300, None),  # all 6 children (100 lines each) below min_lines
-            (50, 3),  # 6 children exceeds max_children=3
-        ],
+        [(300, None), (50, 3)],
     )
     def test_collapse_beta_children(
         self, min_lines: int, max_children: int | None
     ) -> None:
-        """Beta's 6 children (100 lines each) get collapsed."""
-        fig = pmv.py_pkg_treemap(
-            "deep_pkg",
+        """Beta's 6 children get collapsed."""
+        trace = self._trace(
             max_module_depth=2,
             min_lines_for_split=min_lines,
             max_children_for_split=max_children,
-            base_url=None,
         )
-        labels = set(fig.data[0].labels)
-        assert "beta" in labels
-        assert labels.isdisjoint({f"s{idx}" for idx in range(6)})
+        assert "beta" in trace.labels
+        assert set(trace.labels).isdisjoint({f"s{idx}" for idx in range(6)})
 
     @pytest.mark.parametrize(
         ("min_lines", "expected_present", "expected_absent"),
         [
-            # big(800) & medium(400) significant (≥200), tiny(50) merges to "other"
             (200, {"big", "medium", "other"}, {"tiny"}),
-            # only big(800) significant (≥600), medium & tiny merge to "other"
             (600, {"big", "other"}, {"medium", "tiny"}),
         ],
     )
     def test_other_bucket_for_small_children(
-        self,
-        min_lines: int,
-        expected_present: set[str],
-        expected_absent: set[str],
+        self, min_lines: int, expected_present: set[str], expected_absent: set[str]
     ) -> None:
         """Children below min_lines merge into an 'other' bucket."""
-        fig = pmv.py_pkg_treemap(
-            "deep_pkg",
-            max_module_depth=3,
-            min_lines_for_split=min_lines,
-            max_children_for_split=5,
-            base_url=None,
+        labels = set(
+            self._trace(
+                max_module_depth=3,
+                min_lines_for_split=min_lines,
+                max_children_for_split=5,
+            ).labels
         )
-        labels = set(fig.data[0].labels)
         assert expected_present <= labels
         assert labels.isdisjoint(expected_absent)
 
     def test_max_children_only_at_deepest_level(self) -> None:
         """max_children_for_split does not collapse intermediate levels."""
-        fig = pmv.py_pkg_treemap(
-            "deep_pkg",
-            max_module_depth=3,
-            min_lines_for_split=50,
-            max_children_for_split=2,
-            base_url=None,
+        labels = set(
+            self._trace(
+                max_module_depth=3,
+                min_lines_for_split=50,
+                max_children_for_split=2,
+            ).labels
         )
-        labels = set(fig.data[0].labels)
-        # alpha has 3 sub-packages (big, medium, tiny) which exceeds max_children=2,
-        # but max_children only applies at the deepest level, so all 3 survive
-        assert {"alpha", "big", "medium"} <= labels
-        # At the deepest level, alpha/big has 2 children (core, helpers) ≤ 2 → expanded
-        assert {"core", "helpers"} <= labels
+        assert {"alpha", "big", "medium", "core", "helpers"} <= labels
 
     def test_aggregated_values_are_summed(self) -> None:
         """Collapsed groups have summed line counts."""
-        fig = pmv.py_pkg_treemap(
-            "deep_pkg",
-            max_module_depth=2,
-            min_lines_for_split=500,
-            base_url=None,
+        trace = self._trace(max_module_depth=2, min_lines_for_split=500)
+        assert list(trace.values)[list(trace.labels).index("beta")] == pytest.approx(
+            600, abs=5
         )
-        labels = list(fig.data[0].labels)
-        values = list(fig.data[0].values)
-        # beta: 6 files x 100 lines = 600 total, all < 500 -> collapsed
-        assert values[labels.index("beta")] == pytest.approx(600, abs=5)
 
     def test_min_lines_uses_line_count_not_cell_value(self) -> None:
         """min_lines_for_split must compare against line_count, not cell_value."""
-        fig = pmv.py_pkg_treemap(
-            "deep_pkg",
-            max_module_depth=3,
-            min_lines_for_split=200,
-            max_children_for_split=5,
-            cell_size_fn=lambda _m: 1,
-            base_url=None,
+        labels = set(
+            self._trace(
+                max_module_depth=3,
+                min_lines_for_split=200,
+                max_children_for_split=5,
+                cell_size_fn=lambda _module: 1,
+            ).labels
         )
-        labels = set(fig.data[0].labels)
-        # alpha sub-packages: big (800 lines), medium (400 lines) → both >= 200
-        # With cell_value each file is 1, sum ≤ 2 → would wrongly collapse
-        assert "big" in labels, "big (800 lines) should survive min_lines=200"
-        assert "medium" in labels, "medium (400 lines) should survive min_lines=200"
+        assert {"big", "medium"} <= labels
 
     @pytest.mark.parametrize(
         "base_url",
@@ -1838,21 +1524,15 @@ class TestAdaptivePruning:
     ) -> None:
         """Depth limiting skips customdata refs in text and hover templates."""
         monkeypatch.setattr(
-            pmv.treemap.py_pkg, "collect_coverage_data", lambda *_a, **_kw: {}
+            pmv.treemap.py_pkg, "collect_coverage_data", lambda *_args, **_kwargs: {}
         )
-        fig = pmv.py_pkg_treemap(
-            "deep_pkg",
-            max_module_depth=2,
-            color_by="coverage",
-            base_url=base_url,
-        )
-        text_template = fig.data[0].texttemplate or ""
-        assert "customdata" not in text_template
-        assert "%{label}" in text_template
-
-        hover_template = fig.data[0].hovertemplate or ""
-        assert "customdata" not in hover_template
-        assert "%{label}" in hover_template
+        trace = pmv.py_pkg_treemap(
+            "deep_pkg", max_module_depth=2, color_by="coverage", base_url=base_url
+        ).data[0]
+        assert "customdata" not in (trace.texttemplate or "")
+        assert "%{label}" in (trace.texttemplate or "")
+        assert "customdata" not in (trace.hovertemplate or "")
+        assert "%{label}" in (trace.hovertemplate or "")
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/tests/treemap/test_py_pkg_treemap.py
+++ b/tests/treemap/test_py_pkg_treemap.py
@@ -641,8 +641,9 @@ def test_py_pkg_treemap_cell_size_fn(
     assert actual_filenames >= expected_filenames
 
     # Verify cell_value calculations match expectations
-    metrics_keys = pmv.treemap.py_pkg.ModuleStats._fields
-    numeric_keys = {
+    numeric_fields = {
+        "line_count",
+        "depth",
         "n_classes",
         "n_functions",
         "n_methods",
@@ -651,14 +652,10 @@ def test_py_pkg_treemap_cell_size_fn(
         "n_type_checking_imports",
     }
     for _, row in df_passed_to_plotly.iterrows():
-        row_dict = row.to_dict()
-        metrics_dict = {
-            key: 0
-            if key in numeric_keys and pd.isna(row_dict.get(key))
-            else row_dict[key]
-            for key in metrics_keys
-        }
-        metrics_instance = pmv.treemap.py_pkg.ModuleStats(**metrics_dict)  # ty: ignore[invalid-argument-type]
+        metrics_instance = pmv.treemap.py_pkg.ModuleStats._make(
+            0 if field in numeric_fields and pd.isna(row[field]) else row[field]
+            for field in pmv.treemap.py_pkg.ModuleStats._fields
+        )
         expected_val = (
             metrics_instance.line_count
             if calculator is None

--- a/tests/treemap/test_py_pkg_treemap.py
+++ b/tests/treemap/test_py_pkg_treemap.py
@@ -898,8 +898,8 @@ def test_collect_coverage_data_subprocess(
             patch("os.unlink"),
             patch("json.load", return_value=coverage_data),
         ):
-            mock_tempfile.return_value.__enter__.return_value.name = (
-                "/tmp/coverage.json"
+            mock_tempfile.return_value.__enter__.return_value.name = str(
+                tmp_path / "coverage.json"
             )
             mock_run.return_value = MagicMock(
                 returncode=returncode,
@@ -1064,17 +1064,25 @@ def test_py_pkg_treemap_cell_border(
 
 def test_collect_coverage_data_from_url() -> None:
     """Test collecting coverage data from the provided GitHub URL."""
-    url = (
-        "https://github.com/user-attachments/files/21545088/"
-        "2025-07-31-pymatviz-coverage.json"
+    coverage_data = {
+        "files": {
+            "pkg/module.py": {"summary": {"percent_covered": 88.5}},
+            "pkg/empty.py": {"summary": {"percent_covered": 0.0}},
+        }
+    }
+    response = MagicMock()
+    response.read.return_value = json.dumps(coverage_data)
+    response.__enter__.return_value = response
+
+    with patch("urllib.request.urlopen", return_value=response) as mock_urlopen:
+        coverage_map = pmv.treemap.py_pkg.collect_coverage_data(
+            "https://example.com/coverage.json"
+        )
+
+    mock_urlopen.assert_called_once_with(
+        "https://example.com/coverage.json", timeout=15
     )
-    coverage_map = pmv.treemap.py_pkg.collect_coverage_data(url)
-    assert coverage_map
-    for file_path, coverage in coverage_map.items():
-        assert isinstance(file_path, str)
-        assert file_path
-        assert isinstance(coverage, float)
-        assert 0 <= coverage <= 100
+    assert coverage_map == {"pkg/module.py": 88.5, "pkg/empty.py": 0.0}
 
 
 # === count_lines with comment_prefixes ===

--- a/tests/widgets/test_widget_construction.py
+++ b/tests/widgets/test_widget_construction.py
@@ -34,128 +34,123 @@ from pymatviz.widgets.xrd import XrdWidget
 # === Construction and widget_type ===
 
 
+def _case(
+    widget_cls: type,
+    kwargs: dict[str, Any],
+    expected_type: str,
+    state_key: str,
+    expected_state: Any = None,
+) -> tuple[type, dict[str, Any], str, str, Any]:
+    """Build a widget construction test case."""
+    return (
+        widget_cls,
+        kwargs,
+        expected_type,
+        state_key,
+        kwargs[state_key] if expected_state is None else expected_state,
+    )
+
+
 @pytest.mark.parametrize(
     ("widget_cls", "kwargs", "expected_type", "state_key", "expected_state"),
     [
-        (
+        _case(
             ConvexHullWidget,
             {"entries": [{"composition": {"Li": 1}, "energy": -1.5}]},
             "convex_hull",
             "entries",
-            [{"composition": {"Li": 1}, "energy": -1.5}],
         ),
-        (
+        _case(
             BandStructureWidget,
             {"band_structure": {"bands": []}},
             "band_structure",
             "band_structure",
-            {"bands": []},
         ),
-        (DosWidget, {"dos": {"energies": [0]}}, "dos", "dos", {"energies": [0]}),
-        (
+        _case(DosWidget, {"dos": {"energies": [0]}}, "dos", "dos"),
+        _case(
             BandsAndDosWidget,
             {"band_structure": {"bands": []}, "dos": {"energies": []}},
             "bands_and_dos",
             "dos",
-            {"energies": []},
         ),
-        (
+        _case(
             FermiSurfaceWidget,
             {"fermi_data": {"isosurfaces": []}},
             "fermi_surface",
             "fermi_data",
-            {"isosurfaces": []},
         ),
-        (
+        _case(
             FermiSurfaceWidget,
             {"band_data": {"energies": []}},
             "fermi_surface",
             "band_data",
-            {"energies": []},
         ),
-        (
+        _case(
             BrillouinZoneWidget,
             {"structure": {"lattice": {}, "sites": []}},
             "brillouin_zone",
             "structure",
-            {"lattice": {}, "sites": []},
         ),
-        (
+        _case(
             PhaseDiagramWidget,
             {"data": {"components": ["A", "B"]}},
             "phase_diagram",
             "data",
-            {"components": ["A", "B"]},
         ),
-        (
-            XrdWidget,
-            {"patterns": {"x": [10], "y": [100]}},
-            "xrd",
-            "patterns",
-            {"x": [10], "y": [100]},
-        ),
-        (
+        _case(XrdWidget, {"patterns": {"x": [10], "y": [100]}}, "xrd", "patterns"),
+        _case(
             ScatterPlotWidget,
             {"series": [{"x": [0, 1], "y": [1, 2], "label": "curve"}]},
             "scatter_plot",
             "series",
             [{"x": [0.0, 1.0], "y": [1.0, 2.0], "label": "curve"}],
         ),
-        (
+        _case(
             BarPlotWidget,
             {"series": [{"x": [0, 1], "y": [2, 3], "label": "bars"}]},
             "bar_plot",
             "series",
             [{"x": [0.0, 1.0], "y": [2.0, 3.0], "label": "bars"}],
         ),
-        (
+        _case(
             HistogramWidget,
             {"series": [{"x": [0, 1], "y": [2, 2.5], "label": "hist"}]},
             "histogram",
             "series",
             [{"x": [0.0, 1.0], "y": [2.0, 2.5], "label": "hist"}],
         ),
-        (
+        _case(
             PeriodicTableWidget,
             {"heatmap_values": {"Fe": 42, "O": 100}},
             "periodic_table",
             "heatmap_values",
-            {"Fe": 42, "O": 100},
         ),
-        (
+        _case(
             RdfPlotWidget,
             {"structures": {"lattice": {}, "sites": []}},
             "rdf_plot",
             "structures",
-            {"lattice": {}, "sites": []},
         ),
-        (
+        _case(
             ScatterPlot3DWidget,
             {"series": [{"x": [1], "y": [2], "z": [3], "label": "pt"}]},
             "scatter_plot_3d",
             "series",
-            [{"x": [1], "y": [2], "z": [3], "label": "pt"}],
         ),
-        (
+        _case(
             HeatmapMatrixWidget,
             {"x_items": ["A", "B"], "y_items": ["C", "D"], "values": [[1, 2], [3, 4]]},
             "heatmap_matrix",
             "values",
-            [[1, 2], [3, 4]],
         ),
-        (
-            SpacegroupBarPlotWidget,
-            {"data": [225, 166, 62]},
-            "spacegroup_bar",
-            "data",
-            [225, 166, 62],
+        _case(
+            SpacegroupBarPlotWidget, {"data": [225, 166, 62]}, "spacegroup_bar", "data"
         ),
-        (
+        _case(
             ChemPotDiagramWidget,
             {"entries": [{"name": "Li2O", "energy": -14.3}]},
             "chem_pot_diagram",
             "entries",
-            [{"name": "Li2O", "energy": -14.3}],
         ),
     ],
 )
@@ -176,212 +171,37 @@ def test_widget_construction_and_type(
 
 
 @pytest.mark.parametrize(
-    ("widget_cls", "kwargs", "expected_fields"),
+    ("widget_cls", "kwargs"),
     [
-        (
-            ScatterPlotWidget,
-            {"series": [{"x": [0, 1], "y": [1, 2], "label": "s"}]},
-            {
-                "series",
-                "x_axis",
-                "x2_axis",
-                "y_axis",
-                "y2_axis",
-                "display",
-                "legend",
-                "styles",
-                "color_scale",
-                "size_scale",
-                "ref_lines",
-                "fill_regions",
-                "error_bands",
-                "controls",
-                "padding",
-                "range_padding",
-                "show_legend",
-                "x_range",
-                "x2_range",
-                "y_range",
-                "y2_range",
-                "color_bar",
-                "hover_config",
-                "label_placement_config",
-                "point_tween",
-                "line_tween",
-                "point_events",
-            },
-        ),
+        (ScatterPlotWidget, {"series": [{"x": [0, 1], "y": [1, 2], "label": "s"}]}),
         (
             HistogramWidget,
             {"series": [{"x": [0, 1], "y": [1, 2]}], "bins": 50, "mode": "overlay"},
-            {
-                "series",
-                "bins",
-                "mode",
-                "selected_property",
-                "show_legend",
-                "x_axis",
-                "x2_axis",
-                "y_axis",
-                "y2_axis",
-                "display",
-                "legend",
-                "bar",
-                "ref_lines",
-                "controls",
-                "padding",
-                "range_padding",
-                "x_range",
-                "x2_range",
-                "y_range",
-                "y2_range",
-            },
         ),
-        (
-            BarPlotWidget,
-            {"series": [{"x": [0], "y": [1]}], "mode": "grouped"},
-            {
-                "series",
-                "orientation",
-                "mode",
-                "x_axis",
-                "x2_axis",
-                "y_axis",
-                "y2_axis",
-                "display",
-                "legend",
-                "bar",
-                "line",
-                "ref_lines",
-                "controls",
-                "padding",
-                "range_padding",
-                "show_legend",
-                "x_range",
-                "x2_range",
-                "y_range",
-                "y2_range",
-                "color_scale",
-                "size_scale",
-                "point_tween",
-            },
-        ),
-        (
-            DosWidget,
-            {"dos": {"energies": [0, 1]}, "sigma": 0.05},
-            {
-                "dos",
-                "stack",
-                "sigma",
-                "normalize",
-                "orientation",
-                "show_legend",
-                "spin_mode",
-            },
-        ),
-        (
-            ConvexHullWidget,
-            {"entries": [{"composition": {"Li": 1}, "energy": -1.5}]},
-            {
-                "entries",
-                "show_stable",
-                "show_unstable",
-                "show_hull_faces",
-                "hull_face_opacity",
-                "show_stable_labels",
-                "show_unstable_labels",
-                "max_hull_dist_show_labels",
-                "max_hull_dist_show_phases",
-                "temperature",
-            },
-        ),
-        (
-            PeriodicTableWidget,
-            {"heatmap_values": {"Fe": 42}},
-            {
-                "heatmap_values",
-                "color_scale",
-                "color_scale_range",
-                "color_overrides",
-                "labels",
-                "log_scale",
-                "show_color_bar",
-                "gap",
-                "missing_color",
-            },
-        ),
-        (
-            ScatterPlot3DWidget,
-            {"series": [{"x": [1], "y": [2], "z": [3]}]},
-            {
-                "series",
-                "surfaces",
-                "ref_lines",
-                "ref_planes",
-                "x_axis",
-                "y_axis",
-                "z_axis",
-                "display",
-                "styles",
-                "color_scale",
-                "size_scale",
-                "legend",
-                "controls",
-                "camera_projection",
-            },
-        ),
-        (
-            HeatmapMatrixWidget,
-            {"x_items": ["A"], "y_items": ["B"]},
-            {
-                "x_items",
-                "y_items",
-                "values",
-                "color_scale",
-                "color_scale_range",
-                "log_scale",
-                "missing_color",
-                "x_axis",
-                "y_axis",
-                "tile_size",
-                "gap",
-                "show_values",
-                "label_style",
-            },
-        ),
-        (
-            SpacegroupBarPlotWidget,
-            {"data": [225]},
-            {
-                "data",
-                "show_counts",
-                "show_legend",
-                "orientation",
-                "x_axis",
-                "y_axis",
-            },
-        ),
-        (
-            ChemPotDiagramWidget,
-            {"entries": [{"name": "Li", "energy": -1.9}]},
-            {"entries", "config", "temperature"},
-        ),
+        (BarPlotWidget, {"series": [{"x": [0], "y": [1]}], "mode": "grouped"}),
+        (DosWidget, {"dos": {"energies": [0, 1]}, "sigma": 0.05}),
+        (ConvexHullWidget, {"entries": [{"composition": {"Li": 1}, "energy": -1.5}]}),
+        (PeriodicTableWidget, {"heatmap_values": {"Fe": 42}}),
+        (ScatterPlot3DWidget, {"series": [{"x": [1], "y": [2], "z": [3]}]}),
+        (HeatmapMatrixWidget, {"x_items": ["A"], "y_items": ["B"]}),
+        (SpacegroupBarPlotWidget, {"data": [225]}),
+        (ChemPotDiagramWidget, {"entries": [{"name": "Li", "energy": -1.9}]}),
     ],
 )
 def test_to_dict_includes_subclass_fields(
     widget_cls: type,
     kwargs: dict[str, Any],
-    expected_fields: set[str],
 ) -> None:
-    """to_dict returns base fields plus widget-specific synced traitlets."""
+    """to_dict returns all public synced traitlets."""
     widget = widget_cls(**kwargs)
     state = widget.to_dict()
-
-    base_fields = {"widget_type", "style", "show_controls"}
-    assert base_fields <= set(state), f"Missing base fields in {widget_cls.__name__}"
-
-    all_expected = base_fields | expected_fields
-    assert set(state) == all_expected
+    expected = {
+        name
+        for name in widget.traits(sync=True)
+        if not name.startswith("_") and name not in widget._EXCLUDED_TRAITS
+    }
+    assert {"widget_type", "style", "show_controls"} <= set(state)
+    assert set(state) == expected
 
 
 def test_to_dict_reflects_constructor_values() -> None:


### PR DESCRIPTION
## Summary
- Validate element symbols and formula grouping inputs more strictly, including invalid chemical systems and group-by values.
- Restore Plotly figure template and hidden trace state when PDF/image export fails.
- Reduce verbose treemap and widget-construction tests by consolidating repeated setup and assertions.

## Validation
- `python -m pytest tests/test_chem_env.py tests/test_io.py tests/test_process_data.py tests/treemap/test_py_pkg_treemap.py tests/widgets/test_widget_construction.py -k 'not headless'`
- `prek` hooks during commit: ruff check, ruff format, ty check, README link check, formatting, whitespace, codespell, and related file checks.

Note: widget headless image tests were not run locally because Playwright Chromium is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDF export now reliably restores figure template and trace visibility after write errors.
  * Coordination-number parsing/clamping and site-index bounds are more robust, avoiding negative/out-of-range values.

* **Improvements**
  * Stronger element-symbol validation and explicit chem-system grouping/sorting (arity-first).

* **Chores**
  * Bumped pre-commit hook and frontend dev-dependencies; added svelte-multiselect devDependency.

* **Tests**
  * Expanded/refactored tests for environment classification, IO export restoration, data-processing validation, treemap generation, and widgets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janosh/pymatviz/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->