### PR TITLE
Switch to ty-pre-commit and fix type errors across the codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ examples/*.html
 node_modules
 build/
 package-lock.json
+uv.lock
 .coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,17 @@ repos:
       - id: ruff-format
         types_or: [python, jupyter]
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.47
     hooks:
       - id: ty
-        name: ty check
-        entry: ty check --ignore unused-ignore-comment
-        language: python
-        types: [python]
-        pass_filenames: false
-        additional_dependencies: [ty]
+        # --isolated: don't create/update uv.lock or the local .venv
+        # --all-extras: make optional deps (pytest, phonopy, ...) resolvable by ty
+        args: [--isolated, --all-extras]
+        env: { UV_FROZEN: "0" } # prek-only: override global UV_FROZEN=1 which would require a uv.lock
+
+  - repo: local
+    hooks:
       - id: check-readme-src-links
         name: Check README source links
         entry: python .github/scripts/check_readme_src_links.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,13 @@ repos:
         types_or: [python, jupyter]
 
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.47
+    rev: v0.0.48
     hooks:
       - id: ty
         # --isolated: don't create/update uv.lock or the local .venv
         # --all-extras: make optional deps (pytest, phonopy, ...) resolvable by ty
         args: [--isolated, --all-extras]
-        env: { UV_FROZEN: "0" } # prek-only: override global UV_FROZEN=1 which would require a uv.lock
+        env: { UV_FROZEN: "0" } # prek hook: override global UV_FROZEN=1 which would require a uv.lock
 
   - repo: local
     hooks:

--- a/assets/scripts/brillouin/brillouin_zone_3d.py
+++ b/assets/scripts/brillouin/brillouin_zone_3d.py
@@ -42,12 +42,14 @@ def volume_subplot_title(struct: Structure, key: tuple[str, str, str]) -> str:
     )
 
 
-def spacegroup_subplot_title(struct: Structure, key: Hashable) -> str:
+def spacegroup_subplot_title(struct: pmv.typing.AnyStructure, key: Hashable) -> str:
     """Custom subplot title function showing spacegroup information."""
     if isinstance(key, tuple):
         _mat_id, formula, system = key
     else:
         raise TypeError(f"Invalid {type(key)=}")
+    if not isinstance(struct, Structure):
+        raise TypeError(f"expected Structure, got {type(struct).__name__}")
     sym_data = struct.get_symmetry_dataset(backend="moyopy", return_raw_dataset=True)
     spg_num = getattr(sym_data, "number", "N/A")
     return f"{formula} {str(system).title()}<br>Space group: {spg_num}"

--- a/assets/scripts/brillouin/brillouin_zone_3d.py
+++ b/assets/scripts/brillouin/brillouin_zone_3d.py
@@ -48,6 +48,7 @@ def spacegroup_subplot_title(struct: pmv.typing.AnyStructure, key: Hashable) -> 
         _mat_id, formula, system = key
     else:
         raise TypeError(f"Invalid {type(key)=}")
+    # get_symmetry_dataset needs pymatgen Structure, not ASE Atoms etc.
     if not isinstance(struct, Structure):
         raise TypeError(f"expected Structure, got {type(struct).__name__}")
     sym_data = struct.get_symmetry_dataset(backend="moyopy", return_raw_dataset=True)

--- a/assets/scripts/phonons/phonon_bands.py
+++ b/assets/scripts/phonons/phonon_bands.py
@@ -74,6 +74,9 @@ bands = {
     "Γ -> W": np.linspace([0, 0, 0], [1 / 3, 1 / 3, 1 / 2], 51),
 }
 phonopy_nacl.run_band_structure(paths=list(bands.values()))
+band_structure = phonopy_nacl.band_structure
+if band_structure is None:
+    raise RuntimeError("phonopy band structure not computed")
 
-fig = pmv.phonon_bands({"NaCl (phonopy)": phonopy_nacl.band_structure})
+fig = pmv.phonon_bands({"NaCl (phonopy)": band_structure})
 fig.show()

--- a/assets/scripts/phonons/phonon_dos.py
+++ b/assets/scripts/phonons/phonon_dos.py
@@ -82,20 +82,23 @@ phonopy_nacl_pdos = load_phonopy_nacl()
 phonopy_nacl_pdos.run_mesh([10, 10, 10], with_eigenvectors=True, is_mesh_symmetry=False)
 phonopy_nacl_pdos.run_projected_dos()
 phonopy_nacl_pdos.run_total_dos()
-if phonopy_nacl_pdos.total_dos is None:
+nacl_total_dos = phonopy_nacl_pdos.total_dos
+nacl_projected_dos = phonopy_nacl_pdos.projected_dos
+if nacl_total_dos is None:
     raise PhonopyTotalDosMissingError
-if phonopy_nacl_pdos.projected_dos is None:
+if nacl_projected_dos is None:
+    raise PhonopyProjectedDosMissingError
+
+nacl_dos_values = nacl_total_dos.dos
+nacl_projected_dos_values = nacl_projected_dos.projected_dos
+if nacl_dos_values is None:
+    raise PhonopyTotalDosMissingError
+if nacl_projected_dos_values is None:
     raise PhonopyProjectedDosMissingError
 
 struct = get_pmg_structure(phonopy_nacl_pdos.primitive)
-total_dos = PhononDos(
-    phonopy_nacl_pdos.total_dos.frequency_points,
-    phonopy_nacl_pdos.total_dos.dos,
-)
-site_dos = {
-    site: phonopy_nacl_pdos.projected_dos.projected_dos[idx]
-    for idx, site in enumerate(struct)
-}
+total_dos = PhononDos(nacl_total_dos.frequency_points, nacl_dos_values)
+site_dos = {site: nacl_projected_dos_values[idx] for idx, site in enumerate(struct)}
 complete_dos = CompletePhononDos(struct, total_dos, site_dos)
 
 

--- a/assets/scripts/ptable/ptable_scatter.py
+++ b/assets/scripts/ptable/ptable_scatter.py
@@ -10,7 +10,7 @@ import pymatviz as pmv
 np_rng = np.random.default_rng(seed=0)
 
 # Generate some example data - sinusoidal waves with different frequencies and noise
-rand_sine_data: dict[str, tuple[list[float], list[float]]] = {}
+rand_sine_data: dict[str, tuple[np.ndarray, np.ndarray]] = {}
 xs = np.linspace(0, 10, 20)
 for elem in Element:
     freq = np_rng.uniform(0.5, 2.0)

--- a/examples/diatomics/make_vasp_diatomics_inputs.py
+++ b/examples/diatomics/make_vasp_diatomics_inputs.py
@@ -18,7 +18,7 @@ warnings.filterwarnings("ignore", message="No Pauling electronegativity for")
 
 
 def create_diatomic_inputs(
-    distances: Sequence[float] = (1, 10, 40),
+    distances: Sequence[float] | np.ndarray = (1, 10, 40),
     box_size: Xyz = (10, 10, 20),
     elements: Sequence[str] | set[str] = (),
     base_dir: str = "diatomic-calcs",
@@ -43,7 +43,7 @@ def create_diatomic_inputs(
         and isinstance(distances[-1], int)
     ):
         min_dist, max_dist, n_points = distances
-        distances = np.logspace(np.log10(min_dist), np.log10(max_dist), n_points)
+        distances = np.logspace(np.log10(min_dist), np.log10(max_dist), int(n_points))
     a, b, c = box_size
     box = Lattice.orthorhombic(a, b, c)
 
@@ -83,7 +83,7 @@ def create_diatomic_inputs(
 
                 # Generate VASP input files
                 vasp_input_set = MPStaticSet(
-                    dimer,
+                    dimer,  # ty: ignore[invalid-argument-type]
                     user_kpoints_settings={},  # sample a single k-point at Gamma
                     # disable symmetry since spglib in VASP sometimes detects false
                     # symmetries in dimers and fails (used to be Kpoints() before {})

--- a/examples/mp_bimodal_e_form.ipynb
+++ b/examples/mp_bimodal_e_form.ipynb
@@ -55,7 +55,7 @@
    "source": [
     "PMG_MAPI_KEY = \"your Materials Project API key\"\n",
     "\n",
-    "e_form_all_mp = MPRester(PMG_MAPI_KEY).query(\n",
+    "e_form_all_mp = MPRester(PMG_MAPI_KEY).query(  # ty: ignore[call-non-callable]\n",
     "    {}, [\"material_id\", \"formula\", \"formation_energy_per_atom\"]\n",
     ")\n",
     "\n",

--- a/examples/phonons/mlip_phonons.py
+++ b/examples/phonons/mlip_phonons.py
@@ -16,6 +16,7 @@ import os
 import warnings
 from collections import defaultdict
 from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 import torch
@@ -68,7 +69,7 @@ results: dict[str, dict[str, Phonopy]] = defaultdict(
 q_pts: Sequence[np.ndarray] = ()
 connections: Sequence[bool] | None = None
 labels: Sequence[str] | None = None
-systems = (
+systems: tuple[dict[str, Any], ...] = (
     dict(name="Si", crystalstructure="diamond", a=5.431),
     dict(name="Al", crystalstructure="fcc", a=4.11),
 )
@@ -146,8 +147,12 @@ for cubic, bulk_kwargs, (model_name, calc) in itertools.product(
 os.makedirs(fig_dir := f"{module_dir}/tmp/phonons", exist_ok=True)
 
 for bulk_str, model_results in results.items():
-    bands = {key: ph.band_structure for key, ph in model_results.items()}
-    doses = {key: ph.total_dos for key, ph in model_results.items()}
+    bands, doses = {}, {}
+    for key, ph in model_results.items():
+        band_structure, ph_total_dos = ph.band_structure, ph.total_dos
+        if band_structure is None or ph_total_dos is None:
+            raise RuntimeError(f"missing band structure or total DOS for {key}")
+        bands[key], doses[key] = band_structure, ph_total_dos
     fig = pmv.phonon_bands_and_dos(bands, doses)
     fig.layout.title.update(text=f"{bulk_str}")
     fig.layout.margin.t = 60

--- a/examples/ricci_carrier_transport/convert_dtype+add_structs.py
+++ b/examples/ricci_carrier_transport/convert_dtype+add_structs.py
@@ -25,7 +25,7 @@ df_carrier.index.name = "mp_id"
 
 # %%
 with MPRester() as mpr:
-    structs = mpr.query(
+    structs = mpr.query(  # ty: ignore[call-non-callable]
         {task_ids_key: {"$in": df_carrier.index.to_list()}},
         [task_ids_key, Key.structure],
     )

--- a/examples/ward_metallic_glasses/formula_features.py
+++ b/examples/ward_metallic_glasses/formula_features.py
@@ -227,7 +227,7 @@ def calc_liu_features(
     formulas: Sequence[str | Composition],
     include: Sequence[str] = (),
     binary_liquidus_data: dict[str, interp1d] | None = None,
-) -> dict[str, dict[str, float | None]]:
+) -> dict[str, dict[str | Composition, float | None]]:
     """Calculate Liu et al.'s (2023) compositional features for metallic glasses.
 
     Args:
@@ -319,7 +319,7 @@ def one_hot_encode(df_in: pd.DataFrame) -> pd.DataFrame:
     """
     comp_dicts = df_in[Key.composition].map(lambda comp: Composition(comp).as_dict())
     all_elements = sorted({el for comp in comp_dicts for el in comp})
-    comp_features = pd.DataFrame(0.0, index=df_in.index, columns=all_elements)
+    comp_features = pd.DataFrame(0.0, index=df_in.index, columns=pd.Index(all_elements))
     for idx, comp in comp_dicts.items():
         for el, wt in comp.items():
             comp_features.loc[idx, el] = wt

--- a/pymatviz/__init__.py
+++ b/pymatviz/__init__.py
@@ -147,6 +147,6 @@ if os.environ.get("CI"):  # Configure Plotly to be silent in CI
 
     # Replace fig.show() method with a noop version for CI environments to avoid
     # spamming logs with huge HTML strings
-    go.Figure.show = lambda *_args, **_kwargs: None
+    go.Figure.show = lambda *_args, **_kwargs: None  # ty: ignore[invalid-assignment]
 
 notebook_mode(on=IS_IPYTHON)

--- a/pymatviz/brillouin.py
+++ b/pymatviz/brillouin.py
@@ -2,7 +2,7 @@
 
 import re
 import warnings
-from collections.abc import Callable, Hashable, Sequence
+from collections.abc import Callable, Hashable, Mapping, Sequence
 from typing import Any, Literal
 
 import numpy as np
@@ -14,7 +14,7 @@ from pymatviz.typing import AnyStructure
 
 
 def brillouin_zone_3d(
-    struct: AnyStructure | Sequence[AnyStructure] | dict[Hashable, AnyStructure],
+    struct: AnyStructure | Sequence[AnyStructure] | Mapping[Any, AnyStructure],
     *,
     # Surface styling
     surface_kwargs: dict[str, Any] | None = None,
@@ -64,10 +64,10 @@ def brillouin_zone_3d(
     import scipy.spatial as sps
     import seekpath
 
-    from pymatviz.process_data import normalize_structures
+    from pymatviz.process_data import normalize_periodic_structures
     from pymatviz.structure.helpers import get_subplot_title
 
-    structures = normalize_structures(struct)
+    structures = normalize_periodic_structures(struct)
 
     n_structs = len(structures)
     n_cols = min(n_cols, n_structs)

--- a/pymatviz/classify/curves.py
+++ b/pymatviz/classify/curves.py
@@ -54,11 +54,10 @@ def _standardize_input(
         targets, probs_positive = df_to_arrays(df, targets, probs_positive)
 
     curves_dict: dict[str, dict[str, Any]]
-    if isinstance(probs_positive, dict):
-        # cast since ty can't infer dict[str, ...] from the isinstance check (ArrayLike
-        # protocol members intersected with dict degrade the key type to object)
+    if isinstance(probs_positive, Mapping):
+        # convert array values to dicts if needed. both casts needed since ty keeps
+        # ArrayLike & Mapping/dict intersections from the isinstance checks
         probs_dict = cast("Mapping[str, ArrayLike | dict[str, Any]]", probs_positive)
-        # Convert array values to dicts if needed
         curves_dict = {
             name: (
                 cast("dict[str, Any]", probs)

--- a/pymatviz/classify/curves.py
+++ b/pymatviz/classify/curves.py
@@ -1,7 +1,7 @@
 """Plotly-based classification metrics visualization."""
 
-from collections.abc import Callable
-from typing import Any, Literal, TypeAlias
+from collections.abc import Callable, Mapping
+from typing import Any, Literal, TypeAlias, cast
 
 import numpy as np
 import pandas as pd
@@ -13,7 +13,7 @@ from pymatviz.process_data import df_to_arrays
 from pymatviz.utils.plotting import PLOTLY_LINE_STYLES
 
 
-Predictions: TypeAlias = ArrayLike | str | dict[str, ArrayLike | dict[str, Any]]
+Predictions: TypeAlias = ArrayLike | str | Mapping[str, ArrayLike | dict[str, Any]]
 
 
 def _standardize_input(
@@ -45,7 +45,7 @@ def _standardize_input(
                 f"when passing a DataFrame, targets must be a column name, got "
                 f"{type(targets).__name__}"
             )
-        if isinstance(probs_positive, dict):
+        if isinstance(probs_positive, Mapping):
             raise TypeError(
                 f"when passing a DataFrame, probs_positive must be a column name "
                 f"(str) or array, not dict. Got {type(probs_positive).__name__}. "
@@ -53,11 +53,19 @@ def _standardize_input(
             )
         targets, probs_positive = df_to_arrays(df, targets, probs_positive)
 
+    curves_dict: dict[str, dict[str, Any]]
     if isinstance(probs_positive, dict):
+        # cast since ty can't infer dict[str, ...] from the isinstance check (ArrayLike
+        # protocol members intersected with dict degrade the key type to object)
+        probs_dict = cast("Mapping[str, ArrayLike | dict[str, Any]]", probs_positive)
         # Convert array values to dicts if needed
         curves_dict = {
-            name: (probs if isinstance(probs, dict) else {"probs_positive": probs})
-            for name, probs in probs_positive.items()
+            name: (
+                cast("dict[str, Any]", probs)
+                if isinstance(probs, dict)
+                else {"probs_positive": probs}
+            )
+            for name, probs in probs_dict.items()
         }
         for name, trace_dict in curves_dict.items():
             if "probs_positive" not in trace_dict:

--- a/pymatviz/cluster/composition/embed.py
+++ b/pymatviz/cluster/composition/embed.py
@@ -32,7 +32,7 @@ def try_composition(composition: str | Composition) -> Composition:
 
 
 def matminer_featurize(
-    compositions: Sequence[str] | Sequence[Composition] | pd.Series,
+    compositions: Sequence[str | Composition] | pd.Series,
     preset: MatminerElementPropertyPreset = "magpie",
     *,
     normalize: bool = True,
@@ -106,7 +106,7 @@ def matminer_featurize(
 
 
 def one_hot_encode(
-    compositions: Sequence[str] | Sequence[Composition] | pd.Series,
+    compositions: Sequence[str | Composition] | pd.Series,
     *,
     normalize: bool = True,
     elements: Sequence[str] | None = None,

--- a/pymatviz/coordination/figures.py
+++ b/pymatviz/coordination/figures.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import math
 from collections import Counter
-from collections.abc import Hashable, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from inspect import isclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import plotly.graph_objects as go
@@ -29,6 +29,8 @@ from pymatviz.structure.helpers import get_site_elements, get_site_symbol
 if TYPE_CHECKING:
     from typing import Any, Literal
 
+    import pandas as pd
+
     from pymatviz.typing import AnyStructure
 
 
@@ -47,7 +49,10 @@ def _resolve_element_colors(
 
 
 def coordination_hist(
-    structures: AnyStructure | dict[str, AnyStructure] | Sequence[AnyStructure],
+    structures: AnyStructure
+    | Mapping[str, AnyStructure]
+    | Sequence[AnyStructure]
+    | pd.Series,
     *,
     strategy: float | NearNeighbors | type[NearNeighbors] = 3.0,
     split_mode: CnSplitMode | str = CnSplitMode.by_element,
@@ -370,7 +375,10 @@ def coordination_hist(
 
 
 def coordination_vs_cutoff_line(
-    structures: AnyStructure | dict[str, AnyStructure] | Sequence[AnyStructure],
+    structures: AnyStructure
+    | Mapping[str, AnyStructure]
+    | Sequence[AnyStructure]
+    | pd.Series,
     *,
     strategy: tuple[float, float] | NearNeighbors | type[NearNeighbors] = (1, 5),
     num_points: int = 50,
@@ -406,7 +414,8 @@ def coordination_vs_cutoff_line(
         and len(strategy) == 2
         and {*map(type, strategy)} <= {int, float}
     ):
-        cutoff_range = strategy
+        # runtime-checked numeric 2-tuple, ty can't narrow the set comparison above
+        cutoff_range = cast("tuple[float, float]", strategy)
 
     elif isinstance(strategy, NearNeighbors) or (
         isclass(strategy) and issubclass(strategy, NearNeighbors)
@@ -429,7 +438,8 @@ def coordination_vs_cutoff_line(
                 )
         else:
             raise AttributeError(f"Could not determine cutoff for {nn_instance=}")
-        cutoff_range = (0, max_cutoff)
+        # cast since hasattr narrowing types the cutoff attributes as plain object
+        cutoff_range = (0.0, cast("float", max_cutoff))
 
     else:
         raise TypeError(

--- a/pymatviz/coordination/helpers.py
+++ b/pymatviz/coordination/helpers.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Hashable
     from typing import Any
 
-    from pymatgen.core import PeriodicSite, Structure
+    from pymatgen.core import IMolecule, IStructure, PeriodicSite, Structure
 
 
 class CnSplitMode(LabelEnum):
@@ -54,7 +54,7 @@ def create_hover_text(
 
 def normalize_get_neighbors(
     strategy: float | NearNeighbors | type[NearNeighbors],
-) -> Callable[[PeriodicSite, Structure], list[dict[str, Any]]]:
+) -> Callable[[PeriodicSite, Any], list[Any]]:
     """Normalize get_neighbors function."""
     # Prepare the neighbor-finding strategy
     if isinstance(strategy, int | float):
@@ -77,16 +77,16 @@ def normalize_get_neighbors(
 
 
 def calculate_average_cn(
-    structure: Structure,
+    structure: IStructure | IMolecule,
     element: str,
-    get_neighbors: Callable[[PeriodicSite, Structure], list[dict[str, Any]]],
+    get_neighbors: Callable[[PeriodicSite, Any], list[Any]],
 ) -> float:
     """Calculate the average coordination number for a given element in a structure.
 
     Args:
-        structure (Structure): A pymatgen Structure object.
+        structure (IStructure | IMolecule): A pymatgen structure-like object.
         element (str): Element symbol to calculate average CN for.
-        get_neighbors (Callable[[PeriodicSite, Structure], list[dict[str, Any]]]):
+        get_neighbors (Callable[[PeriodicSite, Any], list[Any]]):
             Function to get neighbors for a site.
 
     Returns:

--- a/pymatviz/process_data.py
+++ b/pymatviz/process_data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Hashable, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final, cast
 
 import numpy as np
@@ -20,9 +20,12 @@ from pymatviz.utils import df_ptable
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from ase.atoms import Atoms
     from numpy.typing import ArrayLike
+    from phonopy.structure.atoms import PhonopyAtoms
     from pymatgen.core import IMolecule, Molecule
     from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
+    from typing_extensions import TypeIs
 
     from pymatviz.typing import AnyStructure, ElemValues, FormulaGroupBy, T
 
@@ -298,13 +301,13 @@ def is_structure_like(obj: Any) -> bool:
     return False
 
 
-def is_ase_atoms(struct: Any) -> bool:
+def is_ase_atoms(struct: Any) -> TypeIs[Atoms]:
     """Check if the input is an ASE Atoms object without importing ase."""
     cls_name = f"{type(struct).__module__}.{type(struct).__qualname__}"
     return cls_name in ("ase.atoms.Atoms", "pymatgen.io.ase.MSONAtoms")
 
 
-def is_phonopy_atoms(obj: Any) -> bool:
+def is_phonopy_atoms(obj: Any) -> TypeIs[PhonopyAtoms]:
     """Check if object is PhonopyAtoms."""
     cls_name = f"{type(obj).__module__}.{type(obj).__qualname__}"
     return cls_name == "phonopy.structure.atoms.PhonopyAtoms"
@@ -314,7 +317,7 @@ def normalize_structures(
     systems: AnyStructure
     | Sequence[AnyStructure]
     | pd.Series
-    | dict[Hashable, AnyStructure],
+    | Mapping[Any, AnyStructure],
 ) -> dict[Hashable, Structure | IStructure | Molecule | IMolecule]:
     """Convert pymatgen Structures/IStructures, ASE Atoms, or PhonopyAtoms or
     sequences/dicts of them to a dictionary mapping hashable keys to pymatgen
@@ -368,6 +371,28 @@ def normalize_structures(
         "ASE Atoms, or PhonopyAtoms object, a sequence (list, tuple, pd.Series), "
         f"or a dict. Got {type(systems)=}"
     )
+
+
+def normalize_periodic_structures(
+    systems: AnyStructure
+    | Sequence[AnyStructure]
+    | pd.Series
+    | Mapping[Any, AnyStructure],
+) -> dict[Hashable, IStructure]:
+    """Like normalize_structures but requires all inputs to be periodic.
+
+    Raises:
+        TypeError: If any of the normalized structures is a (non-periodic) molecule.
+    """
+    struct_dict: dict[Hashable, IStructure] = {}
+    for key, struct in normalize_structures(systems).items():
+        if not isinstance(struct, IStructure):
+            raise TypeError(
+                f"Expected periodic structure for key={key!r}, got "
+                f"{type(struct).__name__}"
+            )
+        struct_dict[key] = struct
+    return struct_dict
 
 
 def normalize_to_dict(
@@ -429,7 +454,7 @@ def df_to_arrays(
     df: pd.DataFrame | None,
     *args: str | ArrayLike,
     strict: bool = True,
-) -> list[str | ArrayLike | dict[str, ArrayLike]]:
+) -> list[Any]:
     """If df is None, this is a no-op: args are returned as-is. If df is a
     dataframe, all following args are used as column names and the column data
     returned as arrays (after dropping rows with NaNs in any column).
@@ -445,9 +470,9 @@ def df_to_arrays(
         TypeError: If df is not pd.DataFrame and not None.
 
     Returns:
-        list[str | ArrayLike | dict[str, ArrayLike]]: Array data for each column name,
-            dictionary of column names and array data, or original string args when
-            strict=False and df is not a DataFrame.
+        list[Any]: Array data for each column name, dictionary of column names and
+            array data, or original string args when strict=False and df is not a
+            DataFrame.
     """
     if df is None:
         if cols := [arg for arg in args if isinstance(arg, str)]:
@@ -474,7 +499,7 @@ def df_to_arrays(
             flat_args.extend(col_name)  # ty: ignore[invalid-argument-type]
 
     df_no_nan = df.dropna(subset=flat_args)
-    out_args: list[str | ArrayLike | dict[str, ArrayLike]] = []
+    out_args: list[Any] = []
     for col_name in args:
         if isinstance(col_name, str | int):
             out_args.append(df_no_nan[col_name].to_numpy())

--- a/pymatviz/process_data.py
+++ b/pymatviz/process_data.py
@@ -354,10 +354,7 @@ def normalize_structures(
     if hasattr(systems, "__len__") and len(systems) == 0:
         raise ValueError("Cannot plot empty set of structures")
 
-    if isinstance(systems, dict):  # Process dict values, keep original keys
-        return {key: to_pmg_struct(val) for key, val in systems.items()}
-
-    if isinstance(systems, pd.Series):  # Keep original Series index as keys
+    if isinstance(systems, (pd.Series, Mapping)):  # keep original keys/index
         return {key: to_pmg_struct(val) for key, val in systems.items()}
 
     if isinstance(systems, Sequence) and not isinstance(systems, str):
@@ -369,7 +366,7 @@ def normalize_structures(
     raise TypeError(
         "Input must be a pymatgen Structure, IStructure, Molecule, IMolecule, "
         "ASE Atoms, or PhonopyAtoms object, a sequence (list, tuple, pd.Series), "
-        f"or a dict. Got {type(systems)=}"
+        f"or a mapping. Got {type(systems)=}"
     )
 
 

--- a/pymatviz/ptable/figures.py
+++ b/pymatviz/ptable/figures.py
@@ -42,7 +42,7 @@ def ptable_heatmap(
     heat_mode: Literal["value", "fraction", "percent"] = "value",
     fmt: str | Callable[[float], str] | None = None,
     hover_props: Sequence[str] | dict[str, str] | None = None,
-    hover_data: dict[str, str | int | float] | pd.Series | None = None,
+    hover_data: Mapping[str, str | int | float] | pd.Series | None = None,
     font_colors: Sequence[str] = (),
     gap: float = 5,
     font_size: int | None = None,
@@ -457,7 +457,7 @@ def ptable_hists(
     data: (
         pd.DataFrame
         | pd.Series
-        | dict[str, Sequence[int | float] | np.ndarray[Any, Any]]
+        | Mapping[str, Sequence[int | float] | np.ndarray[Any, Any]]
     ),
     *,
     # Histogram-specific
@@ -928,7 +928,7 @@ def ptable_heatmap_splits(
     data: (
         pd.DataFrame
         | pd.Series
-        | dict[str, Sequence[int | float] | np.ndarray[Any, Any]]
+        | Mapping[str, Sequence[int | float] | np.ndarray[Any, Any]]
     ),
     *,
     # Split
@@ -955,7 +955,7 @@ def ptable_heatmap_splits(
     # Additional options
     nan_color: str = "#eff",
     zero_color: str = "#aaa",
-    hover_data: dict[str, str | int | float] | pd.Series | None = None,
+    hover_data: Mapping[str, str | int | float] | pd.Series | None = None,
     subplot_kwargs: dict[str, Any] | None = None,
 ) -> go.Figure:
     """Create a Plotly figure with an interactive heatmap of the periodic table,
@@ -1597,14 +1597,15 @@ def ptable_heatmap_splits(
     return fig
 
 
+XYArray: TypeAlias = Sequence[float] | np.ndarray[Any, Any]
 ElemData: TypeAlias = (
-    tuple[Sequence[float], Sequence[float]]
-    | tuple[Sequence[float], Sequence[float], Sequence[float | str]]
-    | Mapping[str, tuple[Sequence[float], Sequence[float]]]
+    tuple[XYArray, XYArray]
+    | tuple[XYArray, XYArray, Sequence[float | str] | np.ndarray[Any, Any]]
+    | Mapping[str, tuple[XYArray, XYArray]]
 )
 LineData: TypeAlias = (
-    tuple[Sequence[float], Sequence[float]]
-    | tuple[Sequence[float], Sequence[float], Sequence[float | str]]
+    tuple[XYArray, XYArray]
+    | tuple[XYArray, XYArray, Sequence[float | str] | np.ndarray[Any, Any]]
 )
 
 

--- a/pymatviz/rdf/figures.py
+++ b/pymatviz/rdf/figures.py
@@ -18,22 +18,26 @@ import plotly
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
-from pymatviz.process_data import normalize_structures
+from pymatviz.process_data import normalize_periodic_structures
 from pymatviz.rdf.helpers import calculate_rdf
 from pymatviz.utils.plotting import PLOTLY_LINE_STYLES
 
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
     from typing import Any
 
     import numpy as np
+    import pandas as pd
 
     from pymatviz.typing import AnyStructure
 
 
 def element_pair_rdfs(
-    structures: AnyStructure | Sequence[AnyStructure] | dict[str, AnyStructure],
+    structures: AnyStructure
+    | Sequence[AnyStructure]
+    | Mapping[str, AnyStructure]
+    | pd.Series,
     cutoff: float | None = None,
     n_bins: int = 75,
     bin_size: float | None = None,
@@ -84,7 +88,7 @@ def element_pair_rdfs(
             specified.
         TypeError: If input structures are not pymatgen Structures or ASE Atoms.
     """
-    struct_dict = normalize_structures(structures)
+    struct_dict = normalize_periodic_structures(structures)
 
     for key, struct in struct_dict.items():
         if len(struct) == 0:
@@ -210,7 +214,10 @@ def element_pair_rdfs(
 
 
 def full_rdf(
-    structures: AnyStructure | Sequence[AnyStructure] | dict[str, AnyStructure],
+    structures: AnyStructure
+    | Sequence[AnyStructure]
+    | Mapping[str, AnyStructure]
+    | pd.Series,
     cutoff: float = 15,
     n_bins: int = 75,
     bin_size: float | None = None,
@@ -246,7 +253,7 @@ def full_rdf(
         ValueError: If no structures are provided, if structures have no sites,
             or if both n_bins and bin_size are specified.
     """
-    struct_dict = normalize_structures(structures)
+    struct_dict = normalize_periodic_structures(structures)
 
     for key, struct in struct_dict.items():
         if len(struct) == 0:

--- a/pymatviz/rdf/helpers.py
+++ b/pymatviz/rdf/helpers.py
@@ -34,8 +34,8 @@ def calculate_rdf(
     for the specified element pair. Otherwise, calculates the full RDF.
 
     Args:
-        structure (AnyStructure): A pymatgen Structure/IStructure object or ASE Atoms
-            object.
+        structure (AnyStructure): A periodic pymatgen Structure/IStructure, ASE Atoms,
+            or PhonopyAtoms object (or mapping/sequence thereof).
         center_species (str, optional): Symbol of the central species. If None, all
             species are considered.
         neighbor_species (str, optional): Symbol of the neighbor species. If None, all
@@ -51,7 +51,7 @@ def calculate_rdf(
 
     Raises:
         ValueError: If cutoff or n_bins are not positive values.
-        TypeError: If structure is not a supported type.
+        TypeError: If structure is unsupported or not periodic (e.g. a Molecule).
     """
     struct = next(iter(normalize_periodic_structures(structure).values()))
 

--- a/pymatviz/rdf/helpers.py
+++ b/pymatviz/rdf/helpers.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from pymatgen.optimization.neighbors import find_points_in_spheres
 
-from pymatviz.process_data import normalize_structures
+# compiled cython module, has no type stubs
+from pymatgen.optimization.neighbors import (  # ty: ignore[unresolved-import]
+    find_points_in_spheres,
+)
+
+from pymatviz.process_data import normalize_periodic_structures
 
 
 if TYPE_CHECKING:
@@ -49,7 +53,7 @@ def calculate_rdf(
         ValueError: If cutoff or n_bins are not positive values.
         TypeError: If structure is not a supported type.
     """
-    struct = next(iter(normalize_structures(structure).values()))
+    struct = next(iter(normalize_periodic_structures(structure).values()))
 
     # Handle empty structure
     if len(struct) == 0:

--- a/pymatviz/scatter.py
+++ b/pymatviz/scatter.py
@@ -29,8 +29,8 @@ def _get_axis_labels(
     """Extract axis labels from data or column names."""
     if df is not None:
         # x, y are column names (str) when df is provided
-        xlabel: str = getattr(df[x], "name", x)
-        ylabel: str = getattr(df[y], "name", y)
+        xlabel: str = str(getattr(df[x], "name", x))
+        ylabel: str = str(getattr(df[y], "name", y))
     else:
         xlabel = getattr(x, "name", x if isinstance(x, str) else "Actual")
         ylabel = getattr(y, "name", y if isinstance(y, str) else "Predicted")
@@ -472,7 +472,8 @@ def density_hexbin(
     xlabel, ylabel = _get_axis_labels(x, y, df)
 
     # Use numpy's histogram2d for initial binning, then convert to hex coordinates
-    hist, x_edges, y_edges = np.histogram2d(xs, ys, bins=gridsize, weights=weights)
+    weights_arr = None if weights is None else np.asarray(weights)
+    hist, x_edges, y_edges = np.histogram2d(xs, ys, bins=gridsize, weights=weights_arr)
 
     # Create hexagonal grid from rectangular bins
     x_centers = (x_edges[:-1] + x_edges[1:]) / 2

--- a/pymatviz/scatter.py
+++ b/pymatviz/scatter.py
@@ -32,8 +32,8 @@ def _get_axis_labels(
         xlabel: str = str(getattr(df[x], "name", x))
         ylabel: str = str(getattr(df[y], "name", y))
     else:
-        xlabel = getattr(x, "name", x if isinstance(x, str) else "Actual")
-        ylabel = getattr(y, "name", y if isinstance(y, str) else "Predicted")
+        xlabel = str(getattr(x, "name", x if isinstance(x, str) else "Actual"))
+        ylabel = str(getattr(y, "name", y if isinstance(y, str) else "Predicted"))
     return xlabel, ylabel
 
 
@@ -469,7 +469,9 @@ def density_hexbin(
         raise TypeError(f"stats must be bool or dict, got {type(stats)} instead.")
 
     xs, ys = df_to_arrays(df, x, y)
-    xlabel, ylabel = _get_axis_labels(x, y, df)
+    auto_xlabel, auto_ylabel = _get_axis_labels(x, y, df)
+    xlabel = xlabel or auto_xlabel
+    ylabel = ylabel or auto_ylabel
 
     # Use numpy's histogram2d for initial binning, then convert to hex coordinates
     weights_arr = None if weights is None else np.asarray(weights)

--- a/pymatviz/structure/figures.py
+++ b/pymatviz/structure/figures.py
@@ -8,14 +8,15 @@ import numpy as np
 from plotly.subplots import make_subplots
 
 from pymatviz.enums import ElemColorScheme, SiteCoords
-from pymatviz.process_data import normalize_structures
+from pymatviz.process_data import normalize_periodic_structures
 from pymatviz.structure import helpers
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Hashable, Sequence
+    from collections.abc import Callable, Hashable, Mapping, Sequence
     from typing import Literal
 
+    import pandas as pd
     import plotly.graph_objects as go
     from pymatgen.analysis.local_env import NearNeighbors
     from pymatgen.core import PeriodicSite
@@ -24,7 +25,10 @@ if TYPE_CHECKING:
 
 
 def structure_2d(
-    struct: AnyStructure | dict[str, AnyStructure] | Sequence[AnyStructure],
+    struct: AnyStructure
+    | Mapping[str, AnyStructure]
+    | Sequence[AnyStructure]
+    | pd.Series,
     *,
     rotation: str = "10x,8y,3z",
     atomic_radii: float | dict[str, float] | None = None,
@@ -130,7 +134,7 @@ def structure_2d(
     Returns:
         go.Figure: Plotly figure showing the 2D structure(s).
     """
-    structures = normalize_structures(struct)
+    structures = normalize_periodic_structures(struct)
 
     n_structs = len(structures)
     n_cols = min(n_cols, n_structs)
@@ -386,7 +390,10 @@ def structure_2d(
 
 
 def structure_3d(
-    struct: AnyStructure | dict[str, AnyStructure] | Sequence[AnyStructure],
+    struct: AnyStructure
+    | Mapping[str, AnyStructure]
+    | Sequence[AnyStructure]
+    | pd.Series,
     *,
     atomic_radii: float | dict[str, float] | None = None,
     atom_size: float = 20,
@@ -489,7 +496,7 @@ def structure_3d(
     Returns:
         go.Figure: Plotly figure showing the 3D structure(s).
     """
-    structures = normalize_structures(struct)
+    structures = normalize_periodic_structures(struct)
 
     n_structs = len(structures)
     n_cols = min(n_cols, n_structs)

--- a/pymatviz/structure/helpers.py
+++ b/pymatviz/structure/helpers.py
@@ -104,7 +104,7 @@ def resolve_nn_obj(
     from pymatgen.analysis.local_env import CrystalNN, NearNeighbors
 
     struct_show_bonds = (
-        show_bonds.get(struct_key, False)
+        show_bonds.get(struct_key, False)  # ty: ignore[no-matching-overload]
         if isinstance(show_bonds, dict)
         else show_bonds
     )
@@ -138,7 +138,7 @@ def _is_3d_vector(value: Any) -> bool:
 
 def _get_site_vector(
     site: PeriodicSite,
-    struct: AnyStructure,
+    struct: IStructure | IMolecule,
     site_idx: int,
     vector_prop: str,
 ) -> np.ndarray | None:
@@ -238,7 +238,7 @@ def get_site_symbol(site: PeriodicSite) -> str:
     if isinstance(species, Composition):
         el_amt_dict = species.get_el_amt_dict()
         if el_amt_dict:
-            return max(el_amt_dict, key=el_amt_dict.get)
+            return max(el_amt_dict, key=el_amt_dict.__getitem__)
         if species.elements:
             return species.elements[0].symbol
         return "X"
@@ -430,11 +430,17 @@ def get_subplot_title(
             )
 
     if not title_dict.get("text"):
-        if isinstance(struct_key, int):
+        if isinstance(struct_key, int) and isinstance(struct_i, IStructure):
             from moyopy import MoyoDataset
             from moyopy.interface import MoyoAdapter
 
-            spg_num = MoyoDataset(MoyoAdapter.from_py_obj(struct_i)).number
+            # moyopy only accepts mutable Structure objects, not IStructure
+            struct_for_spg = (
+                struct_i
+                if isinstance(struct_i, Structure)
+                else Structure.from_sites(list(struct_i))
+            )
+            spg_num = MoyoDataset(MoyoAdapter.from_py_obj(struct_for_spg)).number
             title_dict["text"] = f"{idx}. {struct_i.formula} (spg={spg_num})"
         else:  # For str or any other Hashable type, convert to string
             title_dict["text"] = str(struct_key)
@@ -445,7 +451,7 @@ def get_subplot_title(
 def get_site_hover_text(
     site: PeriodicSite,
     hover_text: SiteCoords | Callable[[PeriodicSite], str],
-    majority_species: Species | Element,
+    majority_species: Species | Element | Composition,
     float_fmt: str | Callable[[float], str] = ".4",
 ) -> str:
     """Generate hover text for a site based on the hover template.
@@ -454,7 +460,8 @@ def get_site_hover_text(
         site (PeriodicSite): The periodic site.
         hover_text (SiteCoords | Callable[[PeriodicSite], str]): The hover text template
             or a custom callable.
-        majority_species (Species | Element): The majority species at the site.
+        majority_species (Species | Element | Composition): The majority species at
+            the site.
         float_fmt (str | Callable[[float], str]): Float formatting for coordinates. Can
             be an f-string format like ".4" (default) or a callable that takes a float
             and returns a string.
@@ -520,9 +527,7 @@ def normalize_elem_color(raw_color_from_map: ColorType) -> str:
         and len(raw_color_from_map) == 3
         and all(isinstance(c, (float, int)) for c in raw_color_from_map)
     ):
-        red, green, blue = cast(
-            "tuple[int | float, int | float, int | float]", raw_color_from_map
-        )
+        red, green, blue = raw_color_from_map
         rgb = [
             int(channel * 255)
             if isinstance(channel, float) and 0 <= channel <= 1
@@ -620,7 +625,9 @@ def draw_site(
 
     # Handle ordered sites (single species)
     majority_species = (
-        max(species, key=species.get) if isinstance(species, Composition) else species
+        max(species, key=species.__getitem__)
+        if isinstance(species, Composition)
+        else species
     )
     if not isinstance(majority_species, Species):
         majority_species = Species(str(majority_species))
@@ -676,7 +683,9 @@ def draw_site(
 
 
 def get_disordered_site_legend_name(
-    sorted_species: list[tuple[Species | Element, float]], *, is_image: bool = False
+    sorted_species: Sequence[tuple[Species | Element, float]],
+    *,
+    is_image: bool = False,
 ) -> str:
     """Create a legend name for a disordered site showing all elements with occupancies.
 
@@ -1280,7 +1289,7 @@ def draw_vector(
 
 def draw_cell(
     fig: go.Figure,
-    structure: Structure | IStructure | IMolecule,
+    structure: Structure | IStructure,
     cell_kwargs: dict[str, Any],
     *,
     is_3d: bool = True,
@@ -1492,7 +1501,7 @@ def get_first_matching_site_prop(
 
 def draw_bonds(
     fig: go.Figure,
-    structure: Structure | IStructure | IMolecule,
+    structure: Structure,
     nn: NearNeighbors,
     *,
     is_3d: bool = True,
@@ -1671,12 +1680,12 @@ def draw_bonds(
 
 
 def _standardize_struct(
-    struct_i: Structure | IStructure | IMolecule, *, standardize_struct: bool | None
-) -> Structure | IStructure | IMolecule:
+    struct_i: Structure | IStructure, *, standardize_struct: bool | None
+) -> Structure | IStructure:
     """Standardize the structure if needed."""
     if standardize_struct is None:
         standardize_struct = any(any(site.frac_coords < 0) for site in struct_i)
-    if standardize_struct and isinstance(struct_i, (Structure, IStructure)):
+    if standardize_struct:
         try:
             spg_analyzer = SpacegroupAnalyzer(struct_i)
             return spg_analyzer.get_conventional_standard_structure()
@@ -1686,7 +1695,7 @@ def _standardize_struct(
 
 
 def _prep_augmented_structure_for_bonding(
-    struct_i: Structure | IStructure | IMolecule,
+    struct_i: Structure | IStructure,
     *,
     show_image_sites: bool | dict[str, Any],
     cell_boundary_tol: float = 0,

--- a/pymatviz/structure/helpers.py
+++ b/pymatviz/structure/helpers.py
@@ -94,18 +94,18 @@ def resolve_per_struct_params(
 
 
 def resolve_nn_obj(
-    show_bonds: bool | NearNeighbors | dict[Any, Any],  # noqa: FBT001
+    show_bonds: bool | NearNeighbors | Mapping[Any, Any],  # noqa: FBT001
     struct_key: Hashable,
 ) -> NearNeighbors | None:
-    """Resolve show_bonds (True -> CrystalNN(), NearNeighbors -> itself, dict ->
+    """Resolve show_bonds (True -> CrystalNN(), NearNeighbors -> itself, mapping ->
     lookup by struct_key) to the NearNeighbors algorithm for bond drawing, or
     None if bonds should not be drawn for this structure.
     """
     from pymatgen.analysis.local_env import CrystalNN, NearNeighbors
 
     struct_show_bonds = (
-        show_bonds.get(struct_key, False)  # ty: ignore[no-matching-overload]
-        if isinstance(show_bonds, dict)
+        show_bonds.get(struct_key, False)
+        if isinstance(show_bonds, Mapping)
         else show_bonds
     )
     if not struct_show_bonds:

--- a/pymatviz/sunburst/spacegroup.py
+++ b/pymatviz/sunburst/spacegroup.py
@@ -1,7 +1,7 @@
 """Sunburst plot of crystal systems."""
 
 from collections.abc import Sequence
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import pandas as pd
 import plotly.express as px
@@ -10,6 +10,7 @@ from pymatgen.core import Structure
 
 import pymatviz as pmv
 from pymatviz.enums import Key
+from pymatviz.process_data import is_structure_like
 from pymatviz.sunburst.helpers import (
     _apply_sunburst_show_counts,
     _limit_slices_per_group,
@@ -55,17 +56,31 @@ def spacegroup_sunburst(
     if len(data) == 0:
         raise ValueError("spacegroup_sunburst requires non-empty data")
 
-    if type(data[0]).__qualname__ in ("Structure", "Atoms"):
-        # if 1st sequence item is pymatgen structure or ASE Atoms, assume all are
-        from moyopy import MoyoDataset
-        from moyopy.interface import MoyoAdapter
+    # materialize as list[Any] for Series-safe positional access and untyped iteration
+    values: list[Any] = data.tolist() if isinstance(data, pd.Series) else list(data)
+    if is_structure_like(values[0]):  # if 1st item is structure-like, assume all are
+        try:
+            from moyopy import MoyoDataset
+            from moyopy.interface import MoyoAdapter
+        except ImportError as exc:
+            raise RuntimeError(
+                "moyopy is required to pass Structure objects to "
+                "spacegroup_sunburst. Install it with `pip install moyopy`."
+            ) from exc
 
-        structs = cast("Sequence[Structure]", data)  # narrowed by qualname check above
-        series = pd.Series(
-            MoyoDataset(MoyoAdapter.from_py_obj(struct)).number for struct in structs
-        )
+        spg_nums: list[int] = []
+        for idx, struct in enumerate(values):
+            try:
+                spg_nums.append(MoyoDataset(MoyoAdapter.from_py_obj(struct)).number)
+            except (TypeError, ValueError, RuntimeError) as exc:
+                raise TypeError(
+                    "Could not determine space group for structure at index "
+                    f"{idx} ({type(struct).__name__}). Pass periodic pymatgen "
+                    "Structure objects or ASE Atoms supported by moyopy."
+                ) from exc
+        series = pd.Series(spg_nums)
     else:
-        series = pd.Series(data)
+        series = pd.Series(values)
 
     df_spg_counts = pd.DataFrame(series.value_counts().reset_index())
     df_spg_counts.columns = [Key.spg_num, "count"]

--- a/pymatviz/sunburst/spacegroup.py
+++ b/pymatviz/sunburst/spacegroup.py
@@ -1,11 +1,12 @@
 """Sunburst plot of crystal systems."""
 
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
+from pymatgen.core import Structure
 
 import pymatviz as pmv
 from pymatviz.enums import Key
@@ -17,7 +18,7 @@ from pymatviz.typing import ShowCounts
 
 
 def spacegroup_sunburst(
-    data: Sequence[int | str] | pd.Series,
+    data: Sequence[int | str | Structure] | pd.Series,
     *,
     show_counts: ShowCounts = "value",
     max_slices: int | None = None,
@@ -59,8 +60,9 @@ def spacegroup_sunburst(
         from moyopy import MoyoDataset
         from moyopy.interface import MoyoAdapter
 
+        structs = cast("Sequence[Structure]", data)  # narrowed by qualname check above
         series = pd.Series(
-            MoyoDataset(MoyoAdapter.from_py_obj(struct)).number for struct in data
+            MoyoDataset(MoyoAdapter.from_py_obj(struct)).number for struct in structs
         )
     else:
         series = pd.Series(data)

--- a/pymatviz/typing.py
+++ b/pymatviz/typing.py
@@ -47,8 +47,7 @@ ElemValues: TypeAlias = (
     Mapping[str, int | float]
     | Mapping[int, int | float]
     | pd.Series
-    | Sequence[str]
-    | Sequence["Composition"]
+    | Sequence["str | Composition"]
 )
 
 T = TypeVar("T")  # generic type for input validation

--- a/pymatviz/uncertainty.py
+++ b/pymatviz/uncertainty.py
@@ -64,7 +64,7 @@ def qq_gaussian(
     y_true, y_pred, y_std = _load_regression_data(y_true, y_pred, y_std, df)
 
     fig = fig or go.Figure()
-    if not isinstance(y_std, dict):
+    if not isinstance(y_std, Mapping):
         y_std = {"std": y_std}
 
     # Calculate Q-Q data
@@ -156,7 +156,7 @@ def error_decay_with_uncert(
     y_true, y_pred, y_std = _load_regression_data(y_true, y_pred, y_std, df)
 
     fig = fig or go.Figure()
-    if not isinstance(y_std, dict):
+    if not isinstance(y_std, Mapping):
         y_std = {"std": y_std}
 
     # Calculate error decay curves

--- a/pymatviz/uncertainty.py
+++ b/pymatviz/uncertainty.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 def _load_regression_data(
     y_true: ArrayLike | str,
     y_pred: ArrayLike | str,
-    y_std: ArrayLike | dict[str, ArrayLike] | str | Sequence[str],
+    y_std: ArrayLike | Mapping[str, ArrayLike] | str | Sequence[str],
     df: pd.DataFrame | None,
 ) -> tuple[np.ndarray, np.ndarray, Any]:
     """Resolve y_true/y_pred/y_std into arrays, pulling columns from df when given."""
@@ -42,7 +42,7 @@ def _load_regression_data(
 def qq_gaussian(
     y_true: ArrayLike | str,
     y_pred: ArrayLike | str,
-    y_std: ArrayLike | dict[str, ArrayLike] | str | Sequence[str],
+    y_std: ArrayLike | Mapping[str, ArrayLike] | str | Sequence[str],
     *,
     df: pd.DataFrame | None = None,
     fig: go.Figure | None = None,
@@ -132,7 +132,7 @@ def qq_gaussian(
 def error_decay_with_uncert(
     y_true: ArrayLike | str,
     y_pred: ArrayLike | str,
-    y_std: ArrayLike | dict[str, ArrayLike] | str | Sequence[str],
+    y_std: ArrayLike | Mapping[str, ArrayLike] | str | Sequence[str],
     *,
     df: pd.DataFrame | None = None,
     n_rand: int = 100,

--- a/pymatviz/widgets/_headless.py
+++ b/pymatviz/widgets/_headless.py
@@ -834,7 +834,7 @@ def _apply_nest_asyncio(loop: asyncio.AbstractEventLoop) -> bool:
     that is a hard error or a soft diagnostic).
     """
     try:
-        import nest_asyncio
+        import nest_asyncio  # ty: ignore[unresolved-import]
     except ImportError:
         return False
     nest_asyncio.apply(loop)

--- a/pymatviz/widgets/matterviz.py
+++ b/pymatviz/widgets/matterviz.py
@@ -49,7 +49,10 @@ def _cache_dir(version: str) -> str:
 def _in_marimo_runtime() -> bool:
     """Return whether execution is inside a live marimo runtime context."""
     try:
-        from marimo._runtime.context import ContextNotInitializedError, get_context
+        from marimo._runtime.context import (  # ty: ignore[unresolved-import]
+            ContextNotInitializedError,
+            get_context,
+        )
     except ImportError:
         return False
     try:
@@ -63,8 +66,8 @@ def _in_marimo_runtime() -> bool:
 def _marimo_esm_url(esm_text: str) -> str | None:
     """Resolve ESM text to a marimo virtual-file URL, or None if unsupported."""
     try:
-        from marimo._output.data.data import js
-        from marimo._runtime.context import get_context
+        from marimo._output.data.data import js  # ty: ignore[unresolved-import]
+        from marimo._runtime.context import get_context  # ty: ignore[unresolved-import]
     except ImportError:
         return None
 

--- a/pymatviz/xrd.py
+++ b/pymatviz/xrd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 
 import numpy as np
@@ -14,7 +15,6 @@ from pymatviz.process_data import is_ase_atoms
 
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
     from typing import TypeAlias
 
 
@@ -107,6 +107,11 @@ def xrd_pattern(  # noqa: D417
     # Convert single object to dict for uniform processing
     if isinstance(patterns, (DiffractionPattern, Structure)):
         patterns = {"XRD Pattern": patterns}
+    elif not isinstance(patterns, Mapping):
+        raise TypeError(
+            "patterns must be a DiffractionPattern, Structure, or mapping of labels "
+            f"to patterns/structures, got {type(patterns).__name__}"
+        )
 
     # Determine show_angles based on number of patterns
     if show_angles is None:

--- a/pymatviz/xrd.py
+++ b/pymatviz/xrd.py
@@ -14,6 +14,7 @@ from pymatviz.process_data import is_ase_atoms
 
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from typing import TypeAlias
 
 
@@ -44,7 +45,7 @@ def format_hkl(hkl: tuple[int, int, int], format_type: HklFormat) -> str:
 
 def xrd_pattern(  # noqa: D417
     patterns: PatternOrStruct
-    | dict[str, PatternOrStruct | tuple[PatternOrStruct, dict[str, Any]]],
+    | Mapping[str, PatternOrStruct | tuple[PatternOrStruct, dict[str, Any]]],
     *,
     peak_width: float = 0.5,
     annotate_peaks: float = 5,
@@ -104,7 +105,7 @@ def xrd_pattern(  # noqa: D417
         )
 
     # Convert single object to dict for uniform processing
-    if not isinstance(patterns, dict):
+    if isinstance(patterns, (DiffractionPattern, Structure)):
         patterns = {"XRD Pattern": patterns}
 
     # Determine show_angles based on number of patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,4 +131,9 @@ dev = ["prek>=0.3.11", "ty>=0.0.34"]
 
 [tool.ty.rules]
 unused-ignore-comment = "ignore"
-unresolved-import = "ignore"
+
+[[tool.ty.overrides]]
+# examples and asset scripts import heavy optional deps (torch, mace, mp_api, dash,
+# marimo, matbench-discovery, ...) that aren't part of any pymatviz extra
+include = ["examples/**", "assets/scripts/**"]
+rules = { unresolved-import = "ignore" }

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ See [`pymatviz/ptable/figures.py`](pymatviz/ptable/figures.py). The module suppo
 |                                     [`ptable_heatmap(atomic_masses)`](pymatviz/ptable/figures.py#L35)                                     | [`ptable_heatmap(compositions, log=True)`](pymatviz/ptable/figures.py#L35) [![fig-icon]](assets/scripts/ptable/ptable_heatmap.py) |
 | :---------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------: |
 |                                                 ![ptable-heatmap-plotly-more-hover-data]                                                  |                                                   ![ptable-heatmap-plotly-log]                                                    |
-|               [`ptable_hists(data)`](pymatviz/ptable/figures.py#L456) [![fig-icon]](assets/scripts/ptable/ptable_hists.py)                | [`ptable_scatter(data, mode="markers")`](pymatviz/ptable/figures.py#L1611) [![fig-icon]](assets/scripts/ptable/ptable_scatter.py) |
+|               [`ptable_hists(data)`](pymatviz/ptable/figures.py#L456) [![fig-icon]](assets/scripts/ptable/ptable_hists.py)                | [`ptable_scatter(data, mode="markers")`](pymatviz/ptable/figures.py#L1612) [![fig-icon]](assets/scripts/ptable/ptable_scatter.py) |
 |                                                          ![ptable-hists-plotly]                                                           |                                                 ![ptable-scatter-plotly-markers]                                                  |
 | [`ptable_heatmap_splits(2_vals_per_elem)`](pymatviz/ptable/figures.py#L927) [![fig-icon]](assets/scripts/ptable/ptable_heatmap_splits.py) |                            [`ptable_heatmap_splits(3_vals_per_elem)`](pymatviz/ptable/figures.py#L927)                            |
 |                                                     ![ptable-heatmap-splits-plotly-2]                                                     |                                                 ![ptable-heatmap-splits-plotly-3]                                                 |
@@ -216,10 +216,10 @@ See [`pymatviz/brillouin.py`](pymatviz/brillouin.py).
 
 See [`pymatviz/xrd.py`](pymatviz/xrd.py).
 
-|             [`xrd_pattern(pattern)`](pymatviz/xrd.py#L45) [![fig-icon]](assets/scripts/xrd/xrd_pattern.py)             |  [`xrd_pattern({key1: patt1, key2: patt2})`](pymatviz/xrd.py#L45)   |
+|             [`xrd_pattern(pattern)`](pymatviz/xrd.py#L46) [![fig-icon]](assets/scripts/xrd/xrd_pattern.py)             |  [`xrd_pattern({key1: patt1, key2: patt2})`](pymatviz/xrd.py#L46)   |
 | :--------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------: |
 |                                                     ![xrd-pattern]                                                     |                       ![xrd-pattern-multiple]                       |
-| [`xrd_pattern(struct_dict, stack="horizontal")`](pymatviz/xrd.py#L45) [![fig-icon]](assets/scripts/xrd/xrd_pattern.py) | [`xrd_pattern(struct_dict, stack="vertical")`](pymatviz/xrd.py#L45) |
+| [`xrd_pattern(struct_dict, stack="horizontal")`](pymatviz/xrd.py#L46) [![fig-icon]](assets/scripts/xrd/xrd_pattern.py) | [`xrd_pattern(struct_dict, stack="vertical")`](pymatviz/xrd.py#L46) |
 |                                            ![xrd-pattern-horizontal-stack]                                             |                    ![xrd-pattern-vertical-stack]                    |
 
 [xrd-pattern]: assets/svg/xrd-pattern.svg
@@ -231,7 +231,7 @@ See [`pymatviz/xrd.py`](pymatviz/xrd.py).
 
 See [`pymatviz/rdf/figures.py`](pymatviz/rdf/figures.py).
 
-| [`element_pair_rdfs(pmg_struct)`](pymatviz/rdf/figures.py#L35) | [`element_pair_rdfs({"A": struct1, "B": struct2})`](pymatviz/rdf/figures.py#L35) [![fig-icon]](assets/scripts/rdf/element_pair_rdfs.py) |
+| [`element_pair_rdfs(pmg_struct)`](pymatviz/rdf/figures.py#L36) | [`element_pair_rdfs({"A": struct1, "B": struct2})`](pymatviz/rdf/figures.py#L36) [![fig-icon]](assets/scripts/rdf/element_pair_rdfs.py) |
 | :------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------: |
 |                 ![element-pair-rdfs-Na8Nb8O24]                 |                                                ![element-pair-rdfs-crystal-vs-amorphous]                                                |
 
@@ -242,10 +242,10 @@ See [`pymatviz/rdf/figures.py`](pymatviz/rdf/figures.py).
 
 See [`pymatviz/coordination/figures.py`](pymatviz/coordination/figures.py).
 
-|              [`coordination_hist(struct_dict)`](pymatviz/coordination/figures.py#L49)              |            [`coordination_hist(struct_dict, by_element=True)`](pymatviz/coordination/figures.py#L49) [![fig-icon]](assets/scripts/coordination/coordination_hist.py)             |
+|              [`coordination_hist(struct_dict)`](pymatviz/coordination/figures.py#L51)              |            [`coordination_hist(struct_dict, by_element=True)`](pymatviz/coordination/figures.py#L51) [![fig-icon]](assets/scripts/coordination/coordination_hist.py)             |
 | :------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 |                                    ![coordination-hist-single]                                     |                                                                  ![coordination-hist-by-structure-and-element]                                                                   |
-| [`coordination_vs_cutoff_line(struct_dict, strategy=None)`](pymatviz/coordination/figures.py#L372) | [`coordination_vs_cutoff_line(struct_dict, strategy=None)`](pymatviz/coordination/figures.py#L372) [![fig-icon]](assets/scripts/coordination/coordination_vs_cutoff_line.py#L52) |
+| [`coordination_vs_cutoff_line(struct_dict, strategy=None)`](pymatviz/coordination/figures.py#L377) | [`coordination_vs_cutoff_line(struct_dict, strategy=None)`](pymatviz/coordination/figures.py#L377) [![fig-icon]](assets/scripts/coordination/coordination_vs_cutoff_line.py#L52) |
 |                                  ![coordination-vs-cutoff-single]                                  |                                                                        ![coordination-vs-cutoff-multiple]                                                                        |
 
 [coordination-hist-single]: assets/svg/coordination-hist-single.svg
@@ -371,7 +371,7 @@ See [`pymatviz/classify/confusion_matrix.py`](pymatviz/classify/confusion_matrix
 
 See [`pymatviz/classify/curves.py`](pymatviz/classify/curves.py).
 
-| [`roc_curve(targets, probs_positive)`](pymatviz/classify/curves.py#L117) [![fig-icon]](assets/scripts/classify/roc_curve.py) | [`precision_recall_curve(targets, probs_positive)`](pymatviz/classify/curves.py#L218) [![fig-icon]](assets/scripts/classify/precision_recall_curve.py) |
+| [`roc_curve(targets, probs_positive)`](pymatviz/classify/curves.py#L125) [![fig-icon]](assets/scripts/classify/roc_curve.py) | [`precision_recall_curve(targets, probs_positive)`](pymatviz/classify/curves.py#L226) [![fig-icon]](assets/scripts/classify/precision_recall_curve.py) |
 | :-------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------: |
 |                                                ![roc-curve-plotly-multiple]                                                 |                                                       ![precision-recall-curve-plotly-multiple]                                                        |
 

--- a/readme.md
+++ b/readme.md
@@ -371,7 +371,7 @@ See [`pymatviz/classify/confusion_matrix.py`](pymatviz/classify/confusion_matrix
 
 See [`pymatviz/classify/curves.py`](pymatviz/classify/curves.py).
 
-| [`roc_curve(targets, probs_positive)`](pymatviz/classify/curves.py#L125) [![fig-icon]](assets/scripts/classify/roc_curve.py) | [`precision_recall_curve(targets, probs_positive)`](pymatviz/classify/curves.py#L226) [![fig-icon]](assets/scripts/classify/precision_recall_curve.py) |
+| [`roc_curve(targets, probs_positive)`](pymatviz/classify/curves.py#L124) [![fig-icon]](assets/scripts/classify/roc_curve.py) | [`precision_recall_curve(targets, probs_positive)`](pymatviz/classify/curves.py#L225) [![fig-icon]](assets/scripts/classify/precision_recall_curve.py) |
 | :-------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------: |
 |                                                ![roc-curve-plotly-multiple]                                                 |                                                       ![precision-recall-curve-plotly-multiple]                                                        |
 

--- a/tests/cluster/composition/test_embed.py
+++ b/tests/cluster/composition/test_embed.py
@@ -72,10 +72,10 @@ def test_one_hot_encode_pandas_input() -> None:
 def test_one_hot_encode_invalid_input() -> None:
     """Test one-hot encoding with invalid input."""
     with pytest.raises(ValueError, match="Invalid composition="):
-        one_hot_encode([1, 2, 3])
+        one_hot_encode([1, 2, 3])  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(ValueError, match="Invalid composition="):
-        one_hot_encode([["H2O"]])
+        one_hot_encode([["H2O"]])  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(
@@ -124,10 +124,10 @@ def test_matminer_featurize_invalid_input() -> None:
     """Test matminer featurization with invalid input."""
     pytest.importorskip("matminer")
     with pytest.raises(ValueError, match="Invalid composition="):
-        matminer_featurize([1, 2, 3])
+        matminer_featurize([1, 2, 3])  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(ValueError, match="Invalid composition="):
-        matminer_featurize([["H2O"]])
+        matminer_featurize([["H2O"]])  # ty: ignore[invalid-argument-type]
 
 
 def test_matminer_featurize_invalid_feature_subset() -> None:

--- a/tests/cluster/composition/test_plot.py
+++ b/tests/cluster/composition/test_plot.py
@@ -1332,6 +1332,7 @@ def test_precomputed_embeddings_attributes(sample_df: pd.DataFrame) -> None:
     assert isinstance(fig, ClusterFigure)
 
     # Check that embeddings match the original embeddings
+    assert fig.embeddings is not None
     assert np.allclose(fig.embeddings, original_embeddings)
 
     # Check that projector is the correct type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,7 +167,7 @@ def fe3co4_disordered() -> IStructure:
 
 
 @pytest.fixture
-def fe3co4_disordered_with_props(fe3co4_disordered: Structure) -> Structure:
+def fe3co4_disordered_with_props(fe3co4_disordered: IStructure) -> IStructure:
     """Disordered Fe3C-O2 structure with magnetic moment and force site properties."""
     site_props = {
         "magmom": [[0, 0, 1], [0, 0, -1]],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import json
 from glob import glob
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import numpy as np
 import pandas as pd
@@ -13,7 +13,7 @@ import pytest
 from monty.io import zopen
 from monty.json import MontyDecoder
 from plotly.subplots import make_subplots
-from pymatgen.core import Lattice, Structure
+from pymatgen.core import IStructure, Lattice, Structure
 from pymatgen.io.ase import AseAtomsAdaptor
 
 from pymatviz.utils.testing import TEST_FILES, load_phonopy_nacl
@@ -77,7 +77,10 @@ si2_ru2_pr2_struct = Structure(
     ],
 )
 SI_STRUCTS = (SI2_STRUCT, si2_ru2_pr2_struct)
-SI_ATOMS = tuple(map(AseAtomsAdaptor.get_atoms, SI_STRUCTS))
+# cast since AseAtomsAdaptor.get_atoms returns MSONAtoms | pymatgen.io.ase.Atoms
+SI_ATOMS = cast(
+    "tuple[ase.Atoms, ase.Atoms]", tuple(map(AseAtomsAdaptor.get_atoms, SI_STRUCTS))
+)
 
 
 @pytest.fixture
@@ -88,7 +91,8 @@ def structures() -> tuple[Structure, Structure]:
 
 @pytest.fixture
 def ase_atoms() -> tuple[ase.Atoms, ase.Atoms]:
-    return tuple(copy.copy(atoms) for atoms in SI_ATOMS)
+    atoms1, atoms2 = SI_ATOMS
+    return copy.copy(atoms1), copy.copy(atoms2)
 
 
 @pytest.fixture
@@ -135,7 +139,7 @@ def glass_formulas() -> list[str]:
 @pytest.fixture
 def df_float() -> pd.DataFrame:
     np_rng = np.random.default_rng(seed=0)
-    return pd.DataFrame(np_rng.random(size=(30, 5)), columns=[*"ABCDE"])
+    return pd.DataFrame(np_rng.random(size=(30, 5)), columns=pd.Index([*"ABCDE"]))
 
 
 @pytest.fixture
@@ -153,7 +157,7 @@ def phonopy_nacl() -> Phonopy:
 
 
 @pytest.fixture
-def fe3co4_disordered() -> Structure:
+def fe3co4_disordered() -> IStructure:
     """Disordered Fe3C-O2 structure without site properties. This structure has
     disordered sites with Fe:C ratio of 3:1.
     """

--- a/tests/coordination/test_coordination_plotly.py
+++ b/tests/coordination/test_coordination_plotly.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from pymatgen.analysis.local_env import CrystalNN, NearNeighbors, VoronoiNN
@@ -74,13 +74,14 @@ def test_coordination_hist_custom_strategy(
     """Test coordination_hist with a custom strategy."""
     fig = coordination_hist(structures[1], strategy=strategy)
     assert len(fig.data) == 3
-    expected_max_x = {
+    strategy_to_max_x: dict[Any, int] = {
         3.0: 9,
         6: 47,
         VoronoiNN(): 19,
         CrystalNN: 10,
         CrystalNN(distance_cutoffs=(0.5, 2)): 10,
-    }[strategy]
+    }
+    expected_max_x = strategy_to_max_x[strategy]
     actual_max_x = max(max(trace.x) for trace in fig.data)
     assert actual_max_x == expected_max_x, f"{actual_max_x=} for {strategy=}"
 
@@ -144,7 +145,7 @@ def test_coordination_hist_bar_kwargs(structures: Sequence[Structure]) -> None:
 def test_coordination_hist_invalid_input() -> None:
     """Test coordination_hist with invalid input."""
     with pytest.raises(TypeError):
-        coordination_hist("invalid input")
+        coordination_hist("invalid input")  # ty: ignore[invalid-argument-type]
 
 
 def test_coordination_hist_empty() -> None:
@@ -231,7 +232,7 @@ def test_coordination_vs_cutoff_line_invalid_input() -> None:
     # Test empty sequences
     for inputs in ([], ()):
         with pytest.raises(ValueError, match="Cannot plot empty set of structures"):
-            coordination_vs_cutoff_line(inputs)
+            coordination_vs_cutoff_line(inputs)  # ty: ignore[invalid-argument-type]
 
     # Test invalid types
     for inputs in ("invalid input", None):
@@ -240,14 +241,14 @@ def test_coordination_vs_cutoff_line_invalid_input() -> None:
             match="Input must be a pymatgen Structure, IStructure, Molecule, "
             "IMolecule, ASE Atoms, or PhonopyAtoms object",
         ):
-            coordination_vs_cutoff_line(inputs)
+            coordination_vs_cutoff_line(inputs)  # ty: ignore[invalid-argument-type]
 
 
 def test_coordination_vs_cutoff_line_invalid_strategy() -> None:
     """Test coordination_vs_cutoff_line with invalid strategy."""
     structure = Structure(Lattice.cubic(5), ["Si"], [[0, 0, 0]])
     with pytest.raises(TypeError, match="Invalid strategy="):
-        coordination_vs_cutoff_line(structure, strategy="invalid")
+        coordination_vs_cutoff_line(structure, strategy="invalid")  # ty: ignore[invalid-argument-type]
 
 
 def test_coordination_hist_hover_text_formatting(

--- a/tests/phonons/test_phonon_helpers.py
+++ b/tests/phonons/test_phonon_helpers.py
@@ -166,7 +166,7 @@ def test_phonon_bands_raises(
         match=f"Only {PhononBands.__name__}, phonopy BandStructure or dict supported, "
         "got str",
     ):
-        pmv.phonon_bands("invalid input")
+        pmv.phonon_bands("invalid input")  # ty: ignore[invalid-argument-type]
 
     # issues warning when requesting some available and some unavailable branches
     pmv.phonon_bands(

--- a/tests/phonons/test_phonon_plotly.py
+++ b/tests/phonons/test_phonon_plotly.py
@@ -68,7 +68,7 @@ def test_phonon_dos(
 def test_phonon_dos_raises(phonon_bands_doses_mp_2758: BandsDoses) -> None:
     """Test phonon_dos raises appropriate errors."""
     with pytest.raises(TypeError, match="supported, got str"):
-        pmv.phonon_dos("invalid input")
+        pmv.phonon_dos("invalid input")  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(ValueError, match="Empty DOS dict"):
         pmv.phonon_dos({})
@@ -249,10 +249,12 @@ def test_phonon_dos_with_phonopy(phonopy_nacl: Phonopy) -> None:
     """Test that phonon_dos works with phonopy TotalDos objects."""
     phonopy_nacl.run_mesh([5, 5, 5])
     phonopy_nacl.run_total_dos(freq_pitch=1, use_tetrahedron_method=False)
+    total_dos = phonopy_nacl.total_dos
+    assert total_dos is not None
 
     # Test single TotalDos
     fig = pmv.phonon_dos(
-        phonopy_nacl.total_dos,
+        total_dos,
         stack=False,
         sigma=0.1,
         normalize="max",
@@ -263,7 +265,7 @@ def test_phonon_dos_with_phonopy(phonopy_nacl: Phonopy) -> None:
     assert fig.layout.yaxis.title.text == "Density of States"
 
     # Test dictionary of TotalDos objects
-    dos_dict = {"DFT": phonopy_nacl.total_dos, "ML": phonopy_nacl.total_dos}
+    dos_dict = {"DFT": total_dos, "ML": total_dos}
     fig = pmv.phonon_dos(dos_dict, stack=True, sigma=0.1, normalize="max", units="THz")
     assert isinstance(fig, go.Figure)
     assert {trace.name for trace in fig.data} == {"DFT", "ML"}
@@ -282,16 +284,18 @@ def test_phonon_bands_with_phonopy(phonopy_nacl: Phonopy) -> None:
 
     # Run band structure calculation
     phonopy_nacl.run_band_structure(paths=list(bands.values()))
+    band_structure = phonopy_nacl.band_structure
+    assert band_structure is not None
 
     # Test single band structure
-    fig = pmv.phonon_bands(phonopy_nacl.band_structure)
+    fig = pmv.phonon_bands(band_structure)
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == 6
 
     # Test multiple band structures in dict
     bands_dict = {
-        "NaCl (phonopy)": phonopy_nacl.band_structure,
-        "DFT": phonopy_nacl.band_structure,
+        "NaCl (phonopy)": band_structure,
+        "DFT": band_structure,
     }
     fig = pmv.phonon_bands(bands_dict)
     assert isinstance(fig, go.Figure)

--- a/tests/ptable/plotly/test_ptable_heatmap_splits.py
+++ b/tests/ptable/plotly/test_ptable_heatmap_splits.py
@@ -562,7 +562,7 @@ def test_ptable_heatmap_splits_dataframe_input() -> None:
             "Formation Energy": [1.23, 3.45, 5.67],
             "Band Gap": [2.34, 4.56, 6.78],
         },
-        index=["Fe", "O", "H"],
+        index=pd.Index(["Fe", "O", "H"]),
     )
 
     # Test default hover tooltip with DataFrame

--- a/tests/rdf/test_rdf_helpers.py
+++ b/tests/rdf/test_rdf_helpers.py
@@ -391,7 +391,7 @@ def test_calculate_rdf_with_no_atoms_of_requested_species(
 )
 def test_calculate_rdf_input_validation(
     test_input: dict[str, str | float],
-    expected_err_cls: type | tuple[type, ...],
+    expected_err_cls: type[Exception] | tuple[type[Exception], ...],
     error_msg: str | None,
 ) -> None:
     """Test input validation in calculate_rdf function."""

--- a/tests/structure/test_structure_helpers.py
+++ b/tests/structure/test_structure_helpers.py
@@ -40,7 +40,7 @@ from pymatviz.structure.helpers import (
     get_struct_prop,
     get_subplot_title,
 )
-from pymatviz.typing import RgbColorType, Xyz
+from pymatviz.typing import AnyStructure, RgbColorType, Xyz
 
 
 @pytest.fixture
@@ -340,7 +340,7 @@ def test_draw_site(
 def test_get_subplot_title(
     structures: list[Structure],
     struct_key: Any,
-    subplot_title: Callable[[Structure, Hashable], str | dict[str, Any]] | None,
+    subplot_title: Callable[[AnyStructure, Hashable], str | dict[str, Any]] | None,
     expected_text: str,
 ) -> None:
     structure = structures[0]
@@ -391,11 +391,11 @@ def test_draw_vector(
 ) -> None:
     """Test vector drawing with various settings."""
     fig = go.Figure()
-    start, vector = np.array(start), np.array(vector)
+    start_arr, vector_arr = np.array(start), np.array(vector)
 
     # Draw vector and check trace count
     initial_trace_count = len(fig.data)
-    draw_vector(fig, start, vector, is_3d=is_3d, arrow_kwargs=arrow_kwargs)
+    draw_vector(fig, start_arr, vector_arr, is_3d=is_3d, arrow_kwargs=arrow_kwargs)
     assert len(fig.data) - initial_trace_count == expected_traces
 
     # Check trace properties based on dimensionality
@@ -418,7 +418,7 @@ def test_draw_vector(
 
     # Check scaling
     scale = arrow_kwargs.get("scale", 1.0)
-    end_point = start + vector * scale
+    end_point = start_arr + vector_arr * scale
     if is_3d:
         assert_allclose(fig.data[-2].x[1], end_point[0])
         assert_allclose(fig.data[-2].y[1], end_point[1])
@@ -923,6 +923,7 @@ def test_draw_bonds_advanced(
 
     elif test_case == "rotation_with_image":
         # Check bonds are rotated and only go to visible image atoms
+        assert rotation_matrix is not None
         rotated_coords = tuple(np.dot(np.array(image_coords), rotation_matrix))
         for trace in fig.data:
             if max(trace.x) > 3.0 or max(trace.y) > 3.0:

--- a/tests/structure/test_structure_helpers.py
+++ b/tests/structure/test_structure_helpers.py
@@ -923,7 +923,8 @@ def test_draw_bonds_advanced(
 
     elif test_case == "rotation_with_image":
         # Check bonds are rotated and only go to visible image atoms
-        assert rotation_matrix is not None
+        if rotation_matrix is None or image_coords is None:
+            return
         rotated_coords = tuple(np.dot(np.array(image_coords), rotation_matrix))
         for trace in fig.data:
             if max(trace.x) > 3.0 or max(trace.y) > 3.0:

--- a/tests/structure/test_structure_plotly.py
+++ b/tests/structure/test_structure_plotly.py
@@ -6,7 +6,14 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import pytest
-from pymatgen.core import Composition, Lattice, Species, Structure
+from pymatgen.core import (
+    Composition,
+    IMolecule,
+    IStructure,
+    Lattice,
+    Species,
+    Structure,
+)
 
 import pymatviz as pmv
 from pymatviz.colors import ELEM_COLORS_JMOL, ELEM_COLORS_VESTA
@@ -29,7 +36,7 @@ from pymatviz.structure.helpers import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Hashable
 
-    from pymatviz.typing import Xyz
+    from pymatviz.typing import AnyStructure, Xyz
 
 COORDS: Final[tuple[Xyz, Xyz]] = ((0, 0, 0), (0.5, 0.5, 0.5))
 lattice_cubic = 5 * np.eye(3)  # 5 Å cubic lattice
@@ -72,7 +79,9 @@ def _get_all_rendered_site_info(
     for site_primary in structure:
         if hasattr(site_primary.species, "elements"):  # Disordered
             el_amt_dict = site_primary.species.get_el_amt_dict()
-            symbol = max(el_amt_dict, key=el_amt_dict.get) if el_amt_dict else "X"
+            symbol = (
+                max(el_amt_dict, key=el_amt_dict.__getitem__) if el_amt_dict else "X"
+            )
         elif hasattr(site_primary.species, "symbol"):  # Element
             symbol = site_primary.species.symbol
         elif hasattr(site_primary.species, "element"):  # Specie
@@ -687,7 +696,7 @@ def test_structure_2d_invalid_input() -> None:
     """Test that structure_2d raises errors for invalid inputs."""
     expected_err_msg = "Input must be a pymatgen Structure, IStructure, Molecule"
     with pytest.raises(TypeError, match=expected_err_msg):
-        pmv.structure_2d("invalid input")
+        pmv.structure_2d("invalid input")  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(ValueError, match="Cannot plot empty set of structures"):
         pmv.structure_2d([])
@@ -949,11 +958,10 @@ def test_structure_3d(
         assert len(site_traces) > 0, "No site traces found when show_sites is True"
 
         # Get the first structure for validation
-        test_structure = (
-            structures_input
-            if not isinstance(structures_input, dict)
-            else next(iter(structures_input.values()))
-        )
+        if isinstance(structures_input, IStructure):
+            test_structure = structures_input
+        else:
+            test_structure = next(iter(structures_input.values()))
 
         # Count ordered vs disordered sites
         ordered_sites = [
@@ -1123,7 +1131,8 @@ def test_structure_3d_multiple() -> None:
     assert len(fig.layout.annotations) == expected_n_subplot_titles
 
     # Test subplot_title and its interaction with legend annotations
-    def custom_subplot_title_func(struct: Structure, key: Hashable) -> str:
+    def custom_subplot_title_func(struct: AnyStructure, key: Hashable) -> str:
+        assert isinstance(struct, (IStructure, IMolecule))  # narrow for ty
         return f"{key} - {struct.formula}"
 
     fig = pmv.structure_3d(struct_series, subplot_title=custom_subplot_title_func)
@@ -1203,7 +1212,9 @@ def test_structure_3d_subplot_title_coverage() -> None:
     struct2 = Structure(lattice, ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
 
     # Test with custom subplot_title function that returns dict with y and yanchor
-    def custom_title_with_position(_struct: Structure, k: Hashable) -> dict[str, Any]:
+    def custom_title_with_position(
+        _struct: AnyStructure, k: Hashable
+    ) -> dict[str, Any]:
         return {"text": f"Structure {k}", "x": 0.5, "y": 0.95, "yanchor": "top"}
 
     fig = pmv.structure_3d(

--- a/tests/test_brillouin.py
+++ b/tests/test_brillouin.py
@@ -9,6 +9,7 @@ import pytest
 from pymatgen.core import Structure
 
 from pymatviz.brillouin import brillouin_zone_3d
+from pymatviz.process_data import is_ase_atoms
 from pymatviz.utils.testing import TEST_FILES
 from tests.conftest import SI_ATOMS, SI_STRUCTS
 
@@ -249,6 +250,7 @@ def test_brillouin_zone_3d_subplot_grid(structures: list[Structure]) -> None:
 
     # Test custom subplot titles
     def subplot_title(struct: AnyStructure, key: Hashable) -> str:
+        assert not is_ase_atoms(struct)  # narrow out ase Atoms for ty
         formula = struct.formula
         return f"Custom {key} - {formula}"
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -143,7 +143,7 @@ def test_df_to_html(
 def test_save_fig_type_error(tmp_path: Path) -> None:
     """save_fig raises TypeError for non-Figure input."""
     with pytest.raises(TypeError, match=r"Unsupported figure type.*expected plotly"):
-        pmv.save_fig("not a figure", f"{tmp_path}/dummy.html", env_disable=[])
+        pmv.save_fig("not a figure", f"{tmp_path}/dummy.html", env_disable=[])  # ty: ignore[invalid-argument-type]
 
 
 def test_save_fig_prec_rounds_floats(tmp_path: Path) -> None:
@@ -217,7 +217,7 @@ def test_save_fig_restores_pdf_mutations_on_write_error(tmp_path: Path) -> None:
 def test_save_and_compress_svg_type_error() -> None:
     """save_and_compress_svg raises TypeError for non-Figure."""
     with pytest.raises(TypeError, match="fig must be a plotly Figure"):
-        pmv.io.save_and_compress_svg("not a figure", "test")
+        pmv.io.save_and_compress_svg("not a figure", "test")  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -65,8 +65,8 @@ def test_notebook_mode_toggle(enable: bool) -> None:
     assert hasattr(Structure, "_repr_mimebundle_") == enable
 
     if enable:
-        assert callable(Structure._ipython_display_)
-        assert callable(Structure._repr_mimebundle_)
+        assert callable(Structure._ipython_display_)  # ty: ignore[unresolved-attribute]
+        assert callable(Structure._repr_mimebundle_)  # ty: ignore[unresolved-attribute]
 
     # Check optional classes
     for module_name, class_name in [
@@ -177,11 +177,11 @@ def test_fallback_without_pymatviz(
 
     pmv.notebook_mode(on=True)
     try:
-        structures[0]._ipython_display_()
+        structures[0]._ipython_display_()  # ty: ignore[unresolved-attribute]
         assert len(published_data) == 1
         assert "text/plain" in published_data[0]
 
-        mime = structures[0]._repr_mimebundle_()
+        mime = structures[0]._repr_mimebundle_()  # ty: ignore[unresolved-attribute]
         assert "text/plain" in mime
     finally:
         pmv.notebook_mode(on=False)
@@ -236,7 +236,7 @@ def test_phonopy_dos_integration(monkeypatch: pytest.MonkeyPatch) -> None:
         from phonopy.phonon.dos import TotalDos
 
         assert hasattr(TotalDos, "_ipython_display_")
-        phonopy_nacl.total_dos._ipython_display_()
+        phonopy_nacl.total_dos._ipython_display_()  # ty: ignore[unresolved-attribute]
         assert len(published_data) == 1
         assert "text/plain" in published_data[0]
     finally:

--- a/tests/test_process_data.py
+++ b/tests/test_process_data.py
@@ -418,19 +418,21 @@ class DummyClass:
 
 @pytest.mark.parametrize("cls", [Structure, DummyClass, Lattice])
 def test_normalize_to_dict(cls: type[Structure | DummyClass | Lattice]) -> None:
-    single_instance = {
+    instance_map: dict[type, Any] = {
         Structure: Structure(Lattice.cubic(5), ["Si"], [[0, 0, 0]]),
         DummyClass: DummyClass("dummy"),
         Lattice: Lattice.cubic(5),
-    }[cls]
+    }
+    single_instance = instance_map[cls]
     result = pmv_pd.normalize_to_dict(single_instance, cls=cls)
     assert isinstance(result, dict)
     assert len(result) == 1
-    expected_key = {
+    key_map: dict[type, str] = {
         Structure: "Si1",
         DummyClass: "dummy",
         Lattice: "Lattice",
-    }[cls]
+    }
+    expected_key = key_map[cls]
     assert set(result) == {expected_key}
     assert isinstance(result[expected_key], cls)
 
@@ -439,11 +441,12 @@ def test_normalize_to_dict(cls: type[Structure | DummyClass | Lattice]) -> None:
     assert isinstance(result, dict)
     assert len(result) == 3
     assert all(isinstance(s, cls) for s in result.values())
-    expected_keys = {
+    keys_map: dict[type, set[str]] = {
         Structure: {"Si1", "Si1 1", "Si1 2"},
         DummyClass: {"dummy", "dummy 1", "dummy 2"},
         Lattice: {"Lattice", "Lattice 1", "Lattice 2"},
-    }[cls]
+    }
+    expected_keys = keys_map[cls]
     assert set(result) == expected_keys
 
     instance_dict = {"item1": single_instance, "item2": single_instance}
@@ -470,7 +473,7 @@ def test_normalize_to_dict(cls: type[Structure | DummyClass | Lattice]) -> None:
 def test_normalize_to_dict_mixed_classes(
     cls1: type[Structure | DummyClass], cls2: type[Structure | DummyClass]
 ) -> None:
-    obj_map = {
+    obj_map: dict[type, Any] = {
         Structure: Structure(Lattice.cubic(5), ["Si"], [[0, 0, 0]]),
         DummyClass: DummyClass("dummy1"),
         Lattice: Lattice.cubic(5),
@@ -497,7 +500,7 @@ def test_df_to_arrays() -> None:
     assert y1 == pytest.approx(y_pred)
 
     with pytest.raises(TypeError, match="df should be pandas DataFrame or None"):
-        pmv_pd.df_to_arrays("foo", y_true, y_pred)
+        pmv_pd.df_to_arrays("foo", y_true, y_pred)  # ty: ignore[invalid-argument-type]
 
     bad_col_name = "not-real-col-name"
     with pytest.raises(KeyError) as exc:
@@ -507,11 +510,11 @@ def test_df_to_arrays() -> None:
 
 
 def test_df_to_arrays_strict() -> None:
-    args = pmv_pd.df_to_arrays(42, "foo", "bar", strict=False)
+    args = pmv_pd.df_to_arrays(42, "foo", "bar", strict=False)  # ty: ignore[invalid-argument-type]
     assert args == ["foo", "bar"]
 
     with pytest.raises(TypeError, match="df should be pandas DataFrame or None"):
-        pmv_pd.df_to_arrays(42, "foo", "bar", strict=True)
+        pmv_pd.df_to_arrays(42, "foo", "bar", strict=True)  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sunburst.py
+++ b/tests/test_sunburst.py
@@ -252,7 +252,7 @@ def test_chem_sys_sunburst_input_types(structures: list[Structure]) -> None:
 
     # Test with invalid input type
     with pytest.raises(TypeError, match="Expected str, Composition or Structure"):
-        pmv.chem_sys_sunburst([1])
+        pmv.chem_sys_sunburst([1])  # ty: ignore[invalid-argument-type]
 
 
 def test_chem_sys_sunburst_high_arity() -> None:

--- a/tests/test_sunburst.py
+++ b/tests/test_sunburst.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+import types
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 import pandas as pd
@@ -78,6 +80,39 @@ def test_spacegroup_sunburst_other_types(
     # test with pymatgen structures
     fig = spacegroup_sunburst(structures)
     assert isinstance(fig, go.Figure)
+
+
+def test_spacegroup_sunburst_requires_moyopy(
+    structures: list[Structure], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Raise a helpful error when moyopy is missing for Structure input."""
+    monkeypatch.setitem(sys.modules, "moyopy", None)
+    with pytest.raises(RuntimeError, match=r"moyopy is required.*pip install moyopy"):
+        spacegroup_sunburst(structures)
+
+
+def test_spacegroup_sunburst_reports_moyopy_conversion_failure(
+    structures: list[Structure], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Report index and type when moyopy cannot convert a structure."""
+
+    class MockMoyoAdapter:
+        """Mock adapter that rejects all structures."""
+
+        @staticmethod
+        def from_py_obj(_struct: Any) -> None:
+            """Raise the same broad kind of error as unsupported moyopy input."""
+            raise TypeError("unsupported structure")
+
+    mock_interface = types.ModuleType("moyopy.interface")
+    mock_moyopy = types.ModuleType("moyopy")
+    mock_moyopy.__dict__["MoyoDataset"] = lambda _cell: None
+    mock_interface.__dict__["MoyoAdapter"] = MockMoyoAdapter
+    monkeypatch.setitem(sys.modules, "moyopy", mock_moyopy)
+    monkeypatch.setitem(sys.modules, "moyopy.interface", mock_interface)
+
+    with pytest.raises(TypeError, match="structure at index 0 \\(Structure\\)"):
+        spacegroup_sunburst(structures)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_xrd.py
+++ b/tests/test_xrd.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Literal
 
 import plotly.graph_objects as go
@@ -33,6 +34,9 @@ BI2_ZR2_O7_STRUCT = Structure.from_file(
     f"{TEST_FILES}/xrd/Bi2Zr2O7-Fm3m-experimental-sqs.cif"
 )
 BI2_ZR2_O7_XRD = XRDCalculator().get_pattern(BI2_ZR2_O7_STRUCT)
+ORDERED_XRD_INPUT = OrderedDict(
+    [("Structure", BI2_ZR2_O7_STRUCT), ("Pattern", MOCK_DIFFRACTION_PATTERN)]
+)
 
 
 @pytest.mark.parametrize(
@@ -42,6 +46,7 @@ BI2_ZR2_O7_XRD = XRDCalculator().get_pattern(BI2_ZR2_O7_STRUCT)
         (BI2_ZR2_O7_XRD, 1),
         (BI2_ZR2_O7_STRUCT, 1),
         ({"Structure": BI2_ZR2_O7_STRUCT, "Pattern": MOCK_DIFFRACTION_PATTERN}, 2),
+        (ORDERED_XRD_INPUT, 2),
     ],
 )
 def test_xrd_pattern_input_types(input_data: Any, expected_traces: int) -> None:

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -195,7 +195,7 @@ def test_annotate(color: str, plotly_scatter: go.Figure) -> None:
 
 def test_annotate_invalid_fig() -> None:
     with pytest.raises(TypeError, match="Expected plotly Figure"):
-        pmv.utils.annotate("test", fig="invalid")
+        pmv.utils.annotate("test", fig="invalid")  # ty: ignore[invalid-argument-type]
 
 
 def test_annotate_faceted_plotly(plotly_faceted_scatter: go.Figure) -> None:
@@ -274,7 +274,7 @@ def test_get_fig_xy_range(plotly_scatter: go.Figure) -> None:
     # currently suboptimal behavior: fig must be passed as kwarg to trigger helpful
     # error message
     with pytest.raises(TypeError, match="Expected plotly Figure"):
-        pmv.utils.get_fig_xy_range(fig="invalid")
+        pmv.utils.get_fig_xy_range(fig="invalid")  # ty: ignore[invalid-argument-type]
 
 
 def test_get_font_color() -> None:
@@ -293,7 +293,7 @@ def test_get_font_color_invalid_input() -> None:
     with pytest.raises(
         TypeError, match=re.escape(f"Input must be plotly Figure, got {type(fig)=}")
     ):
-        pmv.utils.get_font_color(fig)
+        pmv.utils.get_font_color(fig)  # ty: ignore[invalid-argument-type]
 
 
 def test_get_plotly_font_color_default() -> None:

--- a/tests/widgets/test_headless.py
+++ b/tests/widgets/test_headless.py
@@ -77,7 +77,7 @@ def test_has_running_event_loop_inside_loop() -> None:
 def test_render_widget_headless_dispatches_async_in_event_loop() -> None:
     """render_widget_headless calls _render_widget_async when inside an event loop."""
     pytest.importorskip("nest_asyncio")
-    import nest_asyncio
+    import nest_asyncio  # ty: ignore[unresolved-import]
 
     fake_png = b"\x89PNG"
 

--- a/tests/widgets/test_mime.py
+++ b/tests/widgets/test_mime.py
@@ -123,7 +123,7 @@ def test_marimo_display_registered() -> None:
         assert callable(display_method), f"{cls.__name__} missing callable _display_"
 
     composition_obj = Composition("Fe2O3")
-    widget = composition_obj._display_()
+    widget = composition_obj._display_()  # ty: ignore[unresolved-attribute]
     expected_widget = create_widget(composition_obj)
     assert widget.widget_type == expected_widget.widget_type
     assert widget.composition == expected_widget.composition


### PR DESCRIPTION
## Summary

- Migrate the pre-commit ty hook from a local entry to [astral-sh/ty-pre-commit](https://github.com/astral-sh/ty-pre-commit) with `--isolated` and `--all-extras`, and scope `unresolved-import` ignores to `examples/**` and `assets/scripts/**` only.
- Fix ty-reported type errors across plotting, structure, coordination, RDF, classification, and data-processing modules: `TypeIs` guards for ASE/Phonopy atoms, `normalize_periodic_structures`, tighter bond/cell typing, `Mapping` over bare `dict`, and targeted `ty: ignore` comments where runtime checks already narrow types.
- Update tests, examples, asset scripts, and README source-link line numbers to match the refactored signatures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `normalize_periodic_structures` helper for improved periodic structure handling
  * Expanded input flexibility: visualization functions now accept `Mapping` and `pandas.Series` in addition to `dict` inputs

* **Bug Fixes**
  * Added runtime validation for optional phonopy band structure and DOS results
  * Improved null-safety checks for spectroscopic data objects
  * Enhanced element selection from ordered dictionaries

* **Refactor**
  * Streamlined type annotations across the codebase for improved type safety
  * Updated pre-commit hook configuration for better code quality checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->