### PR TITLE
Reactive widget linking + interaction-state traits (all widgets reactive via generic bridge)

### DIFF
--- a/examples/widgets/vscode_interactive_demo.py
+++ b/examples/widgets/vscode_interactive_demo.py
@@ -251,7 +251,7 @@ linked_scatter = pmv.ScatterPlotWidget(
 linked_structure = pmv.StructureWidget(
     structure=linked_frames[0], show_bonds=True, style="height: 400px; width: 100%;"
 )
-# clicking a scatter point now updates linked_structure (and vice versa)
+# clicking a scatter point now updates linked_structure
 selection_link = pmv.link_selection(
     linked_scatter, linked_structure, structures=linked_frames
 )

--- a/examples/widgets/vscode_interactive_demo.py
+++ b/examples/widgets/vscode_interactive_demo.py
@@ -18,7 +18,7 @@ from typing import Final
 
 import numpy as np
 from ase.build import bulk, molecule
-from ipywidgets import GridBox, Layout
+from ipywidgets import GridBox, HBox, Layout
 from monty.io import zopen
 from monty.json import MontyDecoder
 from phonopy.structure.atoms import PhonopyAtoms
@@ -225,6 +225,37 @@ trajectory_widget = pmv.TrajectoryWidget(
     style="height: 600px;",
 )
 trajectory_widget.show()
+
+
+# %% [markdown]
+# ### Linked Scatter + Structure (Python-side reactivity)
+# Compose independent widgets and link them with `pmv.link_selection`: clicking a
+# point in the scatter plot shows the matching frame in the structure viewer, with
+# the link expressed in Python (no JS bundling). The reverse also holds -- driving
+# the scatter highlight from Python is reactive. See
+# https://github.com/janosh/pymatviz/issues/354.
+
+
+# %% Linked views — energy scatter drives a structure viewer
+linked_frames = [step["structure"] for step in trajectory]
+linked_energies = [step["energy"] for step in trajectory]
+
+linked_scatter = pmv.ScatterPlotWidget(
+    series=[
+        {"x": list(range(len(linked_frames))), "y": linked_energies, "label": "energy"}
+    ],
+    x_axis={"label": "step"},
+    y_axis={"label": "energy (eV)"},
+    style="height: 400px; width: 100%;",
+)
+linked_structure = pmv.StructureWidget(
+    structure=linked_frames[0], show_bonds=True, style="height: 400px; width: 100%;"
+)
+# clicking a scatter point now updates linked_structure (and vice versa)
+selection_link = pmv.link_selection(
+    linked_scatter, linked_structure, structures=linked_frames
+)
+HBox([linked_scatter, linked_structure], layout=Layout(width="100%"))
 
 
 # === Plot Widgets ===

--- a/pymatviz/__init__.py
+++ b/pymatviz/__init__.py
@@ -105,8 +105,10 @@ from pymatviz.widgets import (
     SpacegroupBarPlotWidget,
     StructureWidget,
     TrajectoryWidget,
+    WidgetLink,
     XrdWidget,
     configure_assets,
+    link_selection,
 )
 from pymatviz.xrd import xrd_pattern
 

--- a/pymatviz/widgets/__init__.py
+++ b/pymatviz/widgets/__init__.py
@@ -17,6 +17,7 @@ from pymatviz.widgets.dos import DosWidget
 from pymatviz.widgets.fermi_surface import FermiSurfaceWidget
 from pymatviz.widgets.heatmap_matrix import HeatmapMatrixWidget
 from pymatviz.widgets.histogram import HistogramWidget
+from pymatviz.widgets.link import WidgetLink, link_selection
 from pymatviz.widgets.matterviz import configure_assets
 from pymatviz.widgets.mime import register_matterviz_widgets
 from pymatviz.widgets.periodic_table import PeriodicTableWidget

--- a/pymatviz/widgets/link.py
+++ b/pymatviz/widgets/link.py
@@ -1,0 +1,208 @@
+"""Reactively link a shared selection index across MatterViz widgets.
+
+This is the Python-side answer to building ``structure+scatter``-style coordinated
+views by composition instead of bundling the link at the JS level (see
+https://github.com/janosh/pymatviz/issues/354). It builds on the interaction-state
+traitlets that sync both ways with the frontend (``TrajectoryWidget``'s
+``current_step_idx``, ``ScatterPlotWidget``'s ``active_point``/``selected_point``,
+``StructureWidget``'s ``structure``): observing one widget's selection and writing
+it to the others keeps a shared "current index" in sync.
+
+Example:
+    >>> import pymatviz as pmv
+    >>> scatter = pmv.ScatterPlotWidget(series=[{"x": steps, "y": energies}])
+    >>> structure = pmv.StructureWidget(structure=frames[0])
+    >>> link = pmv.widgets.link_selection(scatter, structure, structures=frames)
+    >>> # clicking a scatter point now shows the matching frame in `structure`
+    >>> link.unlink()  # stop syncing
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any
+
+from pymatviz.widgets.scatter_plot import ScatterPlotWidget
+from pymatviz.widgets.structure import StructureWidget, structure_to_dict
+from pymatviz.widgets.trajectory import TrajectoryWidget
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pymatviz.widgets.matterviz import MatterVizWidget
+
+
+_LINKABLE = (TrajectoryWidget, ScatterPlotWidget, StructureWidget)
+
+
+class WidgetLink:
+    """Keep a shared selection index in sync across linked MatterViz widgets.
+
+    Each supported widget contributes a source (interaction it reports), a sink
+    (how it reflects the shared index), or both:
+
+    - ``TrajectoryWidget``: source + sink via ``current_step_idx``.
+    - ``ScatterPlotWidget``: source via ``active_point`` (clicked point index),
+      sink via ``selected_point`` (highlight).
+    - ``StructureWidget``: sink only -- its ``structure`` is set to
+      ``structures[index]`` (requires ``structures``).
+
+    Re-entrancy is guarded so a sink update never echoes back into a new
+    broadcast, and traitlets' own no-op-on-unchanged behavior prevents loops.
+    """
+
+    def __init__(
+        self,
+        widgets: Sequence[MatterVizWidget],
+        *,
+        structures: Sequence[Any] | None = None,
+        series_idx: int = 0,
+    ) -> None:
+        """Link the given widgets on a shared selection index.
+
+        Args:
+            widgets: Widgets to keep in sync (need at least two).
+            structures: Ordered structures indexed by the shared selection index.
+                Required if any widget is a ``StructureWidget`` (its ``structure``
+                is set to ``structures[index]`` on every change).
+            series_idx: Series index written into ``ScatterPlotWidget`` sinks
+                (``selected_point``). Defaults to 0 (the first series).
+
+        Raises:
+            ValueError: If fewer than two widgets are given, or a
+                ``StructureWidget`` is included without ``structures``.
+        """
+        if len(widgets) < 2:
+            raise ValueError(
+                f"link_selection needs at least 2 widgets, got {len(widgets)}"
+            )
+
+        unsupported = [
+            widget for widget in widgets if not isinstance(widget, _LINKABLE)
+        ]
+        if unsupported:
+            kinds = ", ".join(sorted({type(widget).__name__ for widget in unsupported}))
+            supported = ", ".join(cls.__name__ for cls in _LINKABLE)
+            raise TypeError(
+                f"link_selection got unsupported widget type(s): {kinds}. "
+                f"Supported: {supported}."
+            )
+
+        self.widgets = list(widgets)
+        self._structures = None if structures is None else list(structures)
+        self._series_idx = series_idx
+        self._syncing = False
+        self._observers: list[tuple[Any, Any, str]] = []
+
+        # structures back a StructureWidget sink; an empty/None list can't (every
+        # index is out of range), so fail early rather than render a stale frame.
+        if not self._structures and any(
+            isinstance(widget, StructureWidget) for widget in self.widgets
+        ):
+            raise ValueError(
+                "link_selection requires non-empty `structures` when a "
+                "StructureWidget is linked (its structure is set to structures[index])."
+            )
+
+        for widget in self.widgets:
+            if isinstance(widget, TrajectoryWidget):
+                self._add_observer(widget, self._on_trajectory, "current_step_idx")
+            elif isinstance(widget, ScatterPlotWidget):
+                self._add_observer(widget, self._on_scatter, "active_point")
+
+        # initial sync so all sinks reflect the starting index (a trajectory's
+        # current step if present, else 0)
+        initial = next(
+            (
+                int(widget.current_step_idx)
+                for widget in self.widgets
+                if isinstance(widget, TrajectoryWidget)
+            ),
+            0,
+        )
+        self._broadcast(initial)
+
+    def _add_observer(self, widget: Any, handler: Any, trait_name: str) -> None:
+        """Register a traitlets observer and remember it for ``unlink``."""
+        widget.observe(handler, names=trait_name)
+        self._observers.append((widget, handler, trait_name))
+
+    def _on_trajectory(self, change: dict[str, Any]) -> None:
+        """Broadcast a trajectory step change to the other widgets."""
+        self._broadcast(int(change["new"]))
+
+    def _on_scatter(self, change: dict[str, Any]) -> None:
+        """Broadcast a scatter point click to the other widgets.
+
+        Only ``point_idx`` drives selection; ``active_point``'s ``event_id`` (which
+        makes repeated identical clicks distinct trait values) is ignored here.
+        """
+        point = change["new"]
+        if not point or point.get("point_idx") is None:
+            return
+        self._broadcast(int(point["point_idx"]))
+
+    def _broadcast(self, index: int) -> None:
+        """Push ``index`` to every linked widget's sink (re-entrancy guarded).
+
+        Applies to all widgets including the interaction source: a scatter source
+        reports via ``active_point`` but its sink is ``selected_point`` (so the
+        clicked point must be highlighted here too), and re-applying a trajectory
+        source's own ``current_step_idx`` is a traitlets no-op. The ``_syncing``
+        guard absorbs any resulting echo notification.
+        """
+        if self._syncing:
+            return
+        self._syncing = True
+        try:
+            for widget in self.widgets:
+                self._apply(widget, index)
+        finally:
+            self._syncing = False
+
+    def _apply(self, widget: Any, index: int) -> None:
+        """Reflect the shared ``index`` in a single widget (its sink)."""
+        if isinstance(widget, TrajectoryWidget):
+            widget.current_step_idx = index
+        elif isinstance(widget, ScatterPlotWidget):
+            widget.selected_point = {"series_idx": self._series_idx, "point_idx": index}
+        elif isinstance(widget, StructureWidget) and self._structures is not None:
+            if 0 <= index < len(self._structures):
+                widget.structure = structure_to_dict(self._structures[index])
+            else:
+                warnings.warn(
+                    f"link_selection: {index=} out of range for {len(self._structures)}"
+                    " structures; StructureWidget not updated.",
+                    stacklevel=2,
+                )
+
+    def unlink(self) -> None:
+        """Remove all observers, stopping further synchronization."""
+        for widget, handler, trait_name in self._observers:
+            widget.unobserve(handler, names=trait_name)
+        self._observers.clear()
+
+
+def link_selection(
+    *widgets: MatterVizWidget,
+    structures: Sequence[Any] | None = None,
+    series_idx: int = 0,
+) -> WidgetLink:
+    """Two-way link a shared selection index across MatterViz widgets.
+
+    Convenience wrapper around :class:`WidgetLink`. Clicking a scatter point or
+    stepping a trajectory updates every other linked widget; a linked
+    ``StructureWidget`` shows ``structures[index]``.
+
+    Args:
+        *widgets: Widgets to link (need at least two). Supported:
+            ``TrajectoryWidget``, ``ScatterPlotWidget``, ``StructureWidget``.
+        structures: Ordered structures indexed by the selection index. Required
+            if a ``StructureWidget`` is linked.
+        series_idx: Series index used when highlighting scatter points.
+
+    Returns:
+        A :class:`WidgetLink` whose ``unlink()`` stops synchronization.
+    """
+    return WidgetLink(widgets, structures=structures, series_idx=series_idx)

--- a/pymatviz/widgets/matterviz.py
+++ b/pymatviz/widgets/matterviz.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 # version already published to npm: the default to_html/to_img path fetches
 # ``matterviz-anywidget@<this>`` from jsDelivr at runtime, so an unpublished pin
 # breaks widget rendering for everyone.
-MATTERVIZ_ANYWIDGET_VERSION = "0.4.0"
+MATTERVIZ_ANYWIDGET_VERSION = "0.4.1"
 _ANYWIDGET_CDN = "https://cdn.jsdelivr.net/npm/matterviz-anywidget"
 # expanded at call time (not import time) so tests can patch os.path.expanduser
 _CACHE_ROOT = "~/.cache/pymatviz"

--- a/pymatviz/widgets/scatter_plot.py
+++ b/pymatviz/widgets/scatter_plot.py
@@ -44,6 +44,19 @@ class ScatterPlotWidget(MatterVizWidget):
     line_tween = tl.Dict(allow_none=True).tag(sync=True)
     point_events = tl.Unicode(allow_none=True).tag(sync=True)
 
+    # Interaction state (two-way synced with the frontend for ipywidgets linking).
+    # selected_point drives a highlight from Python and takes
+    # {"series_idx", "point_idx"}. active_point/hovered_point are
+    # populated on user click/hover (observe them to drive other widgets).
+    # hovered_point is {"series_idx", "point_idx", "x", "y"} or None.
+    # active_point is the last clicked point or None; it adds an
+    # event_id (monotonically increasing per widget instance) so re-clicking
+    # the same point is still observed as a distinct event:
+    # {"series_idx", "point_idx", "x", "y", "event_id"}.
+    selected_point = tl.Dict(allow_none=True, default_value=None).tag(sync=True)
+    active_point = tl.Dict(allow_none=True, default_value=None).tag(sync=True)
+    hovered_point = tl.Dict(allow_none=True, default_value=None).tag(sync=True)
+
     def __init__(
         self,
         series: list[dict[str, Any]] | tuple[dict[str, Any], ...] | None = None,
@@ -74,6 +87,7 @@ class ScatterPlotWidget(MatterVizWidget):
         point_tween: dict[str, Any] | None = None,
         line_tween: dict[str, Any] | None = None,
         point_events: str | None = None,
+        selected_point: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize a scatter plot widget.
@@ -108,6 +122,9 @@ class ScatterPlotWidget(MatterVizWidget):
             point_tween: Point animation configuration.
             line_tween: Line animation configuration.
             point_events: CSS ``pointer-events`` value for data points.
+            selected_point: Point to highlight from Python, as
+                ``{"series_idx", "point_idx"}``. Use ``observe("active_point")``
+                to react to clicks and link this widget to others.
             **kwargs: Additional base widget keyword arguments.
         """
         super().__init__(
@@ -141,5 +158,6 @@ class ScatterPlotWidget(MatterVizWidget):
             point_tween=normalize_plot_json(point_tween, "ScatterPlot.point_tween"),
             line_tween=normalize_plot_json(line_tween, "ScatterPlot.line_tween"),
             point_events=point_events,
+            selected_point=selected_point,
             **kwargs,
         )

--- a/pymatviz/widgets/structure.py
+++ b/pymatviz/widgets/structure.py
@@ -10,7 +10,7 @@ from pymatviz.widgets._traits import StructureVizTraits
 from pymatviz.widgets.matterviz import MatterVizWidget
 
 
-def structure_to_dict(structure: dict[str, Any] | Any | None) -> dict[str, Any] | None:
+def structure_to_dict(structure: Any) -> dict[str, Any] | None:
     """Convert a structure-like object (or dict, or None) to a widget structure dict.
 
     Passes dicts and ``None`` through unchanged; converts pymatgen ``Structure`` /

--- a/pymatviz/widgets/structure.py
+++ b/pymatviz/widgets/structure.py
@@ -10,6 +10,20 @@ from pymatviz.widgets._traits import StructureVizTraits
 from pymatviz.widgets.matterviz import MatterVizWidget
 
 
+def structure_to_dict(structure: dict[str, Any] | Any | None) -> dict[str, Any] | None:
+    """Convert a structure-like object (or dict, or None) to a widget structure dict.
+
+    Passes dicts and ``None`` through unchanged; converts pymatgen ``Structure`` /
+    ASE ``Atoms`` (and other ``normalize_structures`` inputs) via ``.as_dict()``.
+    """
+    if structure is None or isinstance(structure, dict):
+        return structure
+
+    from pymatviz.process_data import normalize_structures
+
+    return next(iter(normalize_structures(structure).values())).as_dict()
+
+
 class StructureWidget(StructureVizTraits, MatterVizWidget):
     """MatterViz widget for visualizing structures in Python notebooks.
 
@@ -64,6 +78,15 @@ class StructureWidget(StructureVizTraits, MatterVizWidget):
     enable_info_pane = tl.Bool(default_value=True).tag(sync=True)
     png_dpi = tl.Int(allow_none=True, default_value=None).tag(sync=True)
 
+    # Interaction state (two-way synced with the frontend for ipywidgets linking).
+    # selected_sites (clicked atoms) and hovered_site_idx (hovered atom) are
+    # populated on user interaction (observe them to drive other widgets) and can
+    # also be set from Python. highlighted_sites is a Python-driven highlight
+    # input (e.g. from a linked plot).
+    selected_sites = tl.List(tl.Int(), default_value=[]).tag(sync=True)
+    highlighted_sites = tl.List(tl.Int(), default_value=[]).tag(sync=True)
+    hovered_site_idx = tl.Int(allow_none=True, default_value=None).tag(sync=True)
+
     def __init__(
         self, structure: dict[str, Any] | Any | None = None, **kwargs: Any
     ) -> None:
@@ -77,13 +100,6 @@ class StructureWidget(StructureVizTraits, MatterVizWidget):
             **kwargs: Additional widget properties (e.g.
                 ``structure_string``, ``atom_radius``, ``show_bonds``).
         """
-        from pymatviz.process_data import normalize_structures
-
-        if isinstance(structure, dict):
-            struct_dict = structure
-        elif structure is not None:
-            struct_dict = next(iter(normalize_structures(structure).values())).as_dict()
-        else:
-            struct_dict = None
-
-        super().__init__(widget_type="structure", structure=struct_dict, **kwargs)
+        super().__init__(
+            widget_type="structure", structure=structure_to_dict(structure), **kwargs
+        )

--- a/pymatviz/widgets/trajectory.py
+++ b/pymatviz/widgets/trajectory.py
@@ -87,7 +87,6 @@ class TrajectoryWidget(StructureVizTraits, MatterVizWidget):
         [tl.Int(), tl.List()], allow_none=True, default_value=None
     ).tag(sync=True)
     property_labels = tl.Dict(allow_none=True).tag(sync=True)
-    units = tl.Dict(allow_none=True).tag(sync=True)
 
     def __init__(
         self, trajectory: dict[str, Any] | list[Any] | Any | None = None, **kwargs: Any

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ testpaths = ["tests"]
 addopts = "-p no:warnings"
 
 [tool.ruff]
-target-version = "py311"
 output-format = "concise"
 
 [tool.ruff.lint]

--- a/tests/widgets/test_widget_linking.py
+++ b/tests/widgets/test_widget_linking.py
@@ -1,0 +1,271 @@
+"""Tests for widget interaction-state traits and Python-side reactive linking."""
+
+from __future__ import annotations
+
+import pytest
+from pymatgen.core import Lattice, Structure
+
+from pymatviz import (
+    ScatterPlotWidget,
+    StructureWidget,
+    TrajectoryWidget,
+    link_selection,
+)
+from pymatviz.widgets.link import WidgetLink
+
+
+def _frames(n_frames: int = 4) -> list[Structure]:
+    """Return n_frames distinct cubic structures (lattice grows per frame)."""
+    return [
+        Structure(Lattice.cubic(3.0 + 0.1 * idx), ("Fe", "Fe"), ((0, 0, 0), (0.5,) * 3))
+        for idx in range(n_frames)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("trait_name", "value"),
+    [
+        ("selected_point", {"series_idx": 0, "point_idx": 3}),
+        ("active_point", {"series_idx": 1, "point_idx": 2, "x": 1.0, "y": 2.0}),
+        ("hovered_point", {"series_idx": 0, "point_idx": 0, "x": 0.0, "y": 0.0}),
+    ],
+)
+def test_scatter_interaction_traits_sync(
+    trait_name: str, value: dict[str, float]
+) -> None:
+    """Scatter interaction traits round-trip and are tagged for frontend sync."""
+    widget = ScatterPlotWidget(series=[{"x": [0, 1], "y": [1, 2]}])
+    assert getattr(widget, trait_name) is None  # default
+    setattr(widget, trait_name, value)
+    assert getattr(widget, trait_name) == value
+    assert widget.class_traits()[trait_name].metadata.get("sync") is True
+
+
+def test_scatter_selected_point_via_constructor() -> None:
+    """selected_point can be seeded at construction time."""
+    point = {"series_idx": 0, "point_idx": 5}
+    widget = ScatterPlotWidget(series=[{"x": [0], "y": [0]}], selected_point=point)
+    assert widget.selected_point == point
+
+
+@pytest.mark.parametrize(
+    ("trait_name", "value", "default"),
+    [
+        ("selected_sites", [1, 2], []),
+        ("highlighted_sites", [0], []),
+        ("hovered_site_idx", 3, None),
+    ],
+)
+def test_structure_interaction_traits_sync(
+    trait_name: str, value: object, default: object
+) -> None:
+    """Structure interaction traits round-trip and are tagged for frontend sync."""
+    widget = StructureWidget()
+    assert getattr(widget, trait_name) == default
+    setattr(widget, trait_name, value)
+    assert getattr(widget, trait_name) == value
+    assert widget.class_traits()[trait_name].metadata.get("sync") is True
+
+
+def test_link_selection_requires_two_widgets() -> None:
+    """A single widget cannot be linked."""
+    scatter = ScatterPlotWidget(series=[{"x": [0], "y": [0]}])
+    with pytest.raises(ValueError, match="at least 2 widgets"):
+        link_selection(scatter)
+
+
+@pytest.mark.parametrize("structures", [None, []])
+def test_link_selection_structure_requires_nonempty_structures(
+    structures: list[Structure] | None,
+) -> None:
+    """Linking a StructureWidget without (non-empty) structures fails early."""
+    scatter = ScatterPlotWidget(series=[{"x": [0], "y": [0]}])
+    structure = StructureWidget()
+    with pytest.raises(ValueError, match="requires non-empty `structures`"):
+        link_selection(scatter, structure, structures=structures)
+
+
+def test_link_selection_rejects_unsupported_widget() -> None:
+    """Linking an unsupported widget type fails with a clear TypeError."""
+    from pymatviz import BarPlotWidget
+
+    scatter = ScatterPlotWidget(series=[{"x": [0], "y": [0]}])
+    bar = BarPlotWidget(series=[{"x": [0], "y": [0]}])
+    with pytest.raises(TypeError, match=r"unsupported widget type.*BarPlotWidget"):
+        link_selection(scatter, bar)
+
+
+def test_link_scatter_click_updates_structure() -> None:
+    """Clicking a scatter point shows the matching frame in the structure view."""
+    frames = _frames()
+    scatter = ScatterPlotWidget(series=[{"x": list(range(4)), "y": list(range(4))}])
+    structure = StructureWidget(structure=frames[0])
+
+    link = link_selection(scatter, structure, structures=frames)
+    assert isinstance(link, WidgetLink)
+    # initial sync shows frame 0
+    assert structure.structure == frames[0].as_dict()
+
+    # simulate a frontend click writing back active_point
+    scatter.active_point = {"series_idx": 0, "point_idx": 2}
+    assert structure.structure == frames[2].as_dict()
+
+
+def test_link_scatter_click_highlights_source_scatter() -> None:
+    """The clicked scatter highlights its own point too (source isn't skipped)."""
+    scatter_a = ScatterPlotWidget(series=[{"x": [0, 1, 2], "y": [0, 1, 2]}])
+    scatter_b = ScatterPlotWidget(series=[{"x": [0, 1, 2], "y": [0, 1, 2]}])
+
+    link_selection(scatter_a, scatter_b, series_idx=0)
+    scatter_a.active_point = {"series_idx": 0, "point_idx": 2}
+    # both the clicked (source) and the other scatter get the persistent highlight
+    assert scatter_a.selected_point == {"series_idx": 0, "point_idx": 2}
+    assert scatter_b.selected_point == {"series_idx": 0, "point_idx": 2}
+
+
+def test_link_trajectory_step_drives_scatter_highlight() -> None:
+    """Stepping a trajectory highlights the matching scatter point."""
+    frames = _frames()
+    traj = TrajectoryWidget(trajectory=frames)
+    scatter = ScatterPlotWidget(series=[{"x": list(range(4)), "y": list(range(4))}])
+
+    link_selection(traj, scatter)
+    traj.current_step_idx = 3
+    assert scatter.selected_point == {"series_idx": 0, "point_idx": 3}
+
+
+def test_link_scatter_click_drives_trajectory_step() -> None:
+    """Clicking a scatter point steps a linked trajectory (two-way)."""
+    frames = _frames()
+    traj = TrajectoryWidget(trajectory=frames)
+    scatter = ScatterPlotWidget(series=[{"x": list(range(4)), "y": list(range(4))}])
+
+    link_selection(traj, scatter)
+    scatter.active_point = {"series_idx": 0, "point_idx": 1}
+    assert traj.current_step_idx == 1
+
+
+def test_link_series_idx_used_for_highlight() -> None:
+    """The configured series_idx is written into scatter selected_point."""
+    frames = _frames()
+    traj = TrajectoryWidget(trajectory=frames)
+    scatter = ScatterPlotWidget(series=[{"x": [0, 1], "y": [0, 1]}])
+
+    link_selection(traj, scatter, series_idx=2)
+    traj.current_step_idx = 1
+    assert scatter.selected_point == {"series_idx": 2, "point_idx": 1}
+
+
+def test_link_no_infinite_loop_between_two_trajectories() -> None:
+    """Two linked trajectories converge without recursing."""
+    frames = _frames()
+    traj_a = TrajectoryWidget(trajectory=frames)
+    traj_b = TrajectoryWidget(trajectory=frames)
+
+    link_selection(traj_a, traj_b)
+    traj_a.current_step_idx = 2
+    assert traj_b.current_step_idx == 2
+    traj_b.current_step_idx = 0
+    assert traj_a.current_step_idx == 0
+
+
+def test_link_ignores_null_scatter_point() -> None:
+    """A null active_point (hover-off) does not change linked widgets."""
+    frames = _frames()
+    scatter = ScatterPlotWidget(series=[{"x": list(range(4)), "y": list(range(4))}])
+    structure = StructureWidget(structure=frames[0])
+
+    link_selection(scatter, structure, structures=frames)
+    scatter.active_point = {"series_idx": 0, "point_idx": 2}
+    assert structure.structure == frames[2].as_dict()
+
+    scatter.active_point = None  # hover-off  # ty: ignore[invalid-assignment]
+    assert structure.structure == frames[2].as_dict()  # unchanged
+
+
+def test_unlink_stops_syncing() -> None:
+    """After unlink, interactions no longer propagate."""
+    frames = _frames()
+    scatter = ScatterPlotWidget(series=[{"x": list(range(4)), "y": list(range(4))}])
+    structure = StructureWidget(structure=frames[0])
+
+    link = link_selection(scatter, structure, structures=frames)
+    link.unlink()
+
+    scatter.active_point = {"series_idx": 0, "point_idx": 3}
+    assert structure.structure == frames[0].as_dict()  # unchanged after unlink
+
+
+def test_link_repeated_scatter_click_resyncs() -> None:
+    """Re-clicking the same point re-syncs after the selection moved elsewhere.
+
+    The frontend tags each click with a monotonic event_id, so repeated
+    identical clicks are distinct trait values (no reset hack needed) and
+    active_point keeps the last clicked point.
+    """
+    frames = _frames()
+    traj = TrajectoryWidget(trajectory=frames)
+    structure = StructureWidget(structure=frames[0])
+    scatter = ScatterPlotWidget(series=[{"x": list(range(4)), "y": list(range(4))}])
+
+    link_selection(traj, scatter, structure, structures=frames)
+    scatter.active_point = {"series_idx": 0, "point_idx": 1, "event_id": 1}
+    assert traj.current_step_idx == 1
+    assert scatter.active_point is not None  # not reset; retains the click
+
+    traj.current_step_idx = 2  # move the shared selection elsewhere
+    assert structure.structure == frames[2].as_dict()
+
+    # same point, new event_id (as the frontend would send) -> re-syncs
+    scatter.active_point = {"series_idx": 0, "point_idx": 1, "event_id": 2}
+    assert traj.current_step_idx == 1
+    assert structure.structure == frames[1].as_dict()
+
+
+def test_link_does_not_emit_synthetic_active_point() -> None:
+    """A user's own active_point observer sees only real clicks, no synthetic None."""
+    frames = _frames()
+    structure = StructureWidget(structure=frames[0])
+    scatter = ScatterPlotWidget(series=[{"x": list(range(4)), "y": list(range(4))}])
+    link_selection(scatter, structure, structures=frames)
+
+    seen: list[dict[str, int] | None] = []
+    scatter.observe(lambda change: seen.append(change["new"]), names="active_point")
+    scatter.active_point = {"series_idx": 0, "point_idx": 2, "event_id": 1}
+
+    assert seen == [{"series_idx": 0, "point_idx": 2, "event_id": 1}]
+    assert scatter.active_point is not None  # trait keeps the click value
+
+
+def test_link_ignores_event_id_for_selection() -> None:
+    """Selection uses point_idx only; event_id does not affect which frame shows."""
+    frames = _frames()
+    structure = StructureWidget(structure=frames[0])
+    scatter = ScatterPlotWidget(series=[{"x": list(range(4)), "y": list(range(4))}])
+    link_selection(scatter, structure, structures=frames)
+
+    scatter.active_point = {"series_idx": 0, "point_idx": 3, "event_id": 99}
+    assert structure.structure == frames[3].as_dict()
+
+
+def test_link_out_of_range_index_warns_and_keeps_structure() -> None:
+    """An out-of-range selection index warns and leaves the structure unchanged."""
+    frames = _frames(3)
+    structure = StructureWidget(structure=frames[0])
+    # scatter has more points than there are structures
+    scatter = ScatterPlotWidget(series=[{"x": list(range(5)), "y": list(range(5))}])
+
+    link_selection(scatter, structure, structures=frames)
+    with pytest.warns(UserWarning, match="index 4 is out of range"):
+        scatter.active_point = {"series_idx": 0, "point_idx": 4}  # beyond len(frames)
+    assert structure.structure == frames[0].as_dict()  # unchanged, no exception
+
+
+def test_link_initial_sync_uses_trajectory_step() -> None:
+    """Initial sync reflects a trajectory's starting step into other sinks."""
+    frames = _frames()
+    traj = TrajectoryWidget(trajectory=frames, current_step_idx=2)
+    structure = StructureWidget(structure=frames[0])
+
+    link_selection(traj, structure, structures=frames)
+    assert structure.structure == frames[2].as_dict()

--- a/tests/widgets/test_widget_linking.py
+++ b/tests/widgets/test_widget_linking.py
@@ -256,7 +256,7 @@ def test_link_out_of_range_index_warns_and_keeps_structure() -> None:
     scatter = ScatterPlotWidget(series=[{"x": list(range(5)), "y": list(range(5))}])
 
     link_selection(scatter, structure, structures=frames)
-    with pytest.warns(UserWarning, match="index 4 is out of range"):
+    with pytest.warns(UserWarning, match=r"index=\d+ out of range for \d+ structures"):
         scatter.active_point = {"series_idx": 0, "point_idx": 4}  # beyond len(frames)
     assert structure.structure == frames[0].as_dict()  # unchanged, no exception
 


### PR DESCRIPTION
## Summary

Adds the Python-side API for reactive, coordinated MatterViz widgets. Paired with the now-fully-generic matterviz anywidget bridge (janosh/matterviz#365 — two-way reactive across *every* widget and prop), this makes pymatviz widgets live:

- **Generic drive (Python → live view):** via the generic bridge, *any* synced trait on *any* pymatviz widget now reactively updates the rendered view on `observe`/`link`/assignment, instead of being read once at mount (fire-once/one-way before).
- **Interaction-state writeback (live view → Python):** new traits `ScatterPlotWidget.{selected_point, active_point, hovered_point}` and `StructureWidget.{selected_sites, highlighted_sites, hovered_site_idx}` flow user interaction back to Python. `active_point` carries a monotonic `event_id` so re-clicking the same point is still observed as a distinct event.
- **`link_selection()` helper (and `WidgetLink`):** keeps a shared selection index in sync across `TrajectoryWidget`, `ScatterPlotWidget` and `StructureWidget` through the ipywidgets `observe` API, so coordinated views (e.g. structure+scatter) are composed in Python instead of being bundled at the JS level.
- Factor a shared `structure_to_dict()` helper and add a linked scatter+structure demo to `examples/widgets/vscode_interactive_demo.py`.
- Remove the unused synced `units` trait from `TrajectoryWidget` (dead — the component never consumed it).
- Drop the redundant ruff `target-version` (inferred from `requires-python`).

## Dependency

The reactive behavior is delivered by the companion matterviz anywidget bridge, which is now two-way/reactive for **all** widgets and props (previously fire-once/one-way): janosh/matterviz#365.

The Python API and tests are in place now, but live notebook behavior requires that bundle. Once it's published to npm, bump `MATTERVIZ_ANYWIDGET_VERSION`; until then it can be exercised locally via `MATTERVIZ_ANYWIDGET_DIR` pointing at a local `matterviz-anywidget` build.

Addresses #354.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Added cross-widget selection linking to synchronize interactions across scatter plots, structure viewers, and trajectory playback.
  * Introduced two-way synced interaction state for scatter point selection/hover and structure site selection/highlighting.
  * Added `WidgetLink`/`link_selection` API, plus an updated interactive demo showing “Linked Scatter + Structure”.
* **Tests**
  * Added comprehensive widget linking tests covering sync, unlinking, validation, and edge cases.
* **Chores**
  * Updated the ruff configuration.
* **Bug Fixes**
  * Removed the unused synchronized `units` trait from the trajectory widget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
